### PR TITLE
refactor(config): remove custom_rules in favor of overrides.rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,11 +114,6 @@ overrides:
     my-rule:
       enabled: true
       severity: error
-
-custom_rules:
-  my-custom-rule:
-    enabled: true
-    severity: warning
 ```
 
 ## Development

--- a/cmd/terratidy/check_integration_test.go
+++ b/cmd/terratidy/check_integration_test.go
@@ -199,3 +199,82 @@ func TestRunCheck(t *testing.T) {
 	// May return ExitError if findings have errors
 	_ = err
 }
+
+// TestEnginesStyleConfigFix verifies that engines.style.fix: true in config
+// enables auto-fix mode without requiring the --fix CLI flag.
+func TestEnginesStyleConfigFix(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create config with style.fix: true
+	configContent := `version: 1
+engines:
+  fmt:
+    enabled: false
+  style:
+    enabled: true
+    fix: true
+  lint:
+    enabled: false
+  policy:
+    enabled: false
+`
+	cfgPath := filepath.Join(dir, ".terratidy.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(configContent), 0o644))
+
+	// Create a file with style issues (multiple blank lines between blocks)
+	tfContent := `resource "aws_instance" "one" {
+  ami = "ami-123"
+}
+
+
+resource "aws_instance" "two" {
+  ami = "ami-456"
+}
+`
+	tfPath := filepath.Join(dir, "main.tf")
+	require.NoError(t, os.WriteFile(tfPath, []byte(tfContent), 0o644))
+
+	// Load config and run style checks
+	cfg, err := config.Load(cfgPath)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	_, err = runStyleCheckWithConfig(ctx, cfg, []string{tfPath}, 1, true)
+	require.NoError(t, err)
+
+	// Verify the file was modified (2 blank lines → 1)
+	modifiedContent, err := os.ReadFile(tfPath)
+	require.NoError(t, err)
+
+	expectedContent := `resource "aws_instance" "one" {
+  ami = "ami-123"
+}
+
+resource "aws_instance" "two" {
+  ami = "ami-456"
+}
+`
+	assert.Equal(t, expectedContent, string(modifiedContent), "style.fix: true should auto-fix blank line issues")
+}
+
+// TestEnginesLintConfigArgs verifies that engines.lint.args in config
+// are passed to buildLintConfig and available in the lint engine.
+func TestEnginesLintConfigArgs(t *testing.T) {
+	cfg := &config.Config{
+		Version: 1,
+		Engines: config.Engines{
+			Lint: config.LintEngineConfig{
+				Enabled:    config.BoolPtr(true),
+				Args:       []string{"--force", "--no-color", "--minimum-tf-version=1.5.0"},
+				ConfigFile: ".tflint.hcl",
+			},
+		},
+	}
+
+	lintCfg := buildLintConfig(cfg)
+
+	require.NotNil(t, lintCfg)
+	assert.Equal(t, []string{"--force", "--no-color", "--minimum-tf-version=1.5.0"}, lintCfg.Args,
+		"lint config should include args from engines.lint.args")
+	assert.Equal(t, ".tflint.hcl", lintCfg.ConfigFile)
+}

--- a/cmd/terratidy/init.go
+++ b/cmd/terratidy/init.go
@@ -289,14 +289,6 @@ engines:
 #     lint.terraform_required_version:
 #       enabled: true
 #       severity: error
-
-# Custom rules (advanced)
-# custom_rules:
-#   my-custom-rule:
-#     enabled: true
-#     severity: warning
-#     config:
-#       option: value
 `
 }
 

--- a/cmd/terratidy/init_rule.go
+++ b/cmd/terratidy/init_rule.go
@@ -352,10 +352,11 @@ tags:
 	fmt.Println()
 	fmt.Println("Next steps:")
 	fmt.Printf("  1. Edit %s to configure your rule\n", yamlFile)
-	fmt.Println("  2. Add the rule to your .terratidy.yaml:")
-	fmt.Printf("     custom_rules:\n")
-	fmt.Printf("       %s:\n", name)
-	fmt.Printf("         enabled: true\n")
+	fmt.Println("  2. Enable plugins in your .terratidy.yaml:")
+	fmt.Println("     plugins:")
+	fmt.Println("       enabled: true")
+	fmt.Println("       directories:")
+	fmt.Printf("         - %s\n", rulesDir)
 
 	return nil
 }

--- a/docs/site/docs/getting-started/configuration.md
+++ b/docs/site/docs/getting-started/configuration.md
@@ -167,19 +167,6 @@ overrides:
         min_version: "1.5.0"
 ```
 
-## Custom Rules
-
-Define custom rules:
-
-```yaml
-custom_rules:
-  my-org.naming-convention:
-    enabled: true
-    severity: warning
-    config:
-      pattern: "^(dev|staging|prod)_.*"
-```
-
 ## Plugins
 
 Enable and configure plugins:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -89,9 +89,6 @@ type Config struct {
 
 	// Plugin settings
 	Plugins PluginsConfig `yaml:"plugins,omitempty"`
-
-	// Custom rules
-	CustomRules map[string]RuleConfig `yaml:"custom_rules,omitempty"`
 }
 
 // Engines holds typed configuration for all engines.
@@ -504,14 +501,6 @@ func (c *Config) merge(other *Config) {
 	c.Engines.Lint.mergeFrom(&other.Engines.Lint)
 	c.Engines.Policy.mergeFrom(&other.Engines.Policy)
 
-	// Merge custom rules
-	if c.CustomRules == nil {
-		c.CustomRules = make(map[string]RuleConfig)
-	}
-	for k, v := range other.CustomRules {
-		c.CustomRules[k] = v
-	}
-
 	// Merge override rules
 	if c.Overrides.Rules == nil {
 		c.Overrides.Rules = make(map[string]RuleConfig)
@@ -582,9 +571,9 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("profile validation: %w", err)
 	}
 
-	// Validate custom rules
-	if err := c.validateCustomRules(); err != nil {
-		return fmt.Errorf("custom rules validation: %w", err)
+	// Validate rule overrides
+	if err := c.validateRuleOverrides(); err != nil {
+		return fmt.Errorf("rule overrides validation: %w", err)
 	}
 
 	// Validate plugin configuration
@@ -635,8 +624,8 @@ func (c *Config) checkCircularInheritance(name string, visited map[string]bool) 
 	return nil
 }
 
-// validateCustomRules validates custom rule configurations
-func (c *Config) validateCustomRules() error {
+// validateRuleOverrides validates rule override configurations
+func (c *Config) validateRuleOverrides() error {
 	validSeverities := map[string]bool{
 		"error":   true,
 		"warning": true,
@@ -644,17 +633,6 @@ func (c *Config) validateCustomRules() error {
 		"":        true, // Allow empty (default)
 	}
 
-	for name, rule := range c.CustomRules {
-		if name == "" {
-			return fmt.Errorf("custom rule name cannot be empty")
-		}
-
-		if !validSeverities[rule.Severity] {
-			return fmt.Errorf("custom rule %q has invalid severity: %s", name, rule.Severity)
-		}
-	}
-
-	// Also validate override rules
 	for name, rule := range c.Overrides.Rules {
 		if name == "" {
 			return fmt.Errorf("override rule name cannot be empty")

--- a/internal/config/config_coverage_test.go
+++ b/internal/config/config_coverage_test.go
@@ -39,38 +39,30 @@ func TestMerge_KeyOverride(t *testing.T) {
 	base := &Config{
 		Version:           1,
 		SeverityThreshold: "warning",
-		CustomRules: map[string]RuleConfig{
-			"rule-a": {Enabled: true, Severity: "warning"},
+		Overrides: OverridesConfig{
+			Rules: map[string]RuleConfig{
+				"rule-a": {Enabled: true, Severity: "warning"},
+			},
 		},
-	}
-	base.Overrides.Rules = map[string]RuleConfig{
-		"override-a": {Enabled: true},
 	}
 
 	other := &Config{
-		CustomRules: map[string]RuleConfig{
-			"rule-a": {Enabled: false, Severity: "error"}, // override
-			"rule-b": {Enabled: true},                     // new
+		Overrides: OverridesConfig{
+			Rules: map[string]RuleConfig{
+				"rule-a": {Enabled: false, Severity: "error"}, // override
+				"rule-b": {Enabled: true},                     // new
+			},
 		},
-	}
-	other.Overrides.Rules = map[string]RuleConfig{
-		"override-a": {Enabled: false}, // override
-		"override-b": {Enabled: true},  // new
 	}
 
 	base.merge(other)
 
-	// Custom rules should be merged with override
-	require.Contains(t, base.CustomRules, "rule-a")
-	assert.False(t, base.CustomRules["rule-a"].Enabled, "rule-a should be overridden to disabled")
-	assert.Equal(t, "error", base.CustomRules["rule-a"].Severity)
-	require.Contains(t, base.CustomRules, "rule-b")
-	assert.True(t, base.CustomRules["rule-b"].Enabled)
-
 	// Override rules should be merged
-	require.Contains(t, base.Overrides.Rules, "override-a")
-	assert.False(t, base.Overrides.Rules["override-a"].Enabled)
-	require.Contains(t, base.Overrides.Rules, "override-b")
+	require.Contains(t, base.Overrides.Rules, "rule-a")
+	assert.False(t, base.Overrides.Rules["rule-a"].Enabled, "rule-a should be overridden to disabled")
+	assert.Equal(t, "error", base.Overrides.Rules["rule-a"].Severity)
+	require.Contains(t, base.Overrides.Rules, "rule-b")
+	assert.True(t, base.Overrides.Rules["rule-b"].Enabled)
 }
 
 func TestLoad_EmptyPath_ReturnsDefaults(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -76,20 +76,21 @@ engines:
 	require.NoError(t, os.MkdirAll(configsDir, 0o755))
 
 	// Create imported config
-	importedConfig := `custom_rules:
-  my-rule:
-    enabled: true
-    severity: warning
+	importedConfig := `overrides:
+  rules:
+    my-rule:
+      enabled: true
+      severity: warning
 `
-	importPath := filepath.Join(configsDir, "custom.yaml")
+	importPath := filepath.Join(configsDir, "rules.yaml")
 	require.NoError(t, os.WriteFile(importPath, []byte(importedConfig), 0o644))
 
 	cfg, err := Load(mainPath)
 	require.NoError(t, err)
 
-	// Check that custom rule was imported
-	assert.Contains(t, cfg.CustomRules, "my-rule")
-	assert.True(t, cfg.CustomRules["my-rule"].Enabled)
+	// Check that override rule was imported
+	assert.Contains(t, cfg.Overrides.Rules, "my-rule")
+	assert.True(t, cfg.Overrides.Rules["my-rule"].Enabled)
 }
 
 func TestLoad_WithImports_EnvVarExpansion(t *testing.T) {
@@ -371,8 +372,10 @@ func TestDefaultConfig(t *testing.T) {
 
 func TestConfig_merge(t *testing.T) {
 	cfg := &Config{
-		CustomRules: map[string]RuleConfig{
-			"rule1": {Enabled: true},
+		Overrides: OverridesConfig{
+			Rules: map[string]RuleConfig{
+				"rule1": {Enabled: true},
+			},
 		},
 		Profiles: map[string]Profile{
 			"profile1": {Name: "profile1"},
@@ -380,45 +383,41 @@ func TestConfig_merge(t *testing.T) {
 	}
 
 	other := &Config{
-		CustomRules: map[string]RuleConfig{
-			"rule2": {Enabled: true},
+		Overrides: OverridesConfig{
+			Rules: map[string]RuleConfig{
+				"rule2": {Enabled: true},
+			},
 		},
 		Profiles: map[string]Profile{
 			"profile2": {Name: "profile2"},
 		},
+	}
+
+	cfg.merge(other)
+
+	// Check that overrides were merged
+	assert.Contains(t, cfg.Overrides.Rules, "rule1")
+	assert.Contains(t, cfg.Overrides.Rules, "rule2")
+
+	// Check that profiles were merged
+	assert.Contains(t, cfg.Profiles, "profile1")
+	assert.Contains(t, cfg.Profiles, "profile2")
+}
+
+func TestConfig_merge_NilMaps(t *testing.T) {
+	cfg := &Config{} // All maps are nil
+	other := &Config{
 		Overrides: OverridesConfig{
 			Rules: map[string]RuleConfig{
-				"override1": {Enabled: false},
+				"rule": {Enabled: true},
 			},
 		},
 	}
 
 	cfg.merge(other)
 
-	// Check that rules were merged
-	assert.Contains(t, cfg.CustomRules, "rule1")
-	assert.Contains(t, cfg.CustomRules, "rule2")
-
-	// Check that profiles were merged
-	assert.Contains(t, cfg.Profiles, "profile1")
-	assert.Contains(t, cfg.Profiles, "profile2")
-
-	// Check that overrides were merged
-	assert.Contains(t, cfg.Overrides.Rules, "override1")
-}
-
-func TestConfig_merge_NilMaps(t *testing.T) {
-	cfg := &Config{} // All maps are nil
-	other := &Config{
-		CustomRules: map[string]RuleConfig{
-			"rule": {Enabled: true},
-		},
-	}
-
-	cfg.merge(other)
-
-	assert.NotNil(t, cfg.CustomRules)
-	assert.Contains(t, cfg.CustomRules, "rule")
+	assert.NotNil(t, cfg.Overrides.Rules)
+	assert.Contains(t, cfg.Overrides.Rules, "rule")
 }
 
 func TestLoad_NonExistentFile(t *testing.T) {
@@ -431,15 +430,16 @@ func TestLoadPartialConfig(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "partial.yaml")
 
-	content := `custom_rules:
-  partial-rule:
-    enabled: true
+	content := `overrides:
+  rules:
+    partial-rule:
+      enabled: true
 `
 	require.NoError(t, os.WriteFile(configPath, []byte(content), 0o644))
 
 	cfg, err := loadPartialConfig(configPath)
 	require.NoError(t, err)
-	assert.Contains(t, cfg.CustomRules, "partial-rule")
+	assert.Contains(t, cfg.Overrides.Rules, "partial-rule")
 }
 
 func TestLoad_WithProfiles(t *testing.T) {
@@ -540,7 +540,7 @@ func TestValidate_NonExistentInheritedProfile(t *testing.T) {
 	assert.Contains(t, err.Error(), "inherits from non-existent profile")
 }
 
-func TestValidate_CustomRuleSeverity(t *testing.T) {
+func TestValidate_RuleOverrideSeverity(t *testing.T) {
 	tests := []struct {
 		name     string
 		severity string
@@ -557,8 +557,10 @@ func TestValidate_CustomRuleSeverity(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &Config{
 				Version: 1,
-				CustomRules: map[string]RuleConfig{
-					"my-rule": {Enabled: true, Severity: tt.severity},
+				Overrides: OverridesConfig{
+					Rules: map[string]RuleConfig{
+						"my-rule": {Enabled: true, Severity: tt.severity},
+					},
 				},
 			}
 			err := cfg.Validate()
@@ -1036,7 +1038,7 @@ imports:
 
 		// Create a few config files (not exceeding limit, just testing normal case)
 		for i := 0; i < 3; i++ {
-			content := "custom_rules: {}\n"
+			content := "version: 1\n"
 			filePath := filepath.Join(configsDir, "config"+string(rune('a'+i))+".yaml")
 			require.NoError(t, os.WriteFile(filePath, []byte(content), 0o644))
 		}
@@ -1492,20 +1494,7 @@ func TestConfig_merge_PluginDirectoriesAppended(t *testing.T) {
 	assert.Equal(t, []string{"./base-plugins", "./extra-plugins"}, base.Plugins.Directories)
 }
 
-func TestValidateCustomRules_EmptyName(t *testing.T) {
-	// The empty rule name check is a distinct branch in validateCustomRules.
-	cfg := &Config{
-		Version: 1,
-		CustomRules: map[string]RuleConfig{
-			"": {Enabled: true},
-		},
-	}
-	err := cfg.Validate()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "custom rule name cannot be empty")
-}
-
-func TestValidateCustomRules_EmptyOverrideName(t *testing.T) {
+func TestValidateRuleOverrides_EmptyOverrideName(t *testing.T) {
 	// The empty override rule name check path.
 	cfg := &Config{
 		Version: 1,


### PR DESCRIPTION
## What and why

Remove the `custom_rules` config key which duplicated functionality already provided by `overrides.rules`. This consolidates rule configuration into a single location, simplifying the config schema.

Changes:
- Remove `CustomRules` field from Config struct and merge logic
- Update `init-rule` command to recommend plugins instead of `custom_rules`
- Update all tests to use `overrides.rules`
- Add integration tests for `engines.style.fix` and `engines.lint.args`

## How to test

```bash
mise run test
mise run test:integration
```

## Notes for reviewers

This is a breaking change for anyone using `custom_rules` in their config, but since we're pre-v0.2 with no external users, no migration path is needed.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`mise run test`)
- [x] I have run the linters (`mise run lint`)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.ai/code)
