### PR TITLE
fix(style): preserve inline comments when reordering HCL attributes

### DIFF
--- a/internal/engines/style/rules/block_organization.go
+++ b/internal/engines/style/rules/block_organization.go
@@ -351,7 +351,7 @@ func (r *LifecycleAttributeOrderRule) fixLifecycleBlock(filePath string, parentL
 
 		attrExprs := make(map[string]hclwrite.Tokens)
 		for name, attr := range nested.Body().Attributes() {
-			attrExprs[name] = attr.Expr().BuildTokens(nil)
+			attrExprs[name] = getExprTokensWithTrailingComment(attr)
 		}
 
 		for _, name := range attrOrder {
@@ -410,7 +410,7 @@ func (r *LifecycleAttributeOrderRule) Fix(ctx *sdk.Context, _ *hcl.File) ([]byte
 
 			attrExprs := make(map[string]hclwrite.Tokens)
 			for name, attr := range nested.Body().Attributes() {
-				attrExprs[name] = attr.Expr().BuildTokens(nil)
+				attrExprs[name] = getExprTokensWithTrailingComment(attr)
 			}
 
 			for _, name := range attrOrder {

--- a/internal/engines/style/rules/helpers.go
+++ b/internal/engines/style/rules/helpers.go
@@ -61,6 +61,43 @@ func GetOrderedAttrNames(syntaxBody *hclsyntax.Body) []string {
 	return result
 }
 
+// getExprTokensWithTrailingComment extracts expression tokens and any trailing inline comment.
+// This preserves comments like: description = "foo" # this comment
+func getExprTokensWithTrailingComment(attr *hclwrite.Attribute) hclwrite.Tokens {
+	// Get expression tokens (the value)
+	exprTokens := attr.Expr().BuildTokens(nil)
+
+	// Get full attribute tokens to find trailing comments
+	fullTokens := attr.BuildTokens(nil)
+
+	// The full tokens structure is: name = expr [comment] [newline]
+	// We need to find comment tokens after the expression
+	var trailingTokens hclwrite.Tokens
+	for i := len(fullTokens) - 1; i >= 0; i-- {
+		tok := fullTokens[i]
+		// Include comment tokens
+		if tok.Type.String() == "TokenComment" {
+			trailingTokens = append(hclwrite.Tokens{tok}, trailingTokens...)
+		} else if tok.Type.String() == "TokenNewline" {
+			// Skip newlines at the very end
+			continue
+		} else {
+			// Stop when we hit something that's not a comment or newline
+			break
+		}
+	}
+
+	// Append trailing tokens (comments) to expression tokens
+	if len(trailingTokens) > 0 {
+		result := make(hclwrite.Tokens, len(exprTokens)+len(trailingTokens))
+		copy(result, exprTokens)
+		copy(result[len(exprTokens):], trailingTokens)
+		return result
+	}
+
+	return exprTokens
+}
+
 // ReorderBlockAttrs reorders attributes in a block according to the specified order.
 // firstAttrs are placed at the start, lastAttrs at the end, others maintain relative order.
 // orderedNames should be the original order of attributes (from hclsyntax parsing).
@@ -79,10 +116,10 @@ func ReorderBlockAttrs(body *hclwrite.Body, orderedNames, firstAttrs, lastAttrs 
 		lastSet[name] = true
 	}
 
-	// Collect attribute info preserving expression tokens
+	// Collect attribute info preserving expression tokens AND trailing comments
 	attrTokens := make(map[string]hclwrite.Tokens)
 	for name, attr := range body.Attributes() {
-		attrTokens[name] = attr.Expr().BuildTokens(nil)
+		attrTokens[name] = getExprTokensWithTrailingComment(attr)
 	}
 
 	// Categorize attribute names
@@ -551,13 +588,13 @@ func ReorderTopLevelBlocks(writeFile *hclwrite.File) []byte {
 	return FormatAndCleanBlankLines(writeFile.Bytes())
 }
 
-// addBlocksWithSpacing adds blocks to a body, preserving their content.
+// addBlocksWithSpacing adds blocks to a body, preserving their content including inline comments.
 func addBlocksWithSpacing(body *hclwrite.Body, blocks []*hclwrite.Block) {
 	for _, block := range blocks {
 		newBlock := body.AppendNewBlock(block.Type(), block.Labels())
-		// Copy attributes
+		// Copy attributes with inline comments preserved
 		for name, attr := range block.Body().Attributes() {
-			newBlock.Body().SetAttributeRaw(name, attr.Expr().BuildTokens(nil))
+			newBlock.Body().SetAttributeRaw(name, getExprTokensWithTrailingComment(attr))
 		}
 		// Copy nested blocks
 		for _, nested := range block.Body().Blocks() {
@@ -567,11 +604,11 @@ func addBlocksWithSpacing(body *hclwrite.Body, blocks []*hclwrite.Block) {
 	}
 }
 
-// copyNestedBlock recursively copies a nested block to a new body.
+// copyNestedBlock recursively copies a nested block to a new body, preserving inline comments.
 func copyNestedBlock(body *hclwrite.Body, block *hclwrite.Block) {
 	newBlock := body.AppendNewBlock(block.Type(), block.Labels())
 	for name, attr := range block.Body().Attributes() {
-		newBlock.Body().SetAttributeRaw(name, attr.Expr().BuildTokens(nil))
+		newBlock.Body().SetAttributeRaw(name, getExprTokensWithTrailingComment(attr))
 	}
 	for _, nested := range block.Body().Blocks() {
 		copyNestedBlock(newBlock.Body(), nested)

--- a/internal/engines/style/rules/helpers_test.go
+++ b/internal/engines/style/rules/helpers_test.go
@@ -767,3 +767,136 @@ func TestParseBothFormats(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+func TestGetExprTokensWithTrailingComment(t *testing.T) {
+	tests := []struct {
+		name            string
+		content         string
+		attrName        string
+		expectComment   bool
+		commentContains string
+	}{
+		{
+			name: "attribute with inline comment",
+			content: `resource "test" "example" {
+  ami = "ami-123" # this is a comment
+}`,
+			attrName:        "ami",
+			expectComment:   true,
+			commentContains: "this is a comment",
+		},
+		{
+			name: "attribute without comment",
+			content: `resource "test" "example" {
+  ami = "ami-123"
+}`,
+			attrName:      "ami",
+			expectComment: false,
+		},
+		{
+			name: "attribute with // style comment",
+			content: `resource "test" "example" {
+  ami = "ami-123" // another comment style
+}`,
+			attrName:        "ami",
+			expectComment:   true,
+			commentContains: "another comment style",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			writeFile, diags := hclwrite.ParseConfig([]byte(tt.content), "test.tf", hcl.InitialPos)
+			require.False(t, diags.HasErrors())
+
+			for _, block := range writeFile.Body().Blocks() {
+				attr := block.Body().GetAttribute(tt.attrName)
+				require.NotNil(t, attr, "attribute %s not found", tt.attrName)
+
+				tokens := getExprTokensWithTrailingComment(attr)
+				assert.NotEmpty(t, tokens)
+
+				// Check if there's a comment token
+				hasComment := false
+				for _, tok := range tokens {
+					if tok.Type.String() == "TokenComment" {
+						hasComment = true
+						if tt.commentContains != "" {
+							assert.Contains(t, string(tok.Bytes), tt.commentContains)
+						}
+						break
+					}
+				}
+
+				assert.Equal(t, tt.expectComment, hasComment, "comment presence mismatch")
+			}
+		})
+	}
+}
+
+func TestReorderBlockAttrsPreservesComments(t *testing.T) {
+	tests := []struct {
+		name       string
+		content    string
+		firstAttrs []string
+		lastAttrs  []string
+		checkFirst string
+		checkLast  string
+		// Check that these comments are preserved in the output
+		expectComments []string
+	}{
+		{
+			name: "preserves inline comment when reordering",
+			content: `resource "test" "example" {
+  ami      = "ami-123"
+  for_each = var.instances # loop over instances
+  name     = "test"
+}`,
+			firstAttrs:     []string{"for_each", "count"},
+			lastAttrs:      nil,
+			checkFirst:     "for_each",
+			expectComments: []string{"loop over instances"},
+		},
+		{
+			name: "preserves multiple inline comments",
+			content: `resource "test" "example" {
+  tags = { Name = "test" } # resource tags
+  ami  = "ami-123" # the ami id
+  name = "test"
+}`,
+			firstAttrs:     nil,
+			lastAttrs:      []string{"tags", "labels"},
+			checkLast:      "tags",
+			expectComments: []string{"resource tags", "the ami id"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Parse with hclsyntax for ordering
+			syntaxFile, diags := hclsyntax.ParseConfig([]byte(tt.content), "test.tf", hcl.InitialPos)
+			require.False(t, diags.HasErrors())
+
+			// Parse with hclwrite for modification
+			writeFile, diags := hclwrite.ParseConfig([]byte(tt.content), "test.tf", hcl.InitialPos)
+			require.False(t, diags.HasErrors())
+
+			syntaxBody := syntaxFile.Body.(*hclsyntax.Body)
+			if len(syntaxBody.Blocks) > 0 {
+				orderedNames := GetOrderedAttrNames(syntaxBody.Blocks[0].Body)
+
+				writeBlock := writeFile.Body().Blocks()[0]
+				ReorderBlockAttrs(writeBlock.Body(), orderedNames, tt.firstAttrs, tt.lastAttrs)
+
+				// Get the result
+				result := string(writeFile.Bytes())
+				assert.NotEmpty(t, result)
+
+				// Check that all expected comments are preserved
+				for _, comment := range tt.expectComments {
+					assert.Contains(t, result, comment, "comment should be preserved: %s", comment)
+				}
+			}
+		})
+	}
+}

--- a/internal/engines/style/rules/ordering.go
+++ b/internal/engines/style/rules/ordering.go
@@ -1107,10 +1107,10 @@ func (r *VariableOrderRule) Fix(ctx *sdk.Context, _ *hcl.File) ([]byte, error) {
 
 		body := block.Body()
 
-		// Collect all attributes with their expressions
+		// Collect all attributes with their expressions and trailing comments
 		attrExprs := make(map[string]hclwrite.Tokens)
 		for name, attr := range body.Attributes() {
-			attrExprs[name] = attr.Expr().BuildTokens(nil)
+			attrExprs[name] = getExprTokensWithTrailingComment(attr)
 		}
 
 		// Remove all known-order attributes
@@ -1283,10 +1283,10 @@ func (r *OutputOrderRule) Fix(ctx *sdk.Context, _ *hcl.File) ([]byte, error) {
 
 		body := block.Body()
 
-		// Collect all attributes with their expressions
+		// Collect all attributes with their expressions and trailing comments
 		attrExprs := make(map[string]hclwrite.Tokens)
 		for name, attr := range body.Attributes() {
-			attrExprs[name] = attr.Expr().BuildTokens(nil)
+			attrExprs[name] = getExprTokensWithTrailingComment(attr)
 		}
 
 		// Remove all known-order attributes


### PR DESCRIPTION
## Description

Preserve inline comments when reordering HCL attributes in style rules.

Previously, when the style engine reordered attributes (e.g., in lifecycle blocks, variables, outputs), trailing inline comments were dropped. This fix adds a `getExprTokensWithTrailingComment` helper that captures the trailing comment tokens along with the attribute expression.

Changes:
- Add `getExprTokensWithTrailingComment` helper in `helpers.go`
- Update `ReorderBlockAttrs` to preserve trailing comments
- Fix `LifecycleAttributeOrderRule` to preserve comments
- Fix `VariableOrderRule` and `OutputOrderRule` comment handling
- Add comprehensive test coverage for comment preservation

## Related Issue

Fixes #1

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linters (`make lint`)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

- Added unit tests in `helpers_test.go` for the new `getExprTokensWithTrailingComment` helper
- Tests cover cases with and without trailing comments
- Existing style rule tests continue to pass

## Screenshots

N/A - no UI changes

## Additional Notes

This ensures that Terraform/HCL files maintain their inline documentation when TerraTidy applies style fixes.