### PR TITLE
chore: improve error messages and fix CI deprecations

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Run osv-scanner on VSCode extension
         continue-on-error: true
-        run: osv-scanner --lockfile=vscode/bun.lock --format=sarif --output=osv-results.sarif
+        run: osv-scanner scan --lockfile=vscode/bun.lock --format=sarif --output-file=osv-results.sarif
 
       - name: Upload SARIF to GitHub Security
         uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,11 +30,13 @@ builds:
 
 archives:
   - id: terratidy
-    format: tar.gz
+    formats:
+      - tar.gz
     name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
     files:
       - LICENSE
       - README.md

--- a/cmd/terratidy/config.go
+++ b/cmd/terratidy/config.go
@@ -151,15 +151,13 @@ func runConfigValidate(_ *cobra.Command, _ []string) error {
 
 	// Check if file exists
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		return fmt.Errorf("configuration file not found: %s", configPath)
+		return fmt.Errorf("configuration file not found: %s (run 'terratidy init' to create one)", configPath)
 	}
 
 	// Load and validate
 	cfg, err := config.Load(configPath)
 	if err != nil {
-		fmt.Println("[!] Validation failed:")
-		fmt.Printf("    %v\n", err)
-		return err
+		return fmt.Errorf("validation failed: %w", err)
 	}
 
 	// Additional validation
@@ -236,7 +234,7 @@ func runConfigSplit(_ *cobra.Command, _ []string) error {
 	configPath := getConfigPath()
 
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		return fmt.Errorf("configuration file not found: %s", configPath)
+		return fmt.Errorf("configuration file not found: %s (run 'terratidy init' to create one)", configPath)
 	}
 
 	cfg, err := config.Load(configPath)

--- a/cmd/terratidy/config_coverage_test.go
+++ b/cmd/terratidy/config_coverage_test.go
@@ -141,13 +141,15 @@ func TestRunConfigValidate(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("nonexistent config file errors", func(t *testing.T) {
+	t.Run("nonexistent config file errors with init hint", func(t *testing.T) {
 		old := cfgFile
 		cfgFile = "/nonexistent/.terratidy.yaml"
 		defer func() { cfgFile = old }()
 
 		err := runConfigValidate(nil, nil)
-		assert.Error(t, err)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "configuration file not found")
+		assert.Contains(t, err.Error(), "terratidy init")
 	})
 }
 
@@ -172,6 +174,17 @@ func TestRunConfigSplit(t *testing.T) {
 	splitDir := filepath.Join(dir, ".terratidy")
 	_, err = os.Stat(splitDir)
 	assert.NoError(t, err)
+}
+
+func TestRunConfigSplit_NonExistentConfig(t *testing.T) {
+	old := cfgFile
+	cfgFile = "/nonexistent/.terratidy.yaml"
+	defer func() { cfgFile = old }()
+
+	err := runConfigSplit(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "configuration file not found")
+	assert.Contains(t, err.Error(), "terratidy init")
 }
 
 func TestRunConfigMerge(t *testing.T) {

--- a/docs/site/docs/development/architecture.md
+++ b/docs/site/docs/development/architecture.md
@@ -263,11 +263,9 @@ type Formatter interface {
 - `SARIFFormatter` - GitHub-compatible SARIF
 - `JUnitFormatter` - JUnit XML for CI systems
 - `MarkdownFormatter` - Markdown tables
-- `HTMLFormatter` - HTML report
+- `HTMLFormatter` - Interactive HTML reports
 - `TableFormatter` - Tabular text output
 - `GitHubActionsFormatter` - GitHub Actions annotations
-- `HTMLFormatter` - Interactive HTML reports
-- `JUnitFormatter` - CI-compatible JUnit XML
 
 ## LSP Server
 

--- a/docs/site/docs/integrations/vscode.md
+++ b/docs/site/docs/integrations/vscode.md
@@ -142,7 +142,7 @@ Default shortcuts:
 
 | Shortcut | Command |
 |----------|---------|
-| `Ctrl+Shift+F` / `Cmd+Shift+F` | Format Document |
+| `Shift+Alt+F` / `Shift+Option+F` | Format Document |
 | `Ctrl+.` / `Cmd+.` | Quick Fix |
 
 Customize in Keyboard Shortcuts (`Ctrl+K Ctrl+S`):
@@ -203,7 +203,7 @@ Run checks manually when needed.
 
 ### Engine Selection for Diagnostics
 
-Document formatting (`Format Document` command, `Ctrl+Shift+F`) works
+Document formatting (`Format Document` command, `Shift+Alt+F`) works
 regardless of engine settings. For real-time diagnostics (squiggly
 underlines), the `engines.style` and `engines.lint` toggles control
 which engines run. Disabling an engine prevents its diagnostics from

--- a/docs/site/docs/user-guide/troubleshooting.md
+++ b/docs/site/docs/user-guide/troubleshooting.md
@@ -7,10 +7,10 @@ Common issues and how to resolve them.
 ### Config file not found
 
 ```text
-Error: configuration file not found: .terratidy.yaml
+Error: configuration file not found: .terratidy.yaml (run 'terratidy init' to create one)
 ```
 
-TerraTidy looks for `.terratidy.yaml` in the current directory. Create one with `terratidy init`
+TerraTidy looks for `.terratidy.yaml` in the current directory. Run `terratidy init` to create one,
 or specify a path with `--config`.
 
 ### Invalid config syntax
@@ -117,7 +117,7 @@ Check that TerraTidy is in your PATH and the configuration file is valid.
 ### TFLint not found
 
 ```text
-Warning: TFLint not found in PATH
+Error: tflint not found in PATH (install: brew install tflint, or see https://github.com/terraform-linters/tflint#installation)
 ```
 
 The lint engine falls back to built-in rules when TFLint is not installed. To use TFLint:

--- a/internal/engines/lint/lint.go
+++ b/internal/engines/lint/lint.go
@@ -1126,7 +1126,7 @@ func (e *Engine) validateTFLintPath() error {
 	if e.config.TFLintPath == "" {
 		_, err := exec.LookPath(path)
 		if err != nil {
-			return fmt.Errorf("tflint not found in PATH")
+			return fmt.Errorf("tflint not found in PATH (install: brew install tflint, or see https://github.com/terraform-linters/tflint#installation)")
 		}
 		return nil
 	}

--- a/internal/plugins/plugin.go
+++ b/internal/plugins/plugin.go
@@ -220,7 +220,7 @@ func (m *Manager) loadFromDirectory(dir string) error {
 	if strings.HasPrefix(dir, "~") {
 		home, err := os.UserHomeDir()
 		if err != nil {
-			return err
+			return fmt.Errorf("expanding ~ in plugin directory: %w", err)
 		}
 		dir = filepath.Join(home, dir[1:])
 	}
@@ -231,7 +231,7 @@ func (m *Manager) loadFromDirectory(dir string) error {
 		return nil // Directory doesn't exist, skip
 	}
 	if err != nil {
-		return err
+		return fmt.Errorf("checking plugin directory %s: %w", relativePath(dir), err)
 	}
 	if !info.IsDir() {
 		return fmt.Errorf("%s is not a directory", relativePath(dir))
@@ -256,7 +256,7 @@ func (m *Manager) loadFromDirectory(dir string) error {
 	// Find plugin files
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return err
+		return fmt.Errorf("reading plugin directory %s: %w", relativePath(dir), err)
 	}
 
 	for _, entry := range entries {
@@ -359,7 +359,7 @@ func (m *Manager) loadRulePlugin(p *plugin.Plugin, metadata *PluginMetadata) err
 
 	newFunc, ok := sym.(func() RulePlugin)
 	if !ok {
-		return fmt.Errorf("new function has wrong signature")
+		return fmt.Errorf("plugin %s (%s): New function has wrong signature, expected func() RulePlugin", metadata.Name, relativePath(metadata.Path))
 	}
 
 	rulePlugin := newFunc()
@@ -389,7 +389,7 @@ func (m *Manager) loadEnginePlugin(p *plugin.Plugin, metadata *PluginMetadata) e
 
 	newFunc, ok := sym.(func() EnginePlugin)
 	if !ok {
-		return fmt.Errorf("new function has wrong signature")
+		return fmt.Errorf("plugin %s (%s): New function has wrong signature, expected func() EnginePlugin", metadata.Name, relativePath(metadata.Path))
 	}
 
 	engine := newFunc()
@@ -415,7 +415,7 @@ func (m *Manager) loadFormatterPlugin(p *plugin.Plugin, metadata *PluginMetadata
 
 	newFunc, ok := sym.(func() FormatterPlugin)
 	if !ok {
-		return fmt.Errorf("new function has wrong signature")
+		return fmt.Errorf("plugin %s (%s): New function has wrong signature, expected func() FormatterPlugin", metadata.Name, relativePath(metadata.Path))
 	}
 
 	formatter := newFunc()

--- a/internal/plugins/plugin_test.go
+++ b/internal/plugins/plugin_test.go
@@ -388,6 +388,17 @@ func TestManager_loadGoPlugin_InvalidFile(t *testing.T) {
 // requires building real .so files with proper symbols, which is better suited for
 // integration tests. The functions are structured to return clear errors for missing
 // symbols and incorrect types, which are tested via the error paths above.
+//
+// Paths that cannot be covered in unit tests:
+//   - loadRulePlugin/loadEnginePlugin/loadFormatterPlugin wrong-signature branches:
+//     require a real compiled .so with a New symbol of the wrong type.
+//   - loadFromDirectory os.UserHomeDir() failure (line ~223): UserHomeDir reads $HOME
+//     on Unix; unsetting it may still succeed via /etc/passwd on some systems.
+//   - loadFromDirectory os.Stat() non-ENOENT error (line ~234): requires a path that
+//     Stat fails on for reasons other than not-exist, which is not reliably triggerable
+//     without mocks.
+//   - os.ReadDir() error (line ~259) is covered by TestManager_LoadFromDirectory_PermissionIssues
+//     on non-Windows via the chmod 0o000 technique.
 
 func TestLoadManifest(t *testing.T) {
 	t.Run("valid manifest", func(t *testing.T) {


### PR DESCRIPTION
## What and why

Improve error message quality and fix CI deprecations across the codebase.

**Error message improvements:**
- Add context to plugin loader errors (include path and expected signature)
- Add actionable hints: config not found suggests `terratidy init`, TFLint not found shows install instructions
- Fix double-print in `config validate` (was printing error then returning it to Cobra)

**CI/CD fixes:**
- Update GoReleaser `archives.format` to non-deprecated `formats:` array syntax
- Fix osv-scanner v2 command syntax (`scan` subcommand, `--output-file` flag)

**Documentation fixes:**
- Fix keyboard shortcut in VSCode docs (`Ctrl+Shift+F` → `Shift+Alt+F`)
- Remove duplicate formatter entries in architecture.md
- Update troubleshooting.md error example to match new hint

**Why:** Better error messages reduce user friction. CI deprecations will eventually break builds.

## How to test

```bash
mise run check  # All tests pass
goreleaser check  # No deprecation errors (only "phased out" warnings)
```

## Notes for reviewers

- GoReleaser `dockers` and `brews` migrations deferred (complex, not urgent)
- OSV-Scanner change needs CI run to verify SARIF output

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.ai/code)
