### PR TITLE
ci(quality): cache pre-commit hooks and skip branch guard in CI

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -34,7 +34,7 @@ jobs:
           python-version: '3.x'
 
       - name: Cache pre-commit hooks
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.3.0
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}


### PR DESCRIPTION
## What and why

Two fixes for the Quality workflow after adding the `no-commit-to-branch` hook in #44:

- **Cache hook environments**: Pre-commit reinstalled all hook environments on every run. Add `actions/cache` keyed on `.pre-commit-config.yaml` hash to reuse them across runs.
- **Skip `no-commit-to-branch` in CI**: The hook blocks commits on `main`, which is correct locally but breaks CI since it legitimately runs on `main` pushes. Use `SKIP` env var to bypass it.

## How to test

- Verify the Quality workflow passes on this PR
- On a subsequent push, confirm the cache is restored (check the "Cache pre-commit hooks" step output)

## Notes for reviewers

The `SKIP` env var is the official pre-commit mechanism for skipping hooks in CI.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linters (`make lint`)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)