### PR TITLE
chore: improve community health templates and add status badges docs

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -138,3 +138,9 @@ replace = "version: 'v{new_version}'"
 filename = "docs/site/docs/getting-started/verification.md"
 search = "download v{current_version}"
 replace = "download v{new_version}"
+
+# Bug report template version placeholder
+[[tool.bumpversion.files]]
+filename = ".github/ISSUE_TEMPLATE/bug_report.yml"
+search = "v{current_version}"
+replace = "v{new_version}"

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,9 +63,23 @@ body:
     attributes:
       label: TerraTidy Version
       description: Output of `terratidy version`
-      placeholder: "v0.2.0-alpha"
+      placeholder: "v0.2.0-alpha.3"
     validations:
       required: true
+
+  - type: input
+    id: go-version
+    attributes:
+      label: Go Version
+      description: Output of `go version` (if installed from source or using go install)
+      placeholder: "go1.26.1 darwin/arm64"
+
+  - type: textarea
+    id: debug-output
+    attributes:
+      label: Debug Output
+      description: Output of `terratidy check --format json` on the affected files (helps reproduce).
+      render: json
 
   - type: dropdown
     id: os

--- a/.github/ISSUE_TEMPLATE/rule_request.yml
+++ b/.github/ISSUE_TEMPLATE/rule_request.yml
@@ -1,0 +1,80 @@
+name: Rule Request
+description: Request a new rule for TerraTidy
+title: "[Rule]: "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Suggest a new rule for one of TerraTidy's engines.
+
+  - type: dropdown
+    id: engine
+    attributes:
+      label: Engine
+      description: Which engine should this rule belong to?
+      options:
+        - fmt (formatting)
+        - style (style conventions)
+        - lint (correctness and best practices)
+        - policy (organizational policies)
+    validations:
+      required: true
+
+  - type: input
+    id: name
+    attributes:
+      label: Rule Name
+      description: Suggested name for the rule (e.g., `require-description`, `no-hardcoded-ami`).
+      placeholder: "require-tags"
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - error
+        - warning
+        - info
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What should this rule check for and why?
+    validations:
+      required: true
+
+  - type: textarea
+    id: bad-example
+    attributes:
+      label: Bad Example (should fail)
+      description: HCL code that should trigger this rule.
+      render: hcl
+    validations:
+      required: true
+
+  - type: textarea
+    id: good-example
+    attributes:
+      label: Good Example (should pass)
+      description: HCL code that should not trigger this rule.
+      render: hcl
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context, links to Terraform docs, or references.
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Checklist
+      options:
+        - label: I have searched existing issues to ensure this is not a duplicate
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,27 +1,16 @@
-## Description
+## What and why
 
-<!-- Describe your changes in detail -->
+<!-- What changed and why? Link to an issue if applicable (Fixes #123). -->
 
-## Related Issue
+## How to test
 
-<!-- Link to the issue this PR addresses, if applicable -->
-<!-- Fixes #123 or Closes #123 -->
+<!-- How can reviewers verify this change? -->
 
-## Type of Change
+## Notes for reviewers
 
-<!-- Mark the relevant option with an x -->
-
-- [ ] Bug fix (non-breaking change that fixes an issue)
-- [ ] New feature (non-breaking change that adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to change)
-- [ ] Documentation update
-- [ ] Refactoring (no functional changes)
-- [ ] CI/CD changes
-- [ ] Other (please describe):
+<!-- Anything reviewers should know: trade-offs, follow-up work, areas of concern. -->
 
 ## Checklist
-
-<!-- Mark completed items with an x -->
 
 - [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
 - [ ] My code follows the project's code style
@@ -30,15 +19,3 @@
 - [ ] I have run the linters (`make lint`)
 - [ ] I have updated documentation as needed
 - [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
-
-## Testing
-
-<!-- Describe how you tested your changes -->
-
-## Screenshots
-
-<!-- If applicable, add screenshots to help explain your changes -->
-
-## Additional Notes
-
-<!-- Any additional information that reviewers should know -->

--- a/docs/site/docs/integrations/github-actions.md
+++ b/docs/site/docs/integrations/github-actions.md
@@ -188,3 +188,21 @@ jobs:
               body: `TerraTidy found ${findings} issue(s).`
             })
 ```
+
+## Status Badges
+
+Add TerraTidy status badges to your repository README to show that your Terraform code is checked:
+
+```markdown
+<!-- Passing badge -->
+![TerraTidy](https://raw.githubusercontent.com/santosr2/terratidy/main/assets/terratidy-status-passing.svg)
+
+<!-- Failing badge -->
+![TerraTidy](https://raw.githubusercontent.com/santosr2/terratidy/main/assets/terratidy-status-failing.svg)
+```
+
+To dynamically show pass/fail status based on your workflow, use GitHub's built-in workflow badge:
+
+```markdown
+[![TerraTidy](https://github.com/<owner>/<repo>/actions/workflows/<workflow>.yml/badge.svg)](https://github.com/<owner>/<repo>/actions)
+```


### PR DESCRIPTION
## What and why

Improve community health files and developer experience:

- **PR template:** Simplified to 3 sections (what/why, how to test, notes for reviewers) with checklist retained. Removed redundant sections (Type of Change, Related Issue, Screenshots, Additional Notes) that added friction without value.
- **Rule request template:** New `rule_request.yml` with engine dropdown (`fmt`, `style`, `lint`, `policy`), severity picker, and bad/good HCL example fields. Makes it easy for users to request new rules with all the context needed.
- **Bug report:** Added Go version input and `--format json` debug output textarea for better reproduction.
- **Status badges:** Documented TerraTidy passing/failing SVG badges and dynamic workflow badges in GitHub Actions docs.
- **Version tracking:** Added bug report placeholder to `.bumpversion.toml` so it stays current on releases.

## How to test

- [ ] Verify rule request template renders correctly: create a new issue and select "Rule Request"
- [ ] Verify bug report template shows new Go version and debug output fields
- [ ] Verify PR template renders with the 3 sections + checklist

## Notes for reviewers

Config.yml URLs verified live (Discussions enabled, docs site accessible). No changes needed to config.yml.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass (`make test`)
- [ ] I have run the linters (`make lint`)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)