### PR TITLE
perf: add benchmarks for lint, policy, and output formatters

### DIFF
--- a/internal/engines/lint/lint_coverage_test.go
+++ b/internal/engines/lint/lint_coverage_test.go
@@ -2,6 +2,7 @@ package lint
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -89,6 +90,47 @@ func TestRun_ContextCancellation(t *testing.T) {
 	engine := New(nil)
 	_, err := engine.Run(ctx, []string{tmpFile})
 	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func BenchmarkLintLargeModule(b *testing.B) {
+	dir := b.TempDir()
+
+	// Create 50 .tf files simulating a large module
+	for i := range 50 {
+		content := fmt.Sprintf(`resource "aws_instance" "server_%d" {
+  ami           = "ami-%06d"
+  instance_type = "t2.micro"
+
+  tags = {
+    Name = "server-%d"
+  }
+}
+
+variable "var_%d" {
+  description = "Variable %d"
+  type        = string
+  default     = "value-%d"
+}
+`, i, i, i, i, i, i)
+		f := filepath.Join(dir, fmt.Sprintf("file_%02d.tf", i))
+		require.NoError(b, os.WriteFile(f, []byte(content), 0o644))
+	}
+
+	var files []string
+	entries, err := os.ReadDir(dir)
+	require.NoError(b, err)
+	for _, e := range entries {
+		files = append(files, filepath.Join(dir, e.Name()))
+	}
+
+	engine := New(nil)
+	ctx := context.Background()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for range b.N {
+		_, _ = engine.Run(ctx, files)
+	}
 }
 
 func BenchmarkLintModule(b *testing.B) {

--- a/internal/engines/policy/policy_coverage_test.go
+++ b/internal/engines/policy/policy_coverage_test.go
@@ -2,6 +2,7 @@ package policy
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -73,6 +74,52 @@ deny[msg] {
 	require.NoError(t, err)
 	// Policy may or may not find issues depending on how input is structured
 	_ = findings
+}
+
+func BenchmarkPolicyMultiFile(b *testing.B) {
+	dir := b.TempDir()
+
+	// Create 20 .tf files
+	var files []string
+	for i := range 20 {
+		content := fmt.Sprintf(`resource "aws_instance" "server_%d" {
+  ami           = "ami-%06d"
+  instance_type = "t2.micro"
+}
+`, i, i)
+		f := filepath.Join(dir, fmt.Sprintf("file_%02d.tf", i))
+		require.NoError(b, os.WriteFile(f, []byte(content), 0o644))
+		files = append(files, f)
+	}
+
+	// Create 5 policy files
+	for i := range 5 {
+		policy := fmt.Sprintf(`package terraform
+
+deny[msg] {
+    resource := input.resources[_]
+    resource.type == "aws_instance"
+    not resource.values.tags
+    msg := {
+        "msg": "Policy %d: missing tags",
+        "rule": "require-tags-%d",
+        "severity": "warning"
+    }
+}
+`, i, i)
+		pf := filepath.Join(dir, fmt.Sprintf("policy_%d.rego", i))
+		require.NoError(b, os.WriteFile(pf, []byte(policy), 0o644))
+	}
+
+	cfg := &Config{PolicyDirs: []string{dir}}
+	engine := New(cfg)
+	ctx := context.Background()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for range b.N {
+		_, _ = engine.Run(ctx, files)
+	}
 }
 
 func BenchmarkPolicyEval(b *testing.B) {

--- a/internal/output/output_benchmark_test.go
+++ b/internal/output/output_benchmark_test.go
@@ -1,0 +1,92 @@
+package output
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/santosr2/terratidy/pkg/sdk"
+)
+
+func generateFindings(n int) []sdk.Finding {
+	findings := make([]sdk.Finding, n)
+	for i := range n {
+		sev := sdk.SeverityWarning
+		switch i % 3 {
+		case 0:
+			sev = sdk.SeverityError
+		case 2:
+			sev = sdk.SeverityInfo
+		}
+		findings[i] = sdk.Finding{
+			Rule:     fmt.Sprintf("test.rule-%d", i%10),
+			Message:  fmt.Sprintf("Issue %d in resource block", i),
+			File:     fmt.Sprintf("modules/service-%d/main.tf", i%5),
+			Severity: sev,
+			Location: hcl.Range{
+				Start: hcl.Pos{Line: i + 1, Column: 1},
+				End:   hcl.Pos{Line: i + 1, Column: 40},
+			},
+		}
+	}
+	return findings
+}
+
+func BenchmarkSARIFOutput(b *testing.B) {
+	findings := generateFindings(1000)
+	formatter := &SARIFFormatter{Version: "1.0.0"}
+	var buf bytes.Buffer
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for range b.N {
+		buf.Reset()
+		err := formatter.Format(findings, &buf)
+		require.NoError(b, err)
+	}
+}
+
+func BenchmarkHTMLOutput(b *testing.B) {
+	findings := generateFindings(1000)
+	formatter := &HTMLFormatter{Version: "1.0.0"}
+	var buf bytes.Buffer
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for range b.N {
+		buf.Reset()
+		err := formatter.Format(findings, &buf)
+		require.NoError(b, err)
+	}
+}
+
+func BenchmarkJSONOutput(b *testing.B) {
+	findings := generateFindings(1000)
+	formatter := &JSONFormatter{Pretty: true}
+	var buf bytes.Buffer
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for range b.N {
+		buf.Reset()
+		err := formatter.Format(findings, &buf)
+		require.NoError(b, err)
+	}
+}
+
+func BenchmarkTextOutput(b *testing.B) {
+	findings := generateFindings(1000)
+	formatter := &TextFormatter{Verbose: true}
+	var buf bytes.Buffer
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for range b.N {
+		buf.Reset()
+		err := formatter.Format(findings, &buf)
+		require.NoError(b, err)
+	}
+}


### PR DESCRIPTION
## What and why

Add benchmarks for the remaining performance-critical paths that lacked measurement. These establish baselines for regression tracking.

**New benchmarks:**

| Benchmark | Package | Input | ns/op | B/op | allocs/op |
|-----------|---------|-------|-------|------|-----------|
| `BenchmarkLintLargeModule` | lint | 50 .tf files | 49,558,924 | 19,397,577 | 19,042 |
| `BenchmarkPolicyMultiFile` | policy | 20 files, 5 policies | 2,072,923 | 1,654,802 | 26,516 |
| `BenchmarkSARIFOutput` | output | 1000 findings | 2,304,079 | 3,556,871 | 1,066 |
| `BenchmarkHTMLOutput` | output | 1000 findings | 9,003,172 | 70,765,771 | 25,063 |
| `BenchmarkJSONOutput` | output | 1000 findings | 1,552,597 | 2,097,183 | 35 |
| `BenchmarkTextOutput` | output | 1000 findings | 180,495 | 70,033 | 4,745 |

**Notable observations:**
- HTML output is the most expensive formatter (70MB/op for 1000 findings) due to inline CSS and template string concatenation. Worth optimizing if large reports are common.
- JSON is efficient (35 allocs for 1000 findings) thanks to `encoding/json` streaming.
- Lint on 50 files takes ~50ms, acceptable for CI but worth watching.

These complement the existing benchmarks in `internal/benchmark/` (fmt, style, runner, cache) and `internal/engines/style/` (7 style rule benchmarks).

## How to test

```bash
go test -bench=. -benchmem ./internal/engines/lint/ ./internal/engines/policy/ ./internal/output/
```

## Notes for reviewers

- `BenchmarkLintModule` and `BenchmarkPolicyEval` already existed from previous PRs. This adds the larger-scale variants.
- Output benchmarks reuse a shared `generateFindings(n)` helper that creates findings with mixed severities and realistic file paths.
- Platform: Apple M2 Pro, Go 1.26.1, Darwin/arm64.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [x] I have run the linters (`make lint`)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
