### PR TITLE
chore(dev): upgrade to Go 1.26.1 and clean up dev tooling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26.1'
 
       - name: Generate release notes
         uses: orhun/git-cliff-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go-version: ['1.25']
+        go-version: ['1.26.1']
 
     runs-on: ${{ matrix.os }}
 
@@ -58,7 +58,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26.1'
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
@@ -80,7 +80,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26.1'
 
       - name: Build
         run: go build -v ./...

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# If you prefer the allow list template instead of the deny list, see community template:
-# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
-#
 # Binaries for programs and plugins
 *.exe
 *.exe~
@@ -11,14 +8,12 @@
 # Test binary, built with `go test -c`
 *.test
 
-# Code coverage profiles and other test artifacts
+# Code coverage
 *.out
-coverage.*
 *.coverprofile
+coverage.*
+coverage/
 profile.cov
-
-# Dependency directories (remove the comment below to include it)
-# vendor/
 
 # Go workspace file
 go.work
@@ -27,25 +22,12 @@ go.work.sum
 # env file
 .env
 
-# Editor/IDE
-# .idea/
-# .vscode/
-
-# Custom
-IDEA.md
-
 # Build outputs
 bin/
 dist/
-*.exe
 
 # Dependencies
 vendor/
-
-# Test artifacts
-coverage.out
-coverage.html
-*.coverprofile
 
 # IDE
 .idea/
@@ -55,12 +37,13 @@ coverage.html
 *.swp
 *.swo
 *~
+*.bkp
 .DS_Store
+IDEA.md
 
 # TerraTidy specific
 test_fixtures/
 .terratidy/
-tmp/
 
 # Release artifacts (generated during CI)
 RELEASE_NOTES.md
@@ -68,12 +51,5 @@ RELEASE_NOTES.md
 # Benchmark results
 benchmarks/
 
-# Coverage reports
-coverage/
-
 # AI assistant configs (local, not tracked)
-*.bkp
 .claude
-.vscode
-
-# Tracked AI config: CLAUDE.md

--- a/Makefile
+++ b/Makefile
@@ -106,10 +106,8 @@ clean-all: ## Clean all generated files and artifacts
 	@echo "Cleaning all generated files..."
 	@rm -rf bin/
 	@rm -rf dist/
-	@rm -rf context/
 	@rm -rf coverage/
 	@rm -rf benchmarks/
-	@rm -rf tmp/
 	@rm -rf test_fixtures/
 	@rm -f coverage.out coverage.html coverage.txt
 	@rm -f *.test
@@ -120,9 +118,7 @@ clean-all: ## Clean all generated files and artifacts
 uninstall-tools: ## Uninstall all development tools
 	@echo "⚠️  This will uninstall all TerraTidy development tools"
 	@echo "The following will be removed:"
-	@echo "  - Go tools (air, benchstat, gofumpt, staticcheck, etc.)"
-	@echo "  - Node tools (repomix)"
-	@echo "  - Python tools (beads-mcp)"
+	@echo "  - Go tools (benchstat, gofumpt, staticcheck, etc.)"
 	@echo ""
 	@read -p "Continue? [y/N] " -n 1 -r; \
 	echo; \
@@ -176,9 +172,6 @@ build-all: ## Build for all platforms
 	@echo "Binaries built in bin/"
 
 # Development tools
-context: ## Generate AI context for LLMs
-	@bash tools/scripts/generate-context.sh
-
 coverage-report: ## Generate detailed coverage report
 	@bash tools/scripts/coverage-report.sh
 
@@ -189,9 +182,3 @@ deps-graph: ## Generate dependency graph
 	@go mod graph | bash tools/scripts/mod-graph.sh > docs/dependencies.svg
 	@echo "Dependency graph saved to docs/dependencies.svg"
 
-hot-reload: ## Run with hot reload (requires air)
-	@if command -v air > /dev/null; then \
-		air -c tools/air.toml; \
-	else \
-		echo "air not found. Install with: go install github.com/cosmtrek/air@latest"; \
-	fi

--- a/action.yml
+++ b/action.yml
@@ -79,7 +79,7 @@ runs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25'
+        go-version: '1.26.1'
         cache: false
 
     - name: Install TerraTidy

--- a/examples/go-rule/go.mod
+++ b/examples/go-rule/go.mod
@@ -1,6 +1,6 @@
 module require-tags
 
-go 1.25.5
+go 1.26.1
 
 require (
 	github.com/hashicorp/hcl/v2 v2.23.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/santosr2/terratidy
 
-go 1.25.5
+go 1.26.1
 
 require (
 	github.com/fsnotify/fsnotify v1.9.0

--- a/mise.toml
+++ b/mise.toml
@@ -1,55 +1,31 @@
 [tools]
-go = "1.25"
+go = "1.26"
 pre-commit = "4"
 terraform = "latest"
 terragrunt = "latest"
 golangci-lint = "latest"
-node = "latest"  # For repomix and other Node-based tools
-python = "3.13"
-"go:github.com/steveyegge/beads/cmd/bd" = "latest"
 uv = "latest"
-bun = "latest"
+bun = "latest"  # VS Code extension development
 "cargo:git-cliff" = "latest"  # Changelog generator
 "pipx:bump-my-version" = "latest"
 
 [tasks.setup]
 description = "Setup development environment"
 run = """
-  echo "📦 Installing Go tools..."
+  echo "Installing Go tools..."
   go install golang.org/x/perf/cmd/benchstat@latest
-  go install github.com/air-verse/air@latest
   go install mvdan.cc/gofumpt@latest
   go install honnef.co/go/tools/cmd/staticcheck@latest
   go install github.com/mgechev/revive@latest
   go install golang.org/x/vuln/cmd/govulncheck@latest
-  # Note: gocov has compatibility issues with Go 1.25
-  # Using native Go coverage tools instead (go test -coverprofile + go tool cover -html)
-
-  echo "📦 Installing Node tools..."
-  npm install -g repomix
-
-  echo "📦 Installing Python tools (MCP servers)..."
-  pip3 install --user beads-mcp || echo "⚠️  Beads install failed (optional)"
 
   echo ""
-  echo "✅ Development environment ready!"
+  echo "Development environment ready!"
   echo ""
   echo "Available commands:"
-  echo "  make context       - Generate AI context"
-  echo "  make hot-reload    - Development with auto-rebuild"
   echo "  make check         - Run all quality checks"
   echo "  make vuln          - Check for vulnerabilities"
-  echo ""
-  echo "📖 Next steps:"
-  echo "  1. Configure MCP servers (see docs/MCP_SETUP.md)"
-  echo "  2. Generate context: make context"
-  echo "  3. Read docs/CURSOR_AI_SETUP.md"
 """
-
-# TODO: add `bd init`
-[tasks.context]
-description = "Generate AI context"
-run = "bash tools/scripts/generate-context.sh"
 
 [tasks.coverage]
 description = "Generate coverage report"


### PR DESCRIPTION
## Description

Upgrades the project from Go 1.25 to Go 1.26.1 and cleans up unused development tooling.

- Pin Go 1.26.1 in CI workflows (test, release), action.yml, and go.mod
- Remove unused tools from mise.toml (node, python, beads, air)
- Remove `hot-reload` and `context` Makefile targets (tools removed)
- Consolidate `.gitignore` (remove duplicates, drop `tmp/`)
- Clean up setup task (remove node/python/air references)

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD changes
- [x] Other (please describe): Dev tooling cleanup

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass (`make test`)
- [ ] I have run the linters (`make lint`)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

CI will validate that tests pass with Go 1.26.1 across all platforms.

## Screenshots

N/A

## Additional Notes

N/A
