### PR TITLE
refactor(sdk): add Severity.Level() method

### DIFF
--- a/cmd/terratidy/helpers.go
+++ b/cmd/terratidy/helpers.go
@@ -272,20 +272,6 @@ func loadConfig() (*config.Config, error) {
 	return cfg, nil
 }
 
-// getSeverityLevel returns the numeric level for a severity.
-func getSeverityLevel(s sdk.Severity) int {
-	switch s {
-	case sdk.SeverityInfo:
-		return 0
-	case sdk.SeverityWarning:
-		return 1
-	case sdk.SeverityError:
-		return 2
-	default:
-		return 0
-	}
-}
-
 // filterFindingsBySeverity filters findings based on the severity threshold.
 // Only findings with severity >= threshold are returned.
 // If threshold is empty, all findings are returned.
@@ -294,11 +280,11 @@ func filterFindingsBySeverity(findings []sdk.Finding, threshold string) []sdk.Fi
 		return findings
 	}
 
-	thresholdLevel := getSeverityLevel(sdk.Severity(threshold))
+	thresholdLevel := sdk.Severity(threshold).Level()
 
 	var filtered []sdk.Finding
 	for _, f := range findings {
-		if getSeverityLevel(f.Severity) >= thresholdLevel {
+		if f.Severity.Level() >= thresholdLevel {
 			filtered = append(filtered, f)
 		}
 	}

--- a/pkg/sdk/types.go
+++ b/pkg/sdk/types.go
@@ -40,6 +40,22 @@ func ParseSeverity(s string, defaultSev Severity) Severity {
 	}
 }
 
+// Level returns the numeric priority level for the severity.
+// Higher values indicate more severe findings: error=2, warning=1, info=0.
+// Unknown severities return 0.
+func (s Severity) Level() int {
+	switch s {
+	case SeverityError:
+		return 2
+	case SeverityWarning:
+		return 1
+	case SeverityInfo:
+		return 0
+	default:
+		return 0
+	}
+}
+
 // Location represents a source code location for findings. It provides
 // a stable public API that does not depend on HCL internal types.
 type Location struct {

--- a/pkg/sdk/types_test.go
+++ b/pkg/sdk/types_test.go
@@ -261,6 +261,32 @@ func TestSeverityComparison(t *testing.T) {
 	})
 }
 
+func TestSeverityLevel(t *testing.T) {
+	tests := []struct {
+		name     string
+		severity Severity
+		expected int
+	}{
+		{"error has highest level", SeverityError, 2},
+		{"warning has middle level", SeverityWarning, 1},
+		{"info has lowest level", SeverityInfo, 0},
+		{"unknown severity returns 0", Severity("unknown"), 0},
+		{"empty severity returns 0", Severity(""), 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.severity.Level())
+		})
+	}
+
+	t.Run("level ordering for filtering", func(t *testing.T) {
+		// Verify error > warning > info for severity filtering
+		assert.Greater(t, SeverityError.Level(), SeverityWarning.Level())
+		assert.Greater(t, SeverityWarning.Level(), SeverityInfo.Level())
+	})
+}
+
 func TestLocation(t *testing.T) {
 	t.Run("basic location", func(t *testing.T) {
 		loc := Location{


### PR DESCRIPTION
## What and why

Add `Severity.Level()` method to the SDK, moving severity level calculation from CLI helpers into the public API.

- Adds `Level()` method to `Severity` type (error=2, warning=1, info=0)
- Removes duplicate `getSeverityLevel()` helper from `cmd/terratidy/helpers.go`
- Updates `filterFindingsBySeverity()` to use the new method
- Adds comprehensive tests for the new method

Consolidates severity handling in the SDK for consistent comparison across the codebase.

## How to test

```bash
mise run test -- -run TestSeverityLevel
mise run test
```

## Notes for reviewers

Straightforward refactoring. The logic is unchanged, just moved to a better location.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`mise run test`)
- [x] I have run the linters (`mise run lint`)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.ai/code)
