### PR TITLE
refactor(sdk): split Rule/Fixer interfaces, unify Engine, remove Context.Logger

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,10 @@ type Rule interface {
     Name() string
     Description() string
     Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Finding, error)
+}
+
+// Rules that support auto-fixing also implement Fixer
+type Fixer interface {
     Fix(ctx *sdk.Context, file *hcl.File) ([]byte, error)
 }
 ```
@@ -185,9 +189,10 @@ func (r *MyRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Finding, error) 
     return findings, nil
 }
 
-func (r *MyRule) Fix(ctx *sdk.Context, file *hcl.File) ([]byte, error) {
-    return nil, nil
-}
+// Optional: implement sdk.Fixer for auto-fix support
+// func (r *MyRule) Fix(ctx *sdk.Context, file *hcl.File) ([]byte, error) {
+//     return fixedContent, nil
+// }
 ```
 
 ### YAML Rule

--- a/docs/site/docs/development/plugins.md
+++ b/docs/site/docs/development/plugins.md
@@ -45,7 +45,13 @@ type Rule interface {
 
     // Check evaluates the rule against a parsed HCL file
     Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Finding, error)
+}
+```
 
+Rules that support auto-fixing also implement `sdk.Fixer`:
+
+```go
+type Fixer interface {
     // Fix applies an automatic fix and returns the corrected file bytes
     Fix(ctx *sdk.Context, file *hcl.File) ([]byte, error)
 }
@@ -58,7 +64,6 @@ The `sdk.Context` provides runtime information to rules:
 ```go
 type Context struct {
     Config  map[string]any
-    Logger  *log.Logger
     WorkDir string
     File    string
 }
@@ -209,9 +214,10 @@ func (r *RequireTagsRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Finding
     return findings, nil
 }
 
-func (r *RequireTagsRule) Fix(_ *sdk.Context, _ *hcl.File) ([]byte, error) {
-    return nil, nil
-}
+// Optional: implement sdk.Fixer for auto-fix support
+// func (r *RequireTagsRule) Fix(_ *sdk.Context, _ *hcl.File) ([]byte, error) {
+//     return fixedContent, nil
+// }
 ```
 
 ### Building Go Plugins

--- a/docs/site/docs/development/sdk.md
+++ b/docs/site/docs/development/sdk.md
@@ -26,10 +26,26 @@ type Rule interface {
     // Check evaluates the rule against a parsed HCL file and returns any findings.
     // Return nil findings and nil error if the file passes the check.
     Check(ctx *Context, file *hcl.File) ([]Finding, error)
+}
+```
 
+Rules that support auto-fixing also implement `Fixer`:
+
+```go
+type Fixer interface {
     // Fix applies an automatic fix and returns the corrected file content.
-    // Return nil, nil if the rule does not support auto-fixing.
     Fix(ctx *Context, file *hcl.File) ([]byte, error)
+}
+```
+
+## Engine Interface
+
+All analysis engines (fmt, style, lint, policy) implement:
+
+```go
+type Engine interface {
+    Name() string
+    Run(ctx context.Context, files []string) ([]Finding, error)
 }
 ```
 
@@ -42,9 +58,6 @@ type Context struct {
     // Config holds rule-specific configuration from .terratidy.yaml.
     // Keys and values correspond to the "options" map under a rule's config.
     Config map[string]any
-
-    // Logger for diagnostic output (not user-facing findings).
-    Logger *log.Logger
 
     // WorkDir is the working directory TerraTidy was invoked from.
     WorkDir string
@@ -125,7 +138,8 @@ func (r *MyRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Finding, error) 
     }}, nil
 }
 
-func (r *MyRule) Fix(ctx *sdk.Context, file *hcl.File) ([]byte, error) {
-    return nil, nil // No auto-fix
-}
+// Optional: implement sdk.Fixer for auto-fix support
+// func (r *MyRule) Fix(ctx *sdk.Context, file *hcl.File) ([]byte, error) {
+//     return fixedContent, nil
+// }
 ```

--- a/docs/site/docs/rules/custom-rules.md
+++ b/docs/site/docs/rules/custom-rules.md
@@ -11,6 +11,13 @@ type Rule interface {
     Name() string
     Description() string
     Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Finding, error)
+}
+```
+
+Rules that support auto-fixing also implement `sdk.Fixer`:
+
+```go
+type Fixer interface {
     Fix(ctx *sdk.Context, file *hcl.File) ([]byte, error)
 }
 ```
@@ -20,7 +27,6 @@ The `sdk.Context` provides runtime information:
 ```go
 type Context struct {
     Config  map[string]any
-    Logger  *log.Logger
     WorkDir string
     File    string
 }

--- a/internal/output/output_coverage_test.go
+++ b/internal/output/output_coverage_test.go
@@ -86,12 +86,18 @@ func TestMarkdownFormatter_AllSeverities(t *testing.T) {
 
 func TestGitHubActionsFormatter_AllSeverities(t *testing.T) {
 	findings := []sdk.Finding{
-		{Rule: "r1", Message: "error msg", File: "a.tf", Severity: sdk.SeverityError,
-			Location: hcl.Range{Start: hcl.Pos{Line: 1, Column: 1}}},
-		{Rule: "r2", Message: "warn msg", File: "a.tf", Severity: sdk.SeverityWarning,
-			Location: hcl.Range{Start: hcl.Pos{Line: 2, Column: 1}}},
-		{Rule: "r3", Message: "info msg", File: "a.tf", Severity: sdk.SeverityInfo,
-			Location: hcl.Range{Start: hcl.Pos{Line: 3, Column: 1}}},
+		{
+			Rule: "r1", Message: "error msg", File: "a.tf", Severity: sdk.SeverityError,
+			Location: hcl.Range{Start: hcl.Pos{Line: 1, Column: 1}},
+		},
+		{
+			Rule: "r2", Message: "warn msg", File: "a.tf", Severity: sdk.SeverityWarning,
+			Location: hcl.Range{Start: hcl.Pos{Line: 2, Column: 1}},
+		},
+		{
+			Rule: "r3", Message: "info msg", File: "a.tf", Severity: sdk.SeverityInfo,
+			Location: hcl.Range{Start: hcl.Pos{Line: 3, Column: 1}},
+		},
 	}
 
 	formatter := &GitHubActionsFormatter{}

--- a/internal/plugins/plugin.go
+++ b/internal/plugins/plugin.go
@@ -15,7 +15,6 @@
 package plugins
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"os"
@@ -61,13 +60,8 @@ type RulePlugin interface {
 	GetRules() []sdk.Rule
 }
 
-// EnginePlugin defines the interface for engine plugins
-type EnginePlugin interface {
-	// Name returns the engine name
-	Name() string
-	// Run executes the engine on the given files
-	Run(ctx context.Context, files []string) ([]sdk.Finding, error)
-}
+// EnginePlugin is sdk.Engine.
+type EnginePlugin = sdk.Engine
 
 // FormatterPlugin defines the interface for formatter plugins
 type FormatterPlugin interface {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -9,12 +9,6 @@ import (
 	"github.com/santosr2/terratidy/pkg/sdk"
 )
 
-// Engine defines the interface that all engines must implement
-type Engine interface {
-	Name() string
-	Run(ctx context.Context, files []string) ([]sdk.Finding, error)
-}
-
 // EngineResult holds the result from a single engine execution
 type EngineResult struct {
 	Engine   string
@@ -24,20 +18,20 @@ type EngineResult struct {
 
 // Runner executes multiple engines, optionally in parallel
 type Runner struct {
-	engines  []Engine
+	engines  []sdk.Engine
 	parallel bool
 }
 
 // New creates a new Runner
 func New() *Runner {
 	return &Runner{
-		engines:  make([]Engine, 0),
+		engines:  make([]sdk.Engine, 0),
 		parallel: false,
 	}
 }
 
 // AddEngine adds an engine to the runner
-func (r *Runner) AddEngine(engine Engine) *Runner {
+func (r *Runner) AddEngine(engine sdk.Engine) *Runner {
 	r.engines = append(r.engines, engine)
 	return r
 }
@@ -137,7 +131,7 @@ func (r *Runner) runParallelWithResults(ctx context.Context, files []string) []E
 
 	for _, engine := range r.engines {
 		wg.Add(1)
-		go func(eng Engine) {
+		go func(eng sdk.Engine) {
 			defer wg.Done()
 
 			findings, err := eng.Run(ctx, files)
@@ -149,11 +143,9 @@ func (r *Runner) runParallelWithResults(ctx context.Context, files []string) []E
 		}(engine)
 	}
 
-	// Wait for all engines to complete
 	wg.Wait()
 	close(resultsChan)
 
-	// Collect results in order received
 	results := make([]EngineResult, 0, len(r.engines))
 	for result := range resultsChan {
 		results = append(results, result)

--- a/pkg/sdk/types.go
+++ b/pkg/sdk/types.go
@@ -4,7 +4,7 @@
 package sdk
 
 import (
-	"log"
+	"context"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
@@ -68,8 +68,6 @@ type Finding struct {
 type Context struct {
 	// Config holds rule-specific options from the "options" map in .terratidy.yaml.
 	Config map[string]any
-	// Logger for diagnostic output (not user-facing findings).
-	Logger *log.Logger
 	// WorkDir is the directory TerraTidy was invoked from.
 	WorkDir string
 	// File is the absolute path to the file being checked.
@@ -78,7 +76,6 @@ type Context struct {
 
 // Rule defines the interface that all rules must implement. Built-in rules,
 // Go plugin rules, YAML rules, and Bash rules all satisfy this interface.
-// The Check method detects issues; the Fix method applies corrections.
 type Rule interface {
 	// Name returns a unique identifier for the rule (e.g., "style.block-label-case").
 	Name() string
@@ -87,7 +84,20 @@ type Rule interface {
 	// Check evaluates the rule against a parsed HCL file and returns any findings.
 	// Return nil findings and nil error if the file passes the check.
 	Check(ctx *Context, file *hcl.File) ([]Finding, error)
+}
+
+// Fixer is an optional interface for rules that support auto-fixing.
+// Rules that implement both Rule and Fixer can automatically correct issues.
+type Fixer interface {
 	// Fix applies an automatic fix and returns the corrected file content as bytes.
-	// Return nil, nil if the rule does not support auto-fixing.
+	// Return nil, nil if no fix is needed.
 	Fix(ctx *Context, file *hcl.File) ([]byte, error)
+}
+
+// Engine defines the interface for analysis engines (fmt, style, lint, policy).
+type Engine interface {
+	// Name returns the engine identifier.
+	Name() string
+	// Run executes the engine on the given files and returns findings.
+	Run(ctx context.Context, files []string) ([]Finding, error)
 }

--- a/pkg/sdk/types_test.go
+++ b/pkg/sdk/types_test.go
@@ -1,8 +1,6 @@
 package sdk
 
 import (
-	"log"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
@@ -82,22 +80,10 @@ func TestContext(t *testing.T) {
 		assert.Equal(t, "main.tf", ctx.File)
 	})
 
-	t.Run("context with logger", func(t *testing.T) {
-		logger := log.New(os.Stderr, "test: ", log.LstdFlags)
-		ctx := &Context{
-			Logger:  logger,
-			WorkDir: ".",
-		}
-
-		assert.NotNil(t, ctx.Logger)
-		assert.Equal(t, ".", ctx.WorkDir)
-	})
-
 	t.Run("empty context", func(t *testing.T) {
 		ctx := &Context{}
 
 		assert.Nil(t, ctx.Config)
-		assert.Nil(t, ctx.Logger)
 		assert.Empty(t, ctx.WorkDir)
 		assert.Empty(t, ctx.File)
 	})
@@ -128,21 +114,15 @@ func (r *MockRule) Fix(ctx *Context, file *hcl.File) ([]byte, error) {
 }
 
 func TestRuleInterface(t *testing.T) {
-	t.Run("mock rule implementation", func(t *testing.T) {
+	t.Run("mock rule implements Rule", func(t *testing.T) {
 		rule := &MockRule{
 			name:        "mock-rule",
 			description: "A mock rule for testing",
 			checkFunc: func(_ *Context, _ *hcl.File) ([]Finding, error) {
-				return []Finding{
-					{Rule: "mock-rule", Message: "Found issue"},
-				}, nil
-			},
-			fixFunc: func(_ *Context, _ *hcl.File) ([]byte, error) {
-				return []byte("fixed"), nil
+				return []Finding{{Rule: "mock-rule", Message: "Found issue"}}, nil
 			},
 		}
 
-		// Test interface compliance
 		var _ Rule = rule
 
 		assert.Equal(t, "mock-rule", rule.Name())
@@ -151,7 +131,17 @@ func TestRuleInterface(t *testing.T) {
 		findings, err := rule.Check(nil, nil)
 		assert.NoError(t, err)
 		assert.Len(t, findings, 1)
-		assert.Equal(t, "mock-rule", findings[0].Rule)
+	})
+
+	t.Run("mock rule implements Fixer", func(t *testing.T) {
+		rule := &MockRule{
+			name: "fixable-rule",
+			fixFunc: func(_ *Context, _ *hcl.File) ([]byte, error) {
+				return []byte("fixed"), nil
+			},
+		}
+
+		var _ Fixer = rule
 
 		fixed, err := rule.Fix(nil, nil)
 		assert.NoError(t, err)
@@ -159,10 +149,7 @@ func TestRuleInterface(t *testing.T) {
 	})
 
 	t.Run("rule with nil functions", func(t *testing.T) {
-		rule := &MockRule{
-			name:        "empty-rule",
-			description: "Rule with no implementation",
-		}
+		rule := &MockRule{name: "empty-rule"}
 
 		findings, err := rule.Check(nil, nil)
 		assert.NoError(t, err)


### PR DESCRIPTION
## What and why

Three breaking changes to the public SDK to clean up the interface design.

**1. Split `sdk.Rule` into `Rule` + `Fixer`**

`Rule` previously required all rules to implement `Fix()`, even rules that can't fix anything (YAML rules, Bash rules, most lint rules). They all had `return nil, nil` stubs. Now:

- `Rule` requires only `Name()`, `Description()`, `Check()`
- `Fixer` is an optional interface with `Fix()`
- Rules that auto-fix implement both interfaces
- The existing style engine already uses `FixFunc` closures on findings (not `rule.Fix()` directly), so no engine changes were needed

**2. Move `Engine` interface to `sdk`**

`runner.Engine` and `plugins.EnginePlugin` were structurally identical interfaces defined in different packages. Now `sdk.Engine` is the single source of truth. The runner uses `sdk.Engine` directly and `EnginePlugin` is a type alias.

**3. Remove `Context.Logger`**

The `Logger *log.Logger` field on `sdk.Context` was never set in production code. Any rule that tried to use it would panic with a nil pointer. Removed rather than wiring it up, since rules should return findings, not log.

## How to test

```bash
go build ./...       # clean
go test ./... -short # all 16 packages pass
go vet ./...         # clean
```

## Notes for reviewers

- Style rules still have `Fix()` methods. They now satisfy both `sdk.Rule` and `sdk.Fixer` without any code change (Go structural typing).
- The `EnginePlugin` alias in `internal/plugins/plugin.go` could be removed entirely, but it's used in type assertions within `loadFormatterPlugin` etc. Keeping as an alias is zero-cost.
- Documentation updated in CLAUDE.md, custom-rules.md, plugins.md, and sdk.md to reflect the new interface split and removed Logger field.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linters (`make lint`)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
