### PR TITLE
docs: fix README inaccuracies, broken Homebrew install, and plugin template bug

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -71,6 +71,7 @@ release:
 
     ```bash
     # Homebrew (macOS/Linux)
+    brew tap santosr2/tap https://github.com/santosr2/TerraTidy
     brew install santosr2/tap/terratidy
 
     # Go install

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ TerraTidy is a single-binary quality platform for Terraform and Terragrunt that 
 
 - **Single Binary** -- No external dependencies for core functionality
 - **Library-first Architecture** -- Uses Go libraries (hclwrite, OPA SDK) directly instead of shelling out
-- **Extensible** -- Custom rules in Go, Rego, YAML, or Bash
+- **Extensible** -- Custom rules in Go, YAML, or Bash
 - **Modular Config** -- Split large configs into organized files with glob imports
 - **Auto-fix** -- Automatically fix formatting and style issues
 - **Multiple Output Formats** -- Text, table, JSON, SARIF, HTML, JUnit, Markdown, GitHub Actions annotations
@@ -42,6 +42,7 @@ TerraTidy is a single-binary quality platform for Terraform and Terragrunt that 
 ### Homebrew (macOS/Linux)
 
 ```bash
+brew tap santosr2/tap https://github.com/santosr2/TerraTidy
 brew install santosr2/tap/terratidy
 ```
 
@@ -223,7 +224,7 @@ For larger projects, split configuration into organized files:
 version: 1
 
 imports:
-  - .terratidy/rules/**/*.yaml
+  - .terratidy/rules/*.yaml
   - .terratidy/profiles/default.yaml
 
 severity_threshold: warning
@@ -293,12 +294,17 @@ func (r *EnforceTaggingRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Find
 ### YAML Rule
 
 ```yaml
-rule: custom.naming_convention
-pattern:
-  block_type: resource
-  conditions:
-    - attribute: "name"
-      regex: "^[a-z][a-z0-9_]*$"
+name: require-description
+description: Resources must have a description attribute
+severity: warning
+enabled: true
+message: "Resource is missing a description attribute"
+patterns:
+  resource_types:
+    - aws_instance
+    - aws_s3_bucket
+  required_attributes:
+    - description
 ```
 
 ### Bash Script

--- a/docs/site/docs/getting-started/installation.md
+++ b/docs/site/docs/getting-started/installation.md
@@ -13,6 +13,7 @@ go install github.com/santosr2/terratidy/cmd/terratidy@latest
 ## Homebrew (macOS/Linux)
 
 ```bash
+brew tap santosr2/tap https://github.com/santosr2/TerraTidy
 brew install santosr2/tap/terratidy
 ```
 

--- a/internal/plugins/example_plugin.go.template
+++ b/internal/plugins/example_plugin.go.template
@@ -109,7 +109,7 @@ func (r *MyCustomRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Finding, e
 }
 
 // Fix attempts to fix the issue (optional)
-func (r *MyCustomRule) Fix(ctx *sdk.Context, file *hcl.File) error {
+func (r *MyCustomRule) Fix(ctx *sdk.Context, file *hcl.File) ([]byte, error) {
 	// Implement fix logic if the issue is auto-fixable
-	return nil
+	return nil, nil
 }

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -25,6 +25,7 @@ This extension brings TerraTidy's powerful formatting, style checking, linting, 
 go install github.com/santosr2/terratidy/cmd/terratidy@latest
 
 # Using Homebrew (macOS)
+brew tap santosr2/tap https://github.com/santosr2/TerraTidy
 brew install santosr2/tap/terratidy
 
 # Download from releases


### PR DESCRIPTION
## What and why

README audit (`.specs/readme-accuracy-audit.md`) found 4 inaccuracies in the README and 1 bug in the plugin template. All verified by cross-referencing source code.

**README fixes:**
- **YAML rule example was completely wrong** -- used nonexistent fields (`rule:`, `pattern:`, `block_type:`, `conditions:`, `regex:`). Replaced with correct schema matching `YAMLRuleConfig` in `internal/plugins/yaml_rule.go`
- **Extensibility claim included Rego** -- plugin system only loads `.so`, `.yaml`, `.sh`. Rego is policy engine input, not a plugin type
- **Modular config example used `**/*.yaml`** -- `filepath.Glob` doesn't support `**` recursive globs; silently matches nothing. Changed to `*.yaml`
- **Homebrew install was broken** -- `brew install santosr2/tap/terratidy` fails without a `homebrew-tap` repo. Added `brew tap` step pointing to source repo. Tested locally and confirmed working

**Code fix:**
- `internal/plugins/example_plugin.go.template` `Fix` method returns `error` but `sdk.Rule` interface requires `([]byte, error)`

## How to test

- Read the YAML rule example in README and compare to `internal/plugins/yaml_rule.go` `YAMLRuleConfig` struct
- Verify Homebrew: `brew tap santosr2/tap https://github.com/santosr2/TerraTidy && brew install santosr2/tap/terratidy`
- Grep for consistency: `grep -n 'brew tap' README.md .goreleaser.yml vscode/README.md docs/site/docs/getting-started/installation.md`
- Verify template fix: compare `internal/plugins/example_plugin.go.template` `Fix` signature to `pkg/sdk/types.go` `Rule` interface

## Notes for reviewers

- The `**` glob limitation is a known Go stdlib gap. A follow-up could add `doublestar` library support, but that's a feature, not a docs fix
- `make lint` passes (0 issues). `make test` passes (all green)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linters (`make lint`)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
