### PR TITLE
test: add fuzz tests and gorelease API compatibility check

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,62 @@
+name: Fuzz
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/fuzz.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/fuzz.yml'
+  schedule:
+    - cron: '0 4 * * 1'  # Weekly on Monday at 4am UTC
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-fuzz-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fuzz:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        include:
+          - package: ./internal/config/
+            target: FuzzConfigParse
+          - package: ./internal/engines/format/
+            target: FuzzFormat
+          - package: ./internal/plugins/
+            target: FuzzYAMLRuleParse
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: '1.26.1'
+
+      - name: Run fuzz test
+        run: |
+          if [ "$IS_SCHEDULED" = "true" ]; then
+            FUZZTIME="5m"
+          else
+            FUZZTIME="30s"
+          fi
+          echo "Running ${{ matrix.target }} for $FUZZTIME"
+          go test -fuzz="${{ matrix.target }}" -fuzztime="$FUZZTIME" "${{ matrix.package }}"
+        env:
+          IS_SCHEDULED: ${{ github.event_name == 'schedule' }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -100,3 +100,36 @@ jobs:
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+
+  api-compat:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check for pkg/sdk changes
+        uses: santosr2/conditional-paths-action@9c124632d1b141a351779440b22130f0c9806166 # v1.0.0
+        id: filter
+        with:
+          filters: |
+            sdk:
+              - 'pkg/sdk/**'
+
+      - name: Set up Go
+        if: steps.filter.outputs.sdk == 'true'
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: '1.26.1'
+
+      - name: Install gorelease
+        if: steps.filter.outputs.sdk == 'true'
+        run: go install golang.org/x/exp/cmd/gorelease@latest
+
+      - name: Run API compatibility check
+        if: steps.filter.outputs.sdk == 'true'
+        run: gorelease

--- a/docs/site/docs/development/contributing.md
+++ b/docs/site/docs/development/contributing.md
@@ -211,8 +211,21 @@ The CI pipeline runs on every PR:
 - **dependency-review:** Reviews dependency changes in PRs for advisories
 - **gitleaks:** Scans for accidentally committed secrets
 - **go-licenses:** Verifies all dependencies use approved licenses
+- **zizmor:** Scans GitHub Actions workflows for security issues
+- **gorelease:** Checks `pkg/sdk` API compatibility on PRs (only when SDK files change)
+
+**Fuzz workflow** (`.github/workflows/fuzz.yml`):
+
+- Runs fuzz tests for config parsing, HCL formatting, and YAML rule loading
+- 30s on PRs, 5m weekly for deeper exploration
 
 All checks must pass before merging. See [Security](security.md) for details on the scanning pipeline.
+
+### API Stability
+
+The `pkg/sdk` package is the public API for rule authors. Changes to exported types and functions
+are checked by `gorelease` on every PR that modifies `pkg/sdk/**`. Breaking changes require a major
+version bump.
 
 ## Commit Format
 

--- a/internal/config/config_fuzz_test.go
+++ b/internal/config/config_fuzz_test.go
@@ -1,0 +1,39 @@
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func FuzzConfigParse(f *testing.F) {
+	f.Add([]byte(`version: 1
+engines:
+  fmt:
+    enabled: true
+  style:
+    enabled: true
+`))
+	f.Add([]byte(`version: 1
+imports:
+  - .terratidy/*.yaml
+profiles:
+  production:
+    engines:
+      policy:
+        enabled: true
+`))
+	f.Add([]byte(`{}`))
+	f.Add([]byte(``))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		expanded := expandEnvVars(string(data))
+
+		var cfg Config
+		if err := yaml.Unmarshal([]byte(expanded), &cfg); err != nil {
+			return
+		}
+
+		_ = cfg.Validate()
+	})
+}

--- a/internal/engines/format/format_fuzz_test.go
+++ b/internal/engines/format/format_fuzz_test.go
@@ -1,0 +1,36 @@
+package format
+
+import (
+	"testing"
+)
+
+func FuzzFormat(f *testing.F) {
+	f.Add([]byte(`resource "aws_s3_bucket" "example" {
+  bucket = "my-bucket"
+  tags = {
+    Name = "test"
+  }
+}
+`))
+	f.Add([]byte(`variable "name" {
+  type    = string
+  default = "hello"
+}
+`))
+	f.Add([]byte(`terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+`))
+	f.Add([]byte(``))
+	f.Add([]byte(`{`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_ = Format(data)
+	})
+}

--- a/internal/plugins/yaml_fuzz_test.go
+++ b/internal/plugins/yaml_fuzz_test.go
@@ -1,0 +1,45 @@
+package plugins
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func FuzzYAMLRuleParse(f *testing.F) {
+	f.Add([]byte(`name: require-description
+description: Resources must have a description
+severity: warning
+enabled: true
+message: "Resource is missing a description attribute"
+patterns:
+  resource_types:
+    - aws_s3_bucket
+  required_attributes:
+    - description
+`))
+	f.Add([]byte(`name: test-rule
+severity: error
+enabled: false
+tags:
+  - security
+  - compliance
+`))
+	f.Add([]byte(`{}`))
+	f.Add([]byte(``))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var config YAMLRuleConfig
+		if err := yaml.Unmarshal(data, &config); err != nil {
+			return
+		}
+
+		if config.Name == "" {
+			return
+		}
+
+		rule := &YAMLRule{config: config}
+		_ = rule.Name()
+		_ = rule.Description()
+	})
+}

--- a/mise.toml
+++ b/mise.toml
@@ -14,6 +14,7 @@ bun = "1"  # VS Code extension development
 "go:github.com/mgechev/revive" = "1"
 "go:golang.org/x/vuln/cmd/govulncheck" = "1"
 "go:github.com/google/go-licenses" = "1"
+"go:golang.org/x/exp/cmd/gorelease" = "latest"  # uses date-based versions, not semver
 zizmor = "1"
 
 [tasks.coverage]


### PR DESCRIPTION
## Description

Add fuzz testing and API compatibility checking:

**Fuzz tests (3 new test files):**
- `internal/config/config_fuzz_test.go` - Fuzzes YAML config parsing (expandEnvVars + Unmarshal + Validate)
- `internal/engines/format/format_fuzz_test.go` - Fuzzes HCL formatting (hclwrite.Format wrapper)
- `internal/plugins/yaml_fuzz_test.go` - Fuzzes YAML rule config parsing

All three verified locally with 200k+ executions each in 6s, no panics found.

**Fuzz workflow** (`.github/workflows/fuzz.yml`):
- Matrix strategy runs all 3 fuzz targets in parallel
- 30s on PRs (quick sanity check), 5m weekly on schedule (deeper exploration)
- Path-filtered to only trigger on Go source changes

**API compatibility** (added to `security.yml`):
- New `api-compat` job runs `gorelease` on PRs that change `pkg/sdk/**`
- Uses `santosr2/conditional-paths-action` v1.0.0 (SHA-pinned) for path filtering
- Detects backwards-incompatible changes to the public SDK before merge

**Tooling:**
- Added `gorelease` to `mise.toml` for local development

## Related Issue

N/A

## Type of Change

- [x] CI/CD changes
- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linters (`make lint`)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

- [x] Fuzz tests verified locally (5s each, all pass)
- [x] Fuzz workflow runs successfully in CI (30s per target)
- [x] API compat job skips when no pkg/sdk changes detected
- [x] Pre-commit hooks all pass