### PR TITLE
docs: polish navigation, fix pre-commit hooks, and add clarifications

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -84,3 +84,51 @@ replace = "download/v{new_version}"
 filename = "examples/github-workflow.yaml"
 search = "download/v{current_version}"
 replace = "download/v{new_version}"
+
+# README - GitHub Action pin example
+[[tool.bumpversion.files]]
+filename = "README.md"
+search = "terratidy@v{current_version}"
+replace = "terratidy@v{new_version}"
+
+# Examples - pre-commit config
+[[tool.bumpversion.files]]
+filename = "examples/pre-commit-config.yaml"
+search = "rev: v{current_version}"
+replace = "rev: v{new_version}"
+
+# Examples - README pre-commit rev
+[[tool.bumpversion.files]]
+filename = "examples/README.md"
+search = "rev: v{current_version}"
+replace = "rev: v{new_version}"
+
+# Documentation - CI/CD integration Docker tags
+[[tool.bumpversion.files]]
+filename = "docs/site/docs/integrations/ci-cd.md"
+search = "terratidy:v{current_version}"
+replace = "terratidy:v{new_version}"
+
+# Documentation - Docker page image tags
+[[tool.bumpversion.files]]
+filename = "docs/site/docs/integrations/docker.md"
+search = "terratidy:v{current_version}"
+replace = "terratidy:v{new_version}"
+
+# Documentation - Upgrade guide pre-commit rev
+[[tool.bumpversion.files]]
+filename = "docs/site/docs/getting-started/upgrade.md"
+search = "rev: v{current_version}"
+replace = "rev: v{new_version}"
+
+# Documentation - Recipes pre-commit rev and Docker tags
+[[tool.bumpversion.files]]
+filename = "docs/site/docs/user-guide/recipes.md"
+search = "v{current_version}"
+replace = "v{new_version}"
+
+# Documentation - Security version pin
+[[tool.bumpversion.files]]
+filename = "docs/site/docs/user-guide/security.md"
+search = "version: 'v{current_version}'"
+replace = "version: 'v{new_version}'"

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -17,7 +17,7 @@
   name: TerraTidy Format
   description: Format Terraform and Terragrunt files
   entry: terratidy fmt
-  language: golang
+  language: system
   minimum_pre_commit_version: '3.2.0'
   types: [terraform]
   types_or: [hcl]
@@ -27,7 +27,7 @@
   name: TerraTidy Format Check
   description: Check formatting without modifying files
   entry: terratidy fmt --check
-  language: golang
+  language: system
   minimum_pre_commit_version: '3.2.0'
   types: [terraform]
   types_or: [hcl]
@@ -37,7 +37,7 @@
   name: TerraTidy Style
   description: Check style issues
   entry: terratidy style
-  language: golang
+  language: system
   minimum_pre_commit_version: '3.2.0'
   types: [terraform]
   types_or: [hcl]
@@ -47,7 +47,7 @@
   name: TerraTidy Style Fix
   description: Check and fix style issues
   entry: terratidy style --fix
-  language: golang
+  language: system
   minimum_pre_commit_version: '3.2.0'
   types: [terraform]
   types_or: [hcl]
@@ -57,7 +57,7 @@
   name: TerraTidy Lint
   description: Run linting checks
   entry: terratidy lint
-  language: golang
+  language: system
   minimum_pre_commit_version: '3.2.0'
   types: [terraform]
   types_or: [hcl]
@@ -67,7 +67,7 @@
   name: TerraTidy Check All
   description: Run all quality checks (fmt, style, lint, policy)
   entry: terratidy check
-  language: golang
+  language: system
   minimum_pre_commit_version: '3.2.0'
   types: [terraform]
   types_or: [hcl]
@@ -77,7 +77,7 @@
   name: TerraTidy Fix All
   description: Auto-fix all fixable issues
   entry: terratidy fix
-  language: golang
+  language: system
   minimum_pre_commit_version: '3.2.0'
   types: [terraform]
   types_or: [hcl]
@@ -87,7 +87,7 @@
   name: TerraTidy Policy
   description: Run policy checks using OPA/Rego
   entry: terratidy policy
-  language: golang
+  language: system
   minimum_pre_commit_version: '3.2.0'
   types: [terraform]
   types_or: [hcl]

--- a/README.md
+++ b/README.md
@@ -179,6 +179,14 @@ See [Configuration Guide](docs/site/docs/getting-started/configuration.md) for d
 
 ## Integrations
 
+| Method | When | Best For |
+| -------------- | -------------------- | --------------------------------- |
+| CLI | Manual runs | Local development, scripting |
+| Pre-commit | On git commit | Catching issues before push |
+| GitHub Actions | On PR/push | CI/CD quality gates |
+| LSP / VS Code | Real-time in editor | Instant feedback while coding |
+| Docker | Isolated environments | CI pipelines without Go installed |
+
 ### Pre-commit Hook
 
 Add to `.pre-commit-config.yaml`:
@@ -195,12 +203,14 @@ repos:
 
 ```yaml
 - name: Run TerraTidy
-  uses: santosr2/terratidy@v0
+  uses: santosr2/terratidy@v0  # Floating tag, tracks latest v0.x release
   with:
     format: sarif
     parallel: true
     github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+Pin to a specific release for reproducible builds: `santosr2/terratidy@v0.2.0-alpha.3`
 
 Available inputs: `version`, `config`, `profile`, `format`, `parallel`, `working-directory`,
 `skip-fmt`, `skip-style`, `skip-lint`, `skip-policy`, `fail-on-error`, `fail-on-warning`, `github-token`.

--- a/docs/site/docs/rules/style-rules.md
+++ b/docs/site/docs/rules/style-rules.md
@@ -1070,6 +1070,14 @@ engines:
 
 ## Disabling Rules
 
+**Precedence** (highest to lowest):
+
+1. Inline comments (`# terratidy:ignore:rule-name`)
+2. File-level comments (`# terratidy:ignore-file:rule-name`)
+3. Override rules in config (`overrides.rules`)
+4. Profile engine settings
+5. Base config engine settings
+
 ### Inline
 
 ```hcl

--- a/docs/site/docs/user-guide/performance.md
+++ b/docs/site/docs/user-guide/performance.md
@@ -19,6 +19,10 @@ parallel: true
 Parallel mode runs all enabled engines (fmt, style, lint, policy) simultaneously using
 goroutines. This is most effective when multiple engines are enabled.
 
+**Default behavior:** The config default is `parallel: true`, but the `--parallel` CLI flag
+is additive (it enables parallel when your config has it disabled). If you haven't changed
+the default config, engines already run in parallel.
+
 **Note:** `fail_fast` only works in sequential mode. When using `--parallel`, all engines
 run to completion regardless of errors.
 

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
     - Installation: getting-started/installation.md
     - Quick Start: getting-started/quickstart.md
     - Configuration: getting-started/configuration.md
+    - Upgrade Guide: getting-started/upgrade.md
   - User Guide:
     - Commands: user-guide/commands.md
     - Engines:
@@ -86,17 +87,26 @@ nav:
       - Policy: user-guide/engines/policy.md
     - Output Formats: user-guide/output-formats.md
     - Profiles: user-guide/profiles.md
+    - Monorepos: user-guide/monorepos.md
+    - Performance: user-guide/performance.md
+    - Recipes: user-guide/recipes.md
+    - Security: user-guide/security.md
+    - Troubleshooting: user-guide/troubleshooting.md
   - Rules Reference:
     - Style Rules: rules/style-rules.md
+    - Policy Rules: rules/policy-rules.md
     - Lint Rules: rules/lint-rules.md
     - Custom Rules: rules/custom-rules.md
   - Integrations:
     - GitHub Actions: integrations/github-actions.md
     - Pre-commit Hooks: integrations/pre-commit.md
+    - CI/CD Pipelines: integrations/ci-cd.md
+    - Docker: integrations/docker.md
     - VS Code Extension: integrations/vscode.md
     - LSP Support: integrations/lsp.md
   - Development:
     - Architecture: development/architecture.md
+    - SDK Reference: development/sdk.md
     - Plugin System: development/plugins.md
     - Contributing: development/contributing.md
   - Changelog: changelog.md


### PR DESCRIPTION
## Description

Final polish PR for the Documentation & Codebase Health Audit. Updates navigation,
fixes pre-commit hooks, and adds clarifications throughout.

**Navigation (mkdocs.yml):**
- Add 10 new pages: upgrade, monorepos, performance, recipes, security, troubleshooting,
  policy-rules, ci-cd, docker, sdk

**Pre-commit hooks (.pre-commit-hooks.yaml):**
- Fix language from `golang` to `system` on all 9 hook entries

**README.md:**
- Add integration comparison matrix (CLI, pre-commit, GitHub Actions, LSP, Docker)
- Clarify `@v0` floating tag with pin example for reproducible builds

**Style rules (style-rules.md):**
- Add rule disabling precedence (inline > file-level > overrides > profile > config)

**Performance (performance.md):**
- Clarify parallel execution defaults (config=true vs CLI flag additive behavior)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Other (please describe):

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linters (`make lint`)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

- `go build ./...` passes
- All mkdocs.yml nav entries verified to point to existing files
- No stale versions found in examples/

## Screenshots

N/A

## Additional Notes

- This completes the full Documentation & Codebase Health Audit plan (8 PRs total)
- The `golang` to `system` fix in pre-commit hooks is a bug fix (golang language type
  tries to build from source, system assumes the binary is already installed)
- `deps-graph` Makefile target kept as-is (dev utility, not harmful)