### PR TITLE
docs: document policy rules, LSP capabilities, and test-rule format

### DIFF
--- a/docs/site/docs/integrations/lsp.md
+++ b/docs/site/docs/integrations/lsp.md
@@ -148,9 +148,12 @@ In settings:
 
 ### Text Document Synchronization
 
+The server uses **full sync mode** (TextDocumentSyncKind = 1), meaning the client sends
+the complete document content on every change. Save notifications include the document text.
+
 - `textDocument/didOpen`
-- `textDocument/didChange`
-- `textDocument/didSave`
+- `textDocument/didChange` (full content)
+- `textDocument/didSave` (with text)
 - `textDocument/didClose`
 
 ### Diagnostics

--- a/docs/site/docs/rules/policy-rules.md
+++ b/docs/site/docs/rules/policy-rules.md
@@ -1,0 +1,117 @@
+# Policy Rules
+
+Built-in policy rules enforced by the policy engine using OPA/Rego.
+
+These rules are always available and do not require custom policy files. Enable the policy
+engine to use them:
+
+```yaml
+engines:
+  policy:
+    enabled: true
+```
+
+## Security Rules
+
+### no-public-ssh
+
+Detects security groups that allow SSH access from the internet.
+
+| Property | Value |
+|----------|-------|
+| Rule ID | `policy.no-public-ssh` |
+| Default Severity | Error |
+| Applies To | `aws_security_group` |
+
+Flags `aws_security_group` resources with ingress rules allowing port 22 from `0.0.0.0/0`.
+
+### no-public-s3
+
+Detects S3 buckets with public-read ACL.
+
+| Property | Value |
+|----------|-------|
+| Rule ID | `policy.no-public-s3` |
+| Default Severity | Error |
+| Applies To | `aws_s3_bucket` |
+
+Flags `aws_s3_bucket` resources where `acl` is set to `public-read`.
+
+### no-public-rds
+
+Detects publicly accessible RDS instances.
+
+| Property | Value |
+|----------|-------|
+| Rule ID | `policy.no-public-rds` |
+| Default Severity | Error |
+| Applies To | `aws_db_instance` |
+
+Flags `aws_db_instance` resources where `publicly_accessible` is `true`.
+
+## Terraform Best Practices
+
+### required-terraform-block
+
+Ensures a `terraform` block exists in the module.
+
+| Property | Value |
+|----------|-------|
+| Rule ID | `policy.required-terraform-block` |
+| Default Severity | Warning |
+| Applies To | All modules |
+
+### required-version
+
+Ensures `required_version` is specified in the `terraform` block.
+
+| Property | Value |
+|----------|-------|
+| Rule ID | `policy.required-version` |
+| Default Severity | Warning |
+| Applies To | `terraform` block |
+
+### required-providers
+
+Ensures providers used in the module have version constraints in `required_providers`.
+
+| Property | Value |
+|----------|-------|
+| Rule ID | `policy.required-providers` |
+| Default Severity | Warning |
+| Applies To | `terraform.required_providers` |
+
+### required-tags
+
+Ensures taggable resources have a `tags` attribute.
+
+| Property | Value |
+|----------|-------|
+| Rule ID | `policy.required-tags` |
+| Default Severity | Warning |
+| Applies To | `aws_instance`, `aws_s3_bucket` |
+
+### module-version
+
+Ensures external modules specify a `version` constraint.
+
+| Property | Value |
+|----------|-------|
+| Rule ID | `policy.module-version` |
+| Default Severity | Warning |
+| Applies To | Module blocks with non-local sources |
+
+Local modules (paths starting with `./` or `../`) are excluded.
+
+## Rule Summary
+
+| Rule | Severity | Description |
+|------|----------|-------------|
+| `no-public-ssh` | Error | Security groups cannot allow SSH from 0.0.0.0/0 |
+| `no-public-s3` | Error | S3 buckets cannot have public-read ACL |
+| `no-public-rds` | Error | RDS instances cannot be publicly accessible |
+| `required-terraform-block` | Warning | Terraform block must exist |
+| `required-version` | Warning | `required_version` must be specified |
+| `required-providers` | Warning | Providers must have version constraints |
+| `required-tags` | Warning | Resources should have tags |
+| `module-version` | Warning | External modules should have version constraints |

--- a/docs/site/docs/user-guide/commands.md
+++ b/docs/site/docs/user-guide/commands.md
@@ -373,6 +373,21 @@ terratidy test-rule [rule-path] [flags]
 | `--expect`   | Expected findings file (YAML or JSON)            |
 | `-v`         | Verbose output                                   |
 
+**Expected Findings Format:**
+
+The `--expect` file uses YAML or JSON with this schema:
+
+```yaml
+findings:
+  - rule: "policy-rule-name"        # Required; matched as suffix
+    severity: "error"               # Optional; must match exactly
+    message: "expected substring"   # Optional; substring match
+```
+
+Matching rules: `rule` is matched as a suffix (e.g., `"no-public-ssh"` matches
+`"policy.no-public-ssh"`). `severity` must match exactly if specified. `message` is
+a substring match if specified.
+
 **Examples:**
 
 ```bash

--- a/docs/site/docs/user-guide/engines/policy.md
+++ b/docs/site/docs/user-guide/engines/policy.md
@@ -37,8 +37,8 @@ engines:
 ## Writing Policies
 
 Policies are written in Rego (v1 syntax) and evaluated against a JSON representation
-of your Terraform modules. TerraTidy uses OPA v1, which requires the `import rego.v1`
-statement and updated rule syntax.
+of your Terraform modules. TerraTidy uses **OPA v1.15.0** with Rego v1, which requires
+the `import rego.v1` statement and updated rule syntax.
 
 ### Basic Policy Structure
 
@@ -102,9 +102,22 @@ Each resource/block includes:
 
 - `type`: The resource type (e.g., "aws_instance")
 - `name`: The resource name
-- `_file`: Source file path
-- `_range`: Line/column information
-- All attributes as key-value pairs
+- `_block_type`: The HCL block type (resource, data, module, etc.)
+- `_file`: Source file path where the block is defined
+- `_range`: Location object with `start_line`, `end_line`, `start_column`, `end_column`
+- All attributes as key-value pairs (raw expression text)
+
+The `_range` field is useful for precise error reporting in custom policies:
+
+```rego
+msg := {
+    "msg": "Issue description",
+    "rule": "my-rule",
+    "severity": "error",
+    "file": resource._file,
+    "line": resource._range.start_line
+}
+```
 
 ## Built-in Policies
 


### PR DESCRIPTION
## Description

Document built-in policy rules, LSP server details, and test-rule expected findings format.

**New page:**
- Create `docs/site/docs/rules/policy-rules.md` with all 8 built-in policy rules:
  3 security rules (no-public-ssh, no-public-s3, no-public-rds) and
  5 best practice rules (required-terraform-block, required-version, required-providers,
  required-tags, module-version). Each rule has severity, scope, description, and summary table.

**LSP (lsp.md):**
- Add full sync mode detail (TextDocumentSyncKind=1, save notifications include text)

**Policy engine (policy.md):**
- Add OPA v1.15.0 version reference
- Document `_block_type`, `_range` metadata fields with `start_line`/`end_line`/`start_column`/`end_column`
- Add `_range` usage example for custom policy error reporting

**Commands (commands.md):**
- Document `test-rule` expected findings YAML schema
- Document matching rules: rule (suffix match), severity (exact), message (substring)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linters (`make lint`)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

- `go build ./...` passes
- All 8 policy rule names verified against `internal/engines/policy/policy.go`
- OPA version confirmed from go.mod

## Screenshots

N/A - documentation changes only.

## Additional Notes

- VCS merge-base logic was already documented in PR 4 (commands.md "VCS Integration" section)
- Tests not applicable (no code changes)