### PR TITLE
ci: add PR title checker and standardize commit conventions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       interval: weekly
       day: monday
     commit-message:
-      prefix: "deps"
+      prefix: "chore"
       include: "scope"
     labels:
       - dependencies
@@ -19,7 +19,7 @@ updates:
       interval: weekly
       day: monday
     commit-message:
-      prefix: "deps"
+      prefix: "vscode"
       include: "scope"
     labels:
       - dependencies
@@ -31,7 +31,7 @@ updates:
       interval: weekly
       day: monday
     commit-message:
-      prefix: "deps"
+      prefix: "container"
       include: "scope"
     labels:
       - dependencies

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -8,12 +8,42 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ci-quality-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  pr-title:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Validate PR title follows Conventional Commits
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+            vscode
+            container
+          requireScope: false
+          subjectPattern: ^[a-z].+[^.]$
+          subjectPatternError: >
+            The subject must start with a lowercase letter and not end with a period.
+
   pre-commit:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,4 +68,4 @@ repos:
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
-        args: [feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert]
+        args: [feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert, vscode, container]

--- a/cliff.toml
+++ b/cliff.toml
@@ -74,8 +74,13 @@ commit_parsers = [
   { message = "^style", group = "Changed" },
   { message = "^test", skip = true },
   { message = "^chore\\(release\\)", skip = true },
-  { message = "^chore\\(deps\\)", skip = true },
+  { message = "^chore\\(deps", group = "Dependencies" },
+  { message = "^vscode\\(deps", group = "Dependencies" },
+  { message = "^container\\(deps", group = "Dependencies" },
+  { message = "^ci\\(deps", group = "Dependencies" },
   { message = "^chore", group = "Other" },
+  { message = "^vscode", group = "VS Code Extension" },
+  { message = "^container", group = "Container" },
   { body = ".*security", group = "Security" },
 ]
 # protect breaking changes from being skipped due to matching a skipping commit_parser


### PR DESCRIPTION
## What and why

Squash-merged PRs use the PR title as the commit message on main, bypassing the conventional commit validation on individual commits. This adds a PR title checker to catch non-conforming titles before merge.

Also standardizes Dependabot commit prefixes by ecosystem area (`chore` for gomod, `vscode` for npm, `container` for docker, `ci` for github-actions) and updates git-cliff to include dependency updates in release notes under a dedicated "Dependencies" section instead of skipping them.

## How to test

- Open a PR with a non-conventional title (e.g., "Update stuff") and verify the `pr-title` check fails
- Open a PR with a valid title (e.g., "feat: add feature") and verify it passes
- Verify `vscode` and `container` are accepted as types in both the PR checker and local pre-commit hook

## Notes for reviewers

- `vscode` and `container` are custom conventional commit types for project areas (same pattern as `ci` and `docs`)
- Dependabot PRs will now produce `chore(deps):`, `vscode(deps):`, `container(deps):`, `ci(deps):` titles
- git-cliff now groups all `**(deps)` commits under "Dependencies" and adds "VS Code Extension" and "Container" sections for non-dependency work in those areas

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linters (`make lint`)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
