### PR TITLE
chore: apply linter fixes and add plan dirs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ benchmarks/
 
 # AI assistant configs (local, not tracked)
 .claude
+.specs
+.plans
+.history

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,4 +157,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.2.0-alpha.3]: https://github.com/santosr2/TerraTidy/compare/v0.2.0-alpha.2...v0.2.0-alpha.3
 [0.2.0-alpha.2]: https://github.com/santosr2/TerraTidy/compare/v0.2.0-alpha...v0.2.0-alpha.2
 [0.2.0-alpha]: https://github.com/santosr2/TerraTidy/compare/v0.1.0...v0.2.0-alpha
-

--- a/Makefile
+++ b/Makefile
@@ -181,4 +181,3 @@ benchmark: ## Run benchmarks
 deps-graph: ## Generate dependency graph
 	@go mod graph | bash tools/scripts/mod-graph.sh > docs/dependencies.svg
 	@echo "Dependency graph saved to docs/dependencies.svg"
-

--- a/internal/engines/style/rules/block_organization_test.go
+++ b/internal/engines/style/rules/block_organization_test.go
@@ -141,7 +141,7 @@ func TestMetaArgumentsOrderRule(t *testing.T) {
   ami           = "ami-123"
   instance_type = "t2.micro"
 }`
-		err := os.WriteFile(tmpFile, []byte(content), 0644)
+		err := os.WriteFile(tmpFile, []byte(content), 0o644)
 		require.NoError(t, err)
 
 		file, diags := hclsyntax.ParseConfig([]byte(content), tmpFile, hcl.InitialPos)
@@ -275,7 +275,7 @@ func TestLifecycleAttributeOrderRule(t *testing.T) {
     create_before_destroy = true
   }
 }`
-		err := os.WriteFile(tmpFile, []byte(content), 0644)
+		err := os.WriteFile(tmpFile, []byte(content), 0o644)
 		require.NoError(t, err)
 
 		file, diags := hclsyntax.ParseConfig([]byte(content), tmpFile, hcl.InitialPos)
@@ -495,7 +495,7 @@ func TestOneLineAttributeSpacingRule(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			tmpFile := filepath.Join(tmpDir, "test.tf")
-			err := os.WriteFile(tmpFile, []byte(tt.content), 0644)
+			err := os.WriteFile(tmpFile, []byte(tt.content), 0o644)
 			require.NoError(t, err)
 
 			file, diags := hclsyntax.ParseConfig([]byte(tt.content), tmpFile, hcl.InitialPos)

--- a/internal/engines/style/rules/comments_test.go
+++ b/internal/engines/style/rules/comments_test.go
@@ -85,7 +85,7 @@ resource "aws_instance" "web" {
 			// Create temp file for the rule to read
 			tmpDir := t.TempDir()
 			tmpFile := filepath.Join(tmpDir, "test.tf")
-			err := os.WriteFile(tmpFile, []byte(tt.content), 0644)
+			err := os.WriteFile(tmpFile, []byte(tt.content), 0o644)
 			require.NoError(t, err)
 
 			file, diags := hclsyntax.ParseConfig([]byte(tt.content), tmpFile, hcl.InitialPos)
@@ -107,7 +107,7 @@ resource "aws_instance" "web" {
 resource "aws_instance" "web" {
   ami = "ami-123"
 }`
-		err := os.WriteFile(tmpFile, []byte(content), 0644)
+		err := os.WriteFile(tmpFile, []byte(content), 0o644)
 		require.NoError(t, err)
 
 		file, diags := hclsyntax.ParseConfig([]byte(content), tmpFile, hcl.InitialPos)
@@ -167,7 +167,7 @@ func TestNoTrailingWhitespaceRule(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			tmpFile := filepath.Join(tmpDir, "test.tf")
-			err := os.WriteFile(tmpFile, []byte(tt.content), 0644)
+			err := os.WriteFile(tmpFile, []byte(tt.content), 0o644)
 			require.NoError(t, err)
 
 			file, diags := hclsyntax.ParseConfig([]byte(tt.content), tmpFile, hcl.InitialPos)
@@ -186,7 +186,7 @@ func TestNoTrailingWhitespaceRule(t *testing.T) {
 		tmpDir := t.TempDir()
 		tmpFile := filepath.Join(tmpDir, "test.tf")
 		content := "resource \"aws_instance\" \"web\" {  \n  ami = \"ami-123\"  \n}"
-		err := os.WriteFile(tmpFile, []byte(content), 0644)
+		err := os.WriteFile(tmpFile, []byte(content), 0o644)
 		require.NoError(t, err)
 
 		file, diags := hclsyntax.ParseConfig([]byte(content), tmpFile, hcl.InitialPos)
@@ -254,7 +254,7 @@ resource "aws_instance" "web" {
 		t.Run(tt.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			tmpFile := filepath.Join(tmpDir, "test.tf")
-			err := os.WriteFile(tmpFile, []byte(tt.content), 0644)
+			err := os.WriteFile(tmpFile, []byte(tt.content), 0o644)
 			require.NoError(t, err)
 
 			file, diags := hclsyntax.ParseConfig([]byte(tt.content), tmpFile, hcl.InitialPos)
@@ -355,7 +355,7 @@ resource "aws_instance" "db" {
 		t.Run(tt.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			tmpFile := filepath.Join(tmpDir, "test.tf")
-			err := os.WriteFile(tmpFile, []byte(tt.content), 0644)
+			err := os.WriteFile(tmpFile, []byte(tt.content), 0o644)
 			require.NoError(t, err)
 
 			file, diags := hclsyntax.ParseConfig([]byte(tt.content), tmpFile, hcl.InitialPos)
@@ -381,7 +381,7 @@ resource "aws_instance" "db" {
 resource "aws_instance" "api" {
   ami = "ami-456"
 }`
-		err := os.WriteFile(tmpFile, []byte(content), 0644)
+		err := os.WriteFile(tmpFile, []byte(content), 0o644)
 		require.NoError(t, err)
 
 		file, diags := hclsyntax.ParseConfig([]byte(content), tmpFile, hcl.InitialPos)

--- a/internal/engines/style/rules/file_structure_test.go
+++ b/internal/engines/style/rules/file_structure_test.go
@@ -138,7 +138,7 @@ resource "aws_vpc" "main" {
 		t.Run(tt.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			tmpFile := filepath.Join(tmpDir, tt.fileName)
-			err := os.WriteFile(tmpFile, []byte(tt.content), 0644)
+			err := os.WriteFile(tmpFile, []byte(tt.content), 0o644)
 			require.NoError(t, err)
 
 			file, diags := hclsyntax.ParseConfig([]byte(tt.content), tmpFile, hcl.InitialPos)
@@ -390,13 +390,13 @@ func TestTerraformFilesStructureRule(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			tmpFile := filepath.Join(tmpDir, tt.fileName)
-			err := os.WriteFile(tmpFile, []byte(tt.content), 0644)
+			err := os.WriteFile(tmpFile, []byte(tt.content), 0o644)
 			require.NoError(t, err)
 
 			// Create any additional setup files
 			for _, setupFile := range tt.setupFiles {
 				setupPath := filepath.Join(tmpDir, setupFile)
-				err := os.WriteFile(setupPath, []byte("# placeholder"), 0644)
+				err := os.WriteFile(setupPath, []byte("# placeholder"), 0o644)
 				require.NoError(t, err)
 			}
 
@@ -424,7 +424,7 @@ func TestTerraformFilesStructureRule_FileExists(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	existingFile := filepath.Join(tmpDir, "existing.tf")
-	err := os.WriteFile(existingFile, []byte("# test"), 0644)
+	err := os.WriteFile(existingFile, []byte("# test"), 0o644)
 	require.NoError(t, err)
 
 	nonExistingFile := filepath.Join(tmpDir, "nonexisting.tf")

--- a/internal/plugins/bash_rule.go
+++ b/internal/plugins/bash_rule.go
@@ -36,9 +36,9 @@ type bashFinding struct {
 
 // BashRule implements sdk.Rule by executing an external Bash script.
 type BashRule struct {
-	name   string
-	path   string
-	desc   string
+	name string
+	path string
+	desc string
 }
 
 // NewBashRule creates a BashRule from a script path.

--- a/internal/plugins/plugin_test.go
+++ b/internal/plugins/plugin_test.go
@@ -111,6 +111,7 @@ func (r *MockRule) Description() string { return r.description }
 func (r *MockRule) Check(_ *sdk.Context, _ *hcl.File) ([]sdk.Finding, error) {
 	return nil, nil
 }
+
 func (r *MockRule) Fix(_ *sdk.Context, _ *hcl.File) ([]byte, error) {
 	return nil, nil
 }

--- a/pkg/sdk/types_test.go
+++ b/pkg/sdk/types_test.go
@@ -119,6 +119,7 @@ func (r *MockRule) Check(ctx *Context, file *hcl.File) ([]Finding, error) {
 	}
 	return nil, nil
 }
+
 func (r *MockRule) Fix(ctx *Context, file *hcl.File) ([]byte, error) {
 	if r.fixFunc != nil {
 		return r.fixFunc(ctx, file)

--- a/tools/scripts/benchmark.sh
+++ b/tools/scripts/benchmark.sh
@@ -21,7 +21,7 @@ go test -bench=. -benchmem -benchtime=5s -run=^$ ./... \
 if command -v benchstat &> /dev/null; then
     LATEST=$(ls -t "$BENCH_DIR"/benchmark-*.txt | head -1)
     PREVIOUS=$(ls -t "$BENCH_DIR"/benchmark-*.txt | head -2 | tail -1)
-    
+
     if [ "$LATEST" != "$PREVIOUS" ] && [ -f "$PREVIOUS" ]; then
         echo ""
         echo "Comparison with previous run:"
@@ -35,4 +35,3 @@ fi
 
 echo ""
 echo "✓ Benchmark results saved to: $BENCH_DIR"
-

--- a/tools/scripts/coverage-report.sh
+++ b/tools/scripts/coverage-report.sh
@@ -42,4 +42,3 @@ fi
 
 echo ""
 echo "✓ Coverage meets minimum requirement ($MIN_COVERAGE%)"
-

--- a/tools/scripts/mod-graph.sh
+++ b/tools/scripts/mod-graph.sh
@@ -18,23 +18,22 @@ INPUT="${1:-/dev/stdin}"
     echo "digraph {"
     echo "  rankdir=LR;"
     echo "  node [shape=box, style=rounded];"
-    
+
     # Parse go mod graph output
     while read -r line; do
         # Split on space
         from=$(echo "$line" | cut -d' ' -f1)
         to=$(echo "$line" | cut -d' ' -f2)
-        
+
         # Simplify module names
         from_short=$(echo "$from" | sed 's/@v[0-9].*//')
         to_short=$(echo "$to" | sed 's/@v[0-9].*//')
-        
+
         # Only show direct dependencies of our module
         if [[ "$from" == github.com/santosr2/terratidy* ]]; then
             echo "  \"$from_short\" -> \"$to_short\";"
         fi
     done < "$INPUT"
-    
+
     echo "}"
 } | dot -Tsvg
-

--- a/tools/scripts/uninstall.sh
+++ b/tools/scripts/uninstall.sh
@@ -50,7 +50,7 @@ fi
 remove_go_bin() {
     local bin_name="$1"
     local bin_path="$(go env GOPATH)/bin/$bin_name"
-    
+
     if [[ -f "$bin_path" ]]; then
         rm -f "$bin_path"
         echo -e "${GREEN}✓${NC} Removed: $bin_name"
@@ -132,4 +132,3 @@ echo "To remove mise-managed tools:"
 echo "  ${BLUE}mise uninstall go@1.25${NC}"
 echo "  ${BLUE}# etc.${NC}"
 echo ""
-


### PR DESCRIPTION
## Description

Apply linter/formatter fixes and add workflow directories to gitignore.

- Fix octal literals `0644` → `0o644` in test files (Go style)
- Clean up trailing whitespace/newlines in shell scripts and Makefile
- Add blank lines between methods in test files
- Fix struct field alignment in `bash_rule.go`
- Add `.specs`, `.plans`, `.history` to `.gitignore`

## Related Issue

N/A - housekeeping cleanup.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linters (`make lint`)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

No behavior changes. All changes are cosmetic (formatting/style) or config (`.gitignore`).

## Screenshots

N/A

## Additional Notes

Tests not applicable - no functional changes, only linter-driven style fixes.