### PR TITLE
fix: remove false claims, fix examples, and implement --diff flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ uninstall-tools-force: ## Force uninstall tools without confirmation
 	@bash tools/scripts/uninstall.sh --force
 
 # Rule development helpers
-init-rule: ## Initialize a new rule (use: make init-rule NAME=my-rule TYPE=go|yaml|bash)
+init-rule: ## Initialize a new rule (use: make init-rule NAME=my-rule TYPE=go|rego|yaml)
 	@if [ -z "$(NAME)" ]; then \
 		echo "Error: NAME is required. Usage: make init-rule NAME=my-rule TYPE=go"; \
 		exit 1; \

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ TerraTidy is a single-binary quality platform for Terraform and Terragrunt that 
 
 - ✅ **Single Binary** - No external dependencies, all tools vendored
 - ⚡ **10-100x Faster** - Library-first architecture, no subprocess overhead
-- 🔌 **Extensible** - Custom rules in Go, YAML, or Bash
+- 🔌 **Extensible** - Custom rules in Go, Rego, YAML, or Bash
 - 📦 **Modular Config** - Split large configs into organized files
 - 🎯 **Great DX** - Interactive setup, hot-reload dev mode, helpful errors
 - 🔧 **Auto-fix** - Automatically fix formatting and style issues

--- a/cmd/terratidy/check.go
+++ b/cmd/terratidy/check.go
@@ -289,9 +289,10 @@ func runPolicyCheckWithConfig(ctx context.Context, cfg *config.Config, files []s
 }
 
 // buildStyleConfig creates a style.Config from the terratidy config.
-func buildStyleConfig(cfg *config.Config, fix bool) *style.Config {
+func buildStyleConfig(cfg *config.Config, fix bool, diff ...bool) *style.Config {
 	styleCfg := &style.Config{
 		Fix:   fix,
+		Diff:  len(diff) > 0 && diff[0],
 		Rules: make(map[string]style.RuleConfig),
 	}
 

--- a/cmd/terratidy/style.go
+++ b/cmd/terratidy/style.go
@@ -61,7 +61,7 @@ Use --fix to automatically fix fixable style issues.`,
 		}
 
 		// Create style engine with config
-		engine := style.New(buildStyleConfig(cfg, styleFix))
+		engine := style.New(buildStyleConfig(cfg, styleFix, styleDiff))
 
 		// For structured output formats, skip the progress messages
 		useStructuredOutput := format != "" && format != "text"

--- a/docs/site/docs/development/plugins.md
+++ b/docs/site/docs/development/plugins.md
@@ -33,7 +33,7 @@ plugins:
 
 ### Rule Interface
 
-Every rule (Go, YAML, or Bash) implements the `sdk.Rule` interface:
+Every rule (Go, Rego, YAML, or Bash) implements the `sdk.Rule` interface:
 
 ```go
 type Rule interface {

--- a/docs/site/docs/getting-started/installation.md
+++ b/docs/site/docs/getting-started/installation.md
@@ -52,7 +52,7 @@ docker pull ghcr.io/santosr2/terratidy:latest
 # Or use a specific version
 docker pull ghcr.io/santosr2/terratidy:v0.2.0-alpha.3
 
-docker run --rm -v $(pwd):/workspace ghcr.io/santosr2/terratidy check
+docker run --rm -v $(pwd):/app ghcr.io/santosr2/terratidy check
 ```
 
 ## Verify Installation

--- a/examples/README.md
+++ b/examples/README.md
@@ -156,13 +156,10 @@ Want to check files before commit?
 ```yaml
 # .pre-commit-config.yaml
 repos:
-  - repo: local
+  - repo: https://github.com/santosr2/terratidy
+    rev: v0.2.0-alpha.3
     hooks:
-      - id: terratidy
-        name: TerraTidy
-        entry: terratidy check
-        language: system
-        files: \.(tf|hcl)$
+      - id: terratidy-check
 ```
 
 ### Scenario 4: Custom Rules

--- a/examples/github-workflow.yaml
+++ b/examples/github-workflow.yaml
@@ -8,7 +8,6 @@
 #   - Runs on pull requests and pushes to main
 #   - Uploads SARIF results to GitHub Code Scanning
 #   - Adds annotations to PR diffs
-#   - Caches TerraTidy binary for faster runs
 
 name: Terraform Quality
 
@@ -39,66 +38,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install TerraTidy
-        run: |
-          # Replace with actual release URL when available
-          # curl -L https://github.com/santosr2/terratidy/releases/download/v0.2.0-alpha.3/terratidy-linux-amd64 -o terratidy
-          # For now, build from source
-
-          # Install Go
-          sudo snap install go --classic
-
-          # Build TerraTidy
-          go build -o terratidy ./cmd/terratidy
-          chmod +x terratidy
-          sudo mv terratidy /usr/local/bin/
-
-      - name: Run TerraTidy Check
-        id: terratidy
-        continue-on-error: true
-        run: |
-          terratidy check --format text | tee terratidy-output.txt
-          echo "exit_code=$?" >> $GITHUB_OUTPUT
+      - name: Run TerraTidy
+        uses: santosr2/terratidy@v0
+        with:
+          format: github
 
       - name: Run TerraTidy with SARIF output
         if: always()
-        run: |
-          terratidy check --format sarif > terratidy.sarif || true
+        uses: santosr2/terratidy@v0
+        with:
+          format: sarif
+          fail-on-error: 'false'
 
       - name: Upload SARIF to GitHub
         if: always()
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v4
         with:
-          sarif_file: terratidy.sarif
+          sarif_file: terratidy-results.sarif
           category: terratidy
-
-      - name: Comment on PR
-        if: always() && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const output = fs.readFileSync('terratidy-output.txt', 'utf8');
-
-            const comment = `## TerraTidy Results
-
-            \`\`\`
-            ${output}
-            \`\`\`
-
-            [View detailed results in Security tab](https://github.com/${{ github.repository }}/security/code-scanning)
-            `;
-
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: comment
-            });
-
-      - name: Fail if checks failed
-        if: steps.terratidy.outputs.exit_code != '0'
-        run: exit 1
 
   # Optional: Auto-fix on push
   terratidy-fix:
@@ -112,22 +69,21 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install TerraTidy
-        run: |
-          # Install Go
-          sudo snap install go --classic
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.1'
 
-          # Build TerraTidy
-          go build -o terratidy ./cmd/terratidy
-          chmod +x terratidy
+      - name: Install TerraTidy
+        run: go install github.com/santosr2/terratidy/cmd/terratidy@latest
 
       - name: Run TerraTidy Fix
-        run: ./terratidy fix
+        run: terratidy fix
 
       - name: Commit changes
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add -A
-          git diff --quiet && git diff --staged --quiet || git commit -m "Auto-fix: TerraTidy formatting and style"
+          git diff --quiet && git diff --staged --quiet || git commit -m "style: auto-fix TerraTidy formatting and style"
           git push

--- a/examples/pre-commit-config.yaml
+++ b/examples/pre-commit-config.yaml
@@ -12,43 +12,14 @@
 
 repos:
   # TerraTidy hooks
-  - repo: local
+  - repo: https://github.com/santosr2/terratidy
+    rev: v0.2.0-alpha.3
     hooks:
-      # Format check - ensures files are formatted
       - id: terratidy-fmt
-        name: TerraTidy Format Check
-        entry: terratidy fmt --check
-        language: system
-        files: \.(tf|hcl)$
-        pass_filenames: true
-        description: Check Terraform/Terragrunt formatting
-
-      # Style check - ensures style guidelines
       - id: terratidy-style
-        name: TerraTidy Style Check
-        entry: terratidy style --check
-        language: system
-        files: \.(tf|hcl)$
-        pass_filenames: true
-        description: Check Terraform/Terragrunt style
-
-      # Lint check - runs TFLint
       - id: terratidy-lint
-        name: TerraTidy Lint
-        entry: terratidy lint
-        language: system
-        files: \.(tf|hcl)$
-        pass_filenames: true
-        description: Run TFLint checks
-
-      # All checks - comprehensive check (choose this OR the individual ones above)
+      # Or use terratidy-check for all checks at once:
       # - id: terratidy-check
-      #   name: TerraTidy Check All
-      #   entry: terratidy check
-      #   language: system
-      #   files: \.(tf|hcl)$
-      #   pass_filenames: true
-      #   description: Run all TerraTidy checks
 
   # Optional: Standard Terraform hooks
   - repo: https://github.com/antonbabenko/pre-commit-terraform

--- a/examples/terratidy.yaml
+++ b/examples/terratidy.yaml
@@ -6,7 +6,7 @@ version: 1
 # Global settings
 severity_threshold: warning  # Fail on warnings and above (info|warning|error)
 fail_fast: false            # Stop on first error
-parallel: true              # Run engines in parallel (future)
+parallel: true              # Run engines in parallel
 
 # Engine configuration
 engines:
@@ -42,14 +42,14 @@ engines:
       # Additional TFLint arguments
       args: []
 
-  # Policy engine - OPA/Conftest (future)
+  # Policy engine - OPA/Conftest
   policy:
     enabled: false
     config:
       policy_dir: policy
       args: []
 
-# Custom rules (future)
+# Custom rules
 custom_rules:
   # Example custom rule configuration
   # custom.my-rule:
@@ -58,7 +58,7 @@ custom_rules:
   #   config:
   #     option1: value1
 
-# Plugin configuration (future)
+# Plugin configuration
 plugins:
   enabled: false
   directories:

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/open-policy-agent/opa v1.15.0
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/text v0.35.0
@@ -33,7 +34,6 @@ require (
 	github.com/lestrrat-go/jwx/v3 v3.0.13 // indirect
 	github.com/lestrrat-go/option/v2 v2.0.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect

--- a/internal/engines/format/fmt.go
+++ b/internal/engines/format/fmt.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/pmezard/go-difflib/difflib"
 	"github.com/santosr2/terratidy/internal/cache"
 	"github.com/santosr2/terratidy/pkg/sdk"
 )
@@ -92,11 +93,31 @@ func (e *Engine) formatFile(path string) (*sdk.Finding, error) {
 		return nil, nil // Already formatted
 	}
 
-	// In check mode, return a finding
+	// Generate unified diff if requested
+	var diffText string
+	if e.config.Diff {
+		diff := difflib.UnifiedDiff{
+			A:        difflib.SplitLines(string(content)),
+			B:        difflib.SplitLines(string(formatted)),
+			FromFile: path,
+			ToFile:   path,
+			Context:  3,
+		}
+		diffText, err = difflib.GetUnifiedDiffString(diff)
+		if err != nil {
+			return nil, fmt.Errorf("generating diff: %w", err)
+		}
+	}
+
+	// In check mode, return a finding without writing
 	if e.config.Check {
+		message := "File needs formatting"
+		if diffText != "" {
+			message = diffText
+		}
 		return &sdk.Finding{
 			Rule:     "fmt.needs-formatting",
-			Message:  "File needs formatting",
+			Message:  message,
 			File:     path,
 			Severity: sdk.SeverityError,
 			Fixable:  true,
@@ -111,9 +132,13 @@ func (e *Engine) formatFile(path string) (*sdk.Finding, error) {
 		return nil, fmt.Errorf("writing formatted file: %w", err)
 	}
 
+	message := "File formatted successfully"
+	if diffText != "" {
+		message = diffText
+	}
 	return &sdk.Finding{
 		Rule:     "fmt.formatted",
-		Message:  "File formatted successfully",
+		Message:  message,
 		File:     path,
 		Severity: sdk.SeverityInfo,
 		Fixable:  false,

--- a/internal/engines/style/style.go
+++ b/internal/engines/style/style.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclparse"
+	"github.com/pmezard/go-difflib/difflib"
 	"github.com/santosr2/terratidy/pkg/sdk"
 )
 
@@ -19,6 +20,7 @@ type Engine struct {
 // Config holds the style engine configuration
 type Config struct {
 	Fix   bool // Auto-fix mode
+	Diff  bool // Show diff of changes
 	Rules map[string]RuleConfig
 }
 
@@ -84,6 +86,16 @@ func (e *Engine) checkFile(parser *hclparse.Parser, path string) ([]sdk.Finding,
 		Config:  make(map[string]interface{}),
 		WorkDir: ".",
 		File:    path,
+	}
+
+	// Capture original content before any fixes for diff generation
+	var originalContent []byte
+	if e.config.Diff && e.config.Fix {
+		var err error
+		originalContent, err = os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("reading file for diff: %w", err)
+		}
 	}
 
 	var allFindings []sdk.Finding
@@ -161,6 +173,37 @@ func (e *Engine) checkFile(parser *hclparse.Parser, path string) ([]sdk.Finding,
 
 		// No fixes applied or not in fix mode, we're done
 		break
+	}
+
+	// Generate diff if requested and fixes were applied
+	if e.config.Diff && e.config.Fix && originalContent != nil {
+		fixedContent, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("reading fixed file for diff: %w", err)
+		}
+
+		if string(originalContent) != string(fixedContent) {
+			diff := difflib.UnifiedDiff{
+				A:        difflib.SplitLines(string(originalContent)),
+				B:        difflib.SplitLines(string(fixedContent)),
+				FromFile: path,
+				ToFile:   path,
+				Context:  3,
+			}
+			diffText, err := difflib.GetUnifiedDiffString(diff)
+			if err != nil {
+				return nil, fmt.Errorf("generating diff: %w", err)
+			}
+			if diffText != "" {
+				allFindings = append(allFindings, sdk.Finding{
+					Rule:     "style.diff",
+					Message:  diffText,
+					File:     path,
+					Severity: sdk.SeverityInfo,
+					Fixable:  false,
+				})
+			}
+		}
 	}
 
 	return allFindings, nil


### PR DESCRIPTION
## Description

Fix false claims in documentation/examples and implement the dead `--diff` flag on both `fmt` and `style` commands.

**Doc/config fixes:**
- Remove 4 "(future)" labels from `examples/terratidy.yaml` (features are shipped)
- Rewrite `examples/pre-commit-config.yaml` to use proper GitHub repo URL instead of `repo: local`
- Rewrite `examples/github-workflow.yaml` to use the `santosr2/terratidy@v0` GitHub Action
- Fix Docker mount path `/workspace` → `/app` in `installation.md` to match Dockerfile WORKDIR
- Add Rego to rule type claims in `README.md`, `Makefile`, `plugins.md`
- Fix deprecated `repo: local` pattern in `examples/README.md`

**Code changes:**
- Implement `--diff` on fmt command: generates unified diff via `go-difflib` in `formatFile`
- Implement `--diff` on style command: captures original content before fix passes, generates unified diff after
- Wire `styleDiff` CLI flag into `buildStyleConfig` via variadic parameter
- Promote `go-difflib` from indirect to direct dependency

## Related Issue

Part of the Documentation & Codebase Health Audit (Phase 1b).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linters (`make lint`)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

- `go build ./...` passes
- `go test ./cmd/... ./internal/engines/format/... ./internal/engines/style/...` — all 4 packages pass
- `--diff` flag was already wired in the CLI; now the engine reads it and produces unified diff output

## Screenshots

N/A

## Additional Notes

- The `--diff` implementation uses `go-difflib` (already an indirect dependency via testify) for unified diff generation
- `buildStyleConfig` uses a variadic `diff` parameter to avoid breaking existing callers
- `coverage.out`/`coverage.html` gitignore task was already covered by existing `*.out` and `coverage.*` patterns
- CLAUDE.md `init-rule` types were already correct from PR 1