### PR TITLE
fix: add LSP write mutex, config cycle detection, and interface cleanup

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -106,12 +106,15 @@ func Load(path string) (*Config, error) {
 
 	// Load imports if specified
 	if len(cfg.Imports) > 0 {
-		if err := cfg.loadImports(filepath.Dir(path)); err != nil {
+		absPath, _ := filepath.Abs(path)
+		visited := map[string]bool{absPath: true}
+		if err := cfg.loadImports(filepath.Dir(path), visited); err != nil {
 			return nil, fmt.Errorf("loading imports: %w", err)
 		}
 	}
 
-	// Validate configuration
+	// Apply defaults and validate
+	cfg.SetDefaults()
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid config: %w", err)
 	}
@@ -153,8 +156,9 @@ func expandEnvVars(content string) string {
 	})
 }
 
-// loadImports loads and merges imported configurations
-func (c *Config) loadImports(baseDir string) error {
+// loadImports loads and merges imported configurations.
+// The visited map tracks already-loaded files to detect circular imports.
+func (c *Config) loadImports(baseDir string, visited map[string]bool) error {
 	for _, pattern := range c.Imports {
 		// Convert relative pattern to absolute
 		if !filepath.IsAbs(pattern) {
@@ -169,9 +173,22 @@ func (c *Config) loadImports(baseDir string) error {
 
 		// Load each matched file
 		for _, match := range matches {
+			absMatch, _ := filepath.Abs(match)
+			if visited[absMatch] {
+				return fmt.Errorf("circular import detected: %s", absMatch)
+			}
+			visited[absMatch] = true
+
 			partial, err := loadPartialConfig(match)
 			if err != nil {
 				return fmt.Errorf("loading %s: %w", match, err)
+			}
+
+			// Recursively load imports from the partial config
+			if len(partial.Imports) > 0 {
+				if err := partial.loadImports(filepath.Dir(match), visited); err != nil {
+					return err
+				}
 			}
 
 			// Merge partial config into main config
@@ -225,11 +242,16 @@ func (c *Config) merge(other *Config) {
 }
 
 // Validate validates the configuration
-func (c *Config) Validate() error {
+// SetDefaults fills in default values for unset fields.
+// Call this before Validate.
+func (c *Config) SetDefaults() {
 	if c.Version == 0 {
 		c.Version = 1
 	}
+}
 
+// Validate checks the configuration for errors.
+func (c *Config) Validate() error {
 	if c.Version != 1 {
 		return fmt.Errorf("unsupported config version: %d", c.Version)
 	}

--- a/internal/config/config_cycle_test.go
+++ b/internal/config/config_cycle_test.go
@@ -1,0 +1,78 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadImports_CircularImport(t *testing.T) {
+	dir := t.TempDir()
+
+	// a.yaml imports b.yaml, b.yaml imports a.yaml
+	aPath := filepath.Join(dir, "a.yaml")
+	bPath := filepath.Join(dir, "b.yaml")
+
+	aContent := "version: 1\nimports:\n  - " + bPath + "\n"
+	bContent := "version: 1\nimports:\n  - " + aPath + "\n"
+
+	require.NoError(t, os.WriteFile(aPath, []byte(aContent), 0o644))
+	require.NoError(t, os.WriteFile(bPath, []byte(bContent), 0o644))
+
+	_, err := Load(aPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "circular import detected")
+}
+
+func TestLoadImports_SameFileViaRelativeAndAbsolute(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a shared import file
+	sharedPath := filepath.Join(dir, "shared.yaml")
+	require.NoError(t, os.WriteFile(sharedPath, []byte("version: 1\n"), 0o644))
+
+	// Main config imports the same file twice (relative and absolute)
+	mainContent := "version: 1\nimports:\n  - shared.yaml\n  - " + sharedPath + "\n"
+	mainPath := filepath.Join(dir, ".terratidy.yaml")
+	require.NoError(t, os.WriteFile(mainPath, []byte(mainContent), 0o644))
+
+	_, err := Load(mainPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "circular import detected")
+}
+
+func TestLoadImports_NoCircle(t *testing.T) {
+	dir := t.TempDir()
+
+	// a.yaml and b.yaml imported by main, no cycle
+	aPath := filepath.Join(dir, "a.yaml")
+	bPath := filepath.Join(dir, "b.yaml")
+
+	require.NoError(t, os.WriteFile(aPath, []byte("engines:\n  fmt:\n    enabled: true\n"), 0o644))
+	require.NoError(t, os.WriteFile(bPath, []byte("engines:\n  style:\n    enabled: true\n"), 0o644))
+
+	mainContent := "version: 1\nimports:\n  - " + aPath + "\n  - " + bPath + "\n"
+	mainPath := filepath.Join(dir, ".terratidy.yaml")
+	require.NoError(t, os.WriteFile(mainPath, []byte(mainContent), 0o644))
+
+	cfg, err := Load(mainPath)
+	require.NoError(t, err)
+	assert.Equal(t, 1, cfg.Version)
+}
+
+func TestSetDefaults(t *testing.T) {
+	t.Run("version 0 gets set to 1", func(t *testing.T) {
+		cfg := &Config{Version: 0}
+		cfg.SetDefaults()
+		assert.Equal(t, 1, cfg.Version)
+	})
+
+	t.Run("version 1 unchanged", func(t *testing.T) {
+		cfg := &Config{Version: 1}
+		cfg.SetDefaults()
+		assert.Equal(t, 1, cfg.Version)
+	})
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -154,6 +154,7 @@ func TestValidate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			tt.cfg.SetDefaults()
 			err := tt.cfg.Validate()
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -24,6 +24,7 @@ import (
 type Server struct {
 	reader        *bufio.Reader
 	writer        io.Writer
+	writeMu       sync.Mutex // protects writer from concurrent writeMessage calls
 	config        *config.Config
 	documents     map[string]*Document
 	docMu         sync.RWMutex
@@ -108,12 +109,17 @@ func (s *Server) readMessage() (json.RawMessage, error) {
 	return content, nil
 }
 
-// writeMessage writes an LSP message to stdout
+// writeMessage writes an LSP message to stdout.
+// The mutex ensures concurrent publishDiagnostics calls don't interleave
+// the header and content of different messages.
 func (s *Server) writeMessage(msg any) error {
 	content, err := json.Marshal(msg)
 	if err != nil {
 		return fmt.Errorf("marshaling message: %w", err)
 	}
+
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
 
 	header := fmt.Sprintf("Content-Length: %d\r\n\r\n", len(content))
 	if _, err := io.WriteString(s.writer, header); err != nil {

--- a/internal/plugins/plugin.go
+++ b/internal/plugins/plugin.go
@@ -17,6 +17,7 @@ package plugins
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"plugin"
@@ -73,7 +74,7 @@ type FormatterPlugin interface {
 	// Name returns the formatter name
 	Name() string
 	// Format formats the findings and writes to the writer
-	Format(findings []sdk.Finding, w any) error
+	Format(findings []sdk.Finding, w io.Writer) error
 }
 
 // Manager manages plugin loading and registration

--- a/internal/plugins/plugin_test.go
+++ b/internal/plugins/plugin_test.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -190,7 +191,7 @@ type MockFormatter struct {
 }
 
 func (f *MockFormatter) Name() string { return f.name }
-func (f *MockFormatter) Format(_ []sdk.Finding, _ any) error {
+func (f *MockFormatter) Format(_ []sdk.Finding, _ io.Writer) error {
 	return nil
 }
 


### PR DESCRIPTION
## What and why

Four safety and correctness improvements to internal architecture:

**1. LSP write mutex** (`internal/lsp/server.go`)

`writeMessage` performs two separate writes (header + content) with no synchronization. When `publishDiagnostics` fires concurrently (e.g., rapid `didChange` notifications from typing), the writes from different messages can interleave, corrupting the LSP protocol stream. Added `writeMu sync.Mutex` to serialize writes.

**2. Config circular import detection** (`internal/config/config.go`)

`loadImports` had no cycle detection. A config `a.yaml` importing `b.yaml` which imports `a.yaml` caused infinite recursion. Now tracks visited files via `filepath.Abs` and returns a clear error. Also fixed a missing feature: partial configs' own imports were not loaded recursively.

**3. Separate Validate from SetDefaults** (`internal/config/config.go`)

`Validate()` was mutating state by setting `Version = 1` when it was 0. A validation method should not have side effects. Extracted this into a `SetDefaults()` method that `Load()` calls explicitly before `Validate()`.

**4. FormatterPlugin interface** (`internal/plugins/plugin.go`)

The writer parameter was `any` but should be `io.Writer` to match the internal `output.Formatter` interface. Plugin formatters and built-in formatters are now type-compatible.

## How to test

```bash
go test ./... -count=1          # all 16 packages pass
go test -race ./internal/lsp/   # race-free
go vet ./...                    # clean
```

New tests:
- `TestLoadImports_CircularImport`: `a.yaml` -> `b.yaml` -> `a.yaml` returns clear error
- `TestLoadImports_SameFileViaRelativeAndAbsolute`: same file via two paths detected as visited
- `TestLoadImports_NoCircle`: valid import chain loads successfully
- `TestSetDefaults`: version 0 -> 1, version 1 unchanged

## Notes for reviewers

- The cycle detection uses `filepath.Abs` to normalize paths before checking the visited map. This prevents the same file imported via relative and absolute paths from being loaded twice.
- `loadImports` now recursively loads imports from partial configs. This was previously a missing feature (partial config imports were silently ignored).
- The `SetDefaults` extraction required updating one existing test (`TestValidate/version_0_gets_defaulted`) to call `SetDefaults()` before `Validate()`.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linters (`make lint`)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
