### PR TITLE
fix: use dynamic version in LSP and fix plugin scaffold

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -29,12 +29,6 @@ filename = "vscode/package.json"
 search = "\"version\": \"{current_version}\""
 replace = "\"version\": \"{new_version}\""
 
-# LSP server version
-[[tool.bumpversion.files]]
-filename = "internal/lsp/server.go"
-search = "Version: \"{current_version}\""
-replace = "Version: \"{new_version}\""
-
 # Documentation - commands
 [[tool.bumpversion.files]]
 filename = "docs/site/docs/user-guide/commands.md"

--- a/cmd/terratidy/plugins.go
+++ b/cmd/terratidy/plugins.go
@@ -201,18 +201,14 @@ func (r *ExampleRule) Description() string {
 	return "Example rule - replace with your implementation"
 }
 
-func (r *ExampleRule) Severity() sdk.Severity {
-	return sdk.SeverityWarning
-}
-
 func (r *ExampleRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Finding, error) {
 	// Implement your rule logic here
 	return nil, nil
 }
 
-func (r *ExampleRule) Fix(ctx *sdk.Context, file *hcl.File) error {
+func (r *ExampleRule) Fix(ctx *sdk.Context, file *hcl.File) ([]byte, error) {
 	// Implement fix logic if auto-fixable
-	return nil
+	return nil, nil
 }
 `, pluginName, pluginName, pluginName, pluginName)
 
@@ -225,9 +221,9 @@ func (r *ExampleRule) Fix(ctx *sdk.Context, file *hcl.File) error {
 		// Create go.mod
 		goModContent := fmt.Sprintf(`module %s
 
-go 1.25
+go 1.26.1
 
-require github.com/santosr2/terratidy v0.1.0
+require github.com/santosr2/terratidy v0.2.0-alpha.3
 `, pluginName)
 
 		goModPath := filepath.Join(dir, "go.mod")

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/santosr2/terratidy/internal/buildinfo"
 	"github.com/santosr2/terratidy/internal/config"
 	"github.com/santosr2/terratidy/internal/engines/lint"
 	"github.com/santosr2/terratidy/internal/engines/style"
@@ -204,7 +205,7 @@ func (s *Server) handleInitialize(msg RequestMessage) error {
 		},
 		ServerInfo: &ServerInfo{
 			Name:    "terratidy-lsp",
-			Version: "0.2.0-alpha.2",
+			Version: buildinfo.GetVersion(),
 		},
 	}
 


### PR DESCRIPTION
## Description

- LSP server now uses `buildinfo.GetVersion()` instead of a hardcoded version string
- Removes the LSP server entry from `.bumpversion.toml` (no longer needed since version is dynamic)
- Fixes the `plugins init` scaffold to match the actual SDK interface:
  - Removes non-existent `Severity()` method
  - `Fix()` now returns `([]byte, error)` instead of `error`
  - Updates generated `go.mod` to Go 1.26.1 and terratidy v0.2.0-alpha.3

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [ ] I have run the linters (`make lint`)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

- `go build ./...` passes
- Existing LSP tests pass (version is now dynamic)

## Screenshots

N/A

## Additional Notes

N/A
