### PR TITLE
fix(style): preserve comments during attribute reordering

### DIFF
--- a/docs/site/docs/rules/style-rules.md
+++ b/docs/site/docs/rules/style-rules.md
@@ -1047,12 +1047,12 @@ resource "aws_instance" "web" {
 
 ## Multi-Pass Fixing
 
-When running with `--fix`, the style engine applies fixes in up to **3 passes**.
+When running with `--fix`, the style engine applies fixes in up to **10 passes**.
 Some rules interact with each other (e.g., reordering attributes may create new spacing issues),
 so the engine re-runs all rules after applying fixes to catch any new violations introduced by the first pass.
 
 ```bash
-# Fix mode applies up to 3 passes automatically
+# Fix mode applies up to 10 passes automatically
 terratidy style --fix
 
 # Show what would change without modifying files
@@ -1067,6 +1067,29 @@ Each pass:
 4. If any fixes were applied, continues to the next pass
 
 The engine stops early if no fixes are applied in a pass, so most files only need 1-2 passes.
+
+### Comment Preservation
+
+Attribute ordering rules (like `for-each-count-first`, `tags-at-end`, `depends-on-order`) preserve leading
+comments when reordering attributes. Comments that appear on lines immediately before an attribute stay
+attached to that attribute after fixing:
+
+```hcl
+# Before fix
+resource "aws_instance" "web" {
+  ami = "ami-12345"
+  # This comment describes the instance type
+  instance_type = "t3.micro"
+  for_each = var.instances
+}
+
+# After fix (comment stays with instance_type)
+resource "aws_instance" "web" {
+  for_each = var.instances
+  ami = "ami-12345"
+  # This comment describes the instance type
+  instance_type = "t3.micro"
+}
 
 ## Configuration
 

--- a/internal/engines/style/rules/helpers.go
+++ b/internal/engines/style/rules/helpers.go
@@ -98,6 +98,89 @@ func getExprTokensWithTrailingComment(attr *hclwrite.Attribute) hclwrite.Tokens 
 	return exprTokens
 }
 
+// AttrRegion represents an attribute with its leading comments.
+type AttrRegion struct {
+	Name           string
+	LeadingComment string   // Comments on lines before the attribute
+	Lines          []string // The attribute line(s) including trailing comment
+	StartLine      int      // 1-indexed line number where region starts
+	EndLine        int      // 1-indexed line number where region ends
+}
+
+// ExtractAttrRegions extracts attribute regions (including leading comments) from content.
+// syntaxBody provides accurate line numbers for attributes.
+func ExtractAttrRegions(content []byte, syntaxBody *hclsyntax.Body) map[string]*AttrRegion {
+	lines := SplitLines(content)
+	regions := make(map[string]*AttrRegion)
+
+	// Get attributes sorted by line number
+	type attrPos struct {
+		name      string
+		startLine int
+		endLine   int
+	}
+	var attrs []attrPos
+	for name, attr := range syntaxBody.Attributes {
+		attrs = append(attrs, attrPos{
+			name:      name,
+			startLine: attr.Range().Start.Line,
+			endLine:   attr.Range().End.Line,
+		})
+	}
+	sort.Slice(attrs, func(i, j int) bool {
+		return attrs[i].startLine < attrs[j].startLine
+	})
+
+	for i, attr := range attrs {
+		region := &AttrRegion{
+			Name:      attr.name,
+			StartLine: attr.startLine,
+			EndLine:   attr.endLine,
+		}
+
+		// Find leading comments by scanning backwards from the attribute
+		// Stop at the previous attribute's end line or block start
+		searchStart := 1
+		if i > 0 {
+			searchStart = attrs[i-1].endLine + 1
+		}
+
+		// Collect leading comment lines
+		var leadingCommentLines []string
+		for lineNum := attr.startLine - 1; lineNum >= searchStart; lineNum-- {
+			if lineNum-1 >= len(lines) {
+				continue
+			}
+			line := lines[lineNum-1]
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" {
+				// Skip blank lines but stop collecting comments
+				continue
+			}
+			if strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "//") {
+				leadingCommentLines = append([]string{line}, leadingCommentLines...)
+			} else {
+				// Hit non-comment content, stop
+				break
+			}
+		}
+		if len(leadingCommentLines) > 0 {
+			region.LeadingComment = strings.Join(leadingCommentLines, "\n") + "\n"
+			// Adjust StartLine to include comments
+			region.StartLine = attr.startLine - len(leadingCommentLines)
+		}
+
+		// Collect attribute lines
+		for lineNum := attr.startLine; lineNum <= attr.endLine && lineNum-1 < len(lines); lineNum++ {
+			region.Lines = append(region.Lines, lines[lineNum-1])
+		}
+
+		regions[attr.name] = region
+	}
+
+	return regions
+}
+
 // ReorderBlockAttrs reorders attributes in a block according to the specified order.
 // firstAttrs are placed at the start, lastAttrs at the end, others maintain relative order.
 // orderedNames should be the original order of attributes (from hclsyntax parsing).
@@ -174,6 +257,115 @@ func ReorderBlockAttrs(body *hclwrite.Body, orderedNames, firstAttrs, lastAttrs 
 	for _, name := range last {
 		body.SetAttributeRaw(name, attrTokens[name])
 	}
+}
+
+// ReorderBlockAttrsPreservingComments reorders attributes while preserving leading comments.
+// This is a line-based approach that works with raw content.
+// Returns the modified content.
+func ReorderBlockAttrsPreservingComments(
+	content []byte,
+	syntaxBody *hclsyntax.Body,
+	blockStartLine, blockEndLine int,
+	orderedNames, firstAttrs, lastAttrs []string,
+) []byte {
+	if len(orderedNames) == 0 {
+		return content
+	}
+
+	// Extract attribute regions with leading comments
+	regions := ExtractAttrRegions(content, syntaxBody)
+
+	// Build sets for quick lookup
+	firstSet := make(map[string]bool)
+	for _, name := range firstAttrs {
+		firstSet[name] = true
+	}
+	lastSet := make(map[string]bool)
+	for _, name := range lastAttrs {
+		lastSet[name] = true
+	}
+
+	// Categorize attribute names
+	var first, middle, last []string
+	for _, name := range orderedNames {
+		if _, exists := regions[name]; !exists {
+			continue
+		}
+		if firstSet[name] {
+			first = append(first, name)
+		} else if lastSet[name] {
+			last = append(last, name)
+		} else {
+			middle = append(middle, name)
+		}
+	}
+
+	// Sort first and last attributes by priority order
+	sortByPriority := func(names []string, priority []string) {
+		prioMap := make(map[string]int)
+		for i, name := range priority {
+			prioMap[name] = i
+		}
+		sort.SliceStable(names, func(i, j int) bool {
+			pi, oki := prioMap[names[i]]
+			pj, okj := prioMap[names[j]]
+			if oki && okj {
+				return pi < pj
+			}
+			if oki {
+				return true
+			}
+			return !okj
+		})
+	}
+
+	sortByPriority(first, firstAttrs)
+	sortByPriority(last, lastAttrs)
+
+	// Build the new block content in order
+	lines := SplitLines(content)
+	var newBlockContent []string
+
+	// Get block opening line
+	if blockStartLine-1 < len(lines) {
+		newBlockContent = append(newBlockContent, lines[blockStartLine-1])
+	}
+
+	// Add attributes in new order
+	reorderedNames := append(append(first, middle...), last...)
+	for _, name := range reorderedNames {
+		region := regions[name]
+		if region == nil {
+			continue
+		}
+		// Add leading comment if present
+		if region.LeadingComment != "" {
+			commentLines := strings.Split(strings.TrimSuffix(region.LeadingComment, "\n"), "\n")
+			newBlockContent = append(newBlockContent, commentLines...)
+		}
+		// Add attribute lines
+		newBlockContent = append(newBlockContent, region.Lines...)
+	}
+
+	// Get block closing line
+	if blockEndLine-1 < len(lines) {
+		newBlockContent = append(newBlockContent, lines[blockEndLine-1])
+	}
+
+	// Rebuild full content
+	var result []string
+	// Lines before block
+	for i := 0; i < blockStartLine-1 && i < len(lines); i++ {
+		result = append(result, lines[i])
+	}
+	// New block content
+	result = append(result, newBlockContent...)
+	// Lines after block
+	for i := blockEndLine; i < len(lines); i++ {
+		result = append(result, lines[i])
+	}
+
+	return []byte(strings.Join(result, "\n") + "\n")
 }
 
 // FormatAndCleanBlankLines applies hclwrite.Format and removes leading/trailing blank lines inside blocks.

--- a/internal/engines/style/rules/helpers_test.go
+++ b/internal/engines/style/rules/helpers_test.go
@@ -108,33 +108,32 @@ func TestReorderBlockAttrs(t *testing.T) {
 			result := string(writeFile.Bytes())
 
 			// Verify checkFirst attribute appears before others
+			// Use "\n  " prefix to match line start (immune to hclwrite alignment padding)
 			if tt.checkFirst != "" {
-				firstIdx := strings.Index(result, tt.checkFirst+" =")
+				firstIdx := strings.Index(result, "\n  "+tt.checkFirst)
 				require.NotEqual(t, -1, firstIdx, "%s should be in result", tt.checkFirst)
 
 				for _, name := range orderedNames {
 					if name != tt.checkFirst {
-						otherIdx := strings.Index(result, name+" =")
-						if otherIdx != -1 {
-							assert.Less(t, firstIdx, otherIdx,
-								"%s should appear before %s", tt.checkFirst, name)
-						}
+						otherIdx := strings.Index(result, "\n  "+name)
+						require.NotEqual(t, -1, otherIdx, "%s should be in result", name)
+						assert.Less(t, firstIdx, otherIdx,
+							"%s should appear before %s", tt.checkFirst, name)
 					}
 				}
 			}
 
 			// Verify checkLast attribute appears after others
 			if tt.checkLast != "" {
-				lastIdx := strings.LastIndex(result, tt.checkLast+" =")
+				lastIdx := strings.LastIndex(result, "\n  "+tt.checkLast)
 				require.NotEqual(t, -1, lastIdx, "%s should be in result", tt.checkLast)
 
 				for _, name := range orderedNames {
 					if name != tt.checkLast {
-						otherIdx := strings.LastIndex(result, name+" =")
-						if otherIdx != -1 {
-							assert.Greater(t, lastIdx, otherIdx,
-								"%s should appear after %s", tt.checkLast, name)
-						}
+						otherIdx := strings.LastIndex(result, "\n  "+name)
+						require.NotEqual(t, -1, otherIdx, "%s should be in result", name)
+						assert.Greater(t, lastIdx, otherIdx,
+							"%s should appear after %s", tt.checkLast, name)
 					}
 				}
 			}
@@ -1096,35 +1095,34 @@ func TestReorderBlockAttrsPreservingComments(t *testing.T) {
 			assert.NotEmpty(t, resultStr)
 
 			// Verify positional ordering if checkFirst is specified
+			// Use "\n  " prefix to match line start (immune to alignment padding, avoids comment matches)
 			if tt.checkFirst != "" {
-				firstIdx := strings.Index(resultStr, tt.checkFirst+" =")
-				require.NotEqual(t, -1, firstIdx, "%s assignment should be in result", tt.checkFirst)
+				firstIdx := strings.Index(resultStr, "\n  "+tt.checkFirst)
+				require.NotEqual(t, -1, firstIdx, "%s should be in result", tt.checkFirst)
 
 				// Check it comes before other attributes
 				for _, name := range orderedNames {
 					if name != tt.checkFirst {
-						otherIdx := strings.Index(resultStr, name+" =")
-						if otherIdx != -1 {
-							assert.Less(t, firstIdx, otherIdx,
-								"%s should appear before %s", tt.checkFirst, name)
-						}
+						otherIdx := strings.Index(resultStr, "\n  "+name)
+						require.NotEqual(t, -1, otherIdx, "%s should be in result", name)
+						assert.Less(t, firstIdx, otherIdx,
+							"%s should appear before %s", tt.checkFirst, name)
 					}
 				}
 			}
 
 			// Verify positional ordering if checkLast is specified
 			if tt.checkLast != "" {
-				lastIdx := strings.LastIndex(resultStr, tt.checkLast+" =")
-				require.NotEqual(t, -1, lastIdx, "%s assignment should be in result", tt.checkLast)
+				lastIdx := strings.LastIndex(resultStr, "\n  "+tt.checkLast)
+				require.NotEqual(t, -1, lastIdx, "%s should be in result", tt.checkLast)
 
 				// Check it comes after other attributes
 				for _, name := range orderedNames {
 					if name != tt.checkLast {
-						otherIdx := strings.LastIndex(resultStr, name+" =")
-						if otherIdx != -1 {
-							assert.Greater(t, lastIdx, otherIdx,
-								"%s should appear after %s", tt.checkLast, name)
-						}
+						otherIdx := strings.LastIndex(resultStr, "\n  "+name)
+						require.NotEqual(t, -1, otherIdx, "%s should be in result", name)
+						assert.Greater(t, lastIdx, otherIdx,
+							"%s should appear after %s", tt.checkLast, name)
 					}
 				}
 			}

--- a/internal/engines/style/rules/helpers_test.go
+++ b/internal/engines/style/rules/helpers_test.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
@@ -903,14 +904,15 @@ func TestReorderBlockAttrsPreservesComments(t *testing.T) {
 
 func TestExtractAttrRegions(t *testing.T) {
 	tests := []struct {
-		name          string
-		content       string
-		expectRegions []string
-		expectComment map[string]string // attr name -> expected comment content
+		name           string
+		content        string
+		expectRegions  []string
+		expectComment  map[string]string // attr name -> expected comment content
+		expectMinLines map[string]int    // attr name -> minimum number of lines
 	}{
 		{
 			name: "attributes with leading comments",
-			//nolint:dupword // HCL content with repeated attribute names is expected
+			//nolint:dupword // HCL content intentionally contains repeated identifiers
 			content: `resource "test" "example" {
   # This is a comment for ami
   ami = "ami-123"
@@ -933,17 +935,18 @@ func TestExtractAttrRegions(t *testing.T) {
 			expectComment: map[string]string{},
 		},
 		{
-			name: "multi-line attribute",
+			name: "multi-line attribute spans all lines",
 			content: `resource "test" "example" {
   tags = {
     Name = "test"
     Env  = "prod"
   }
 }`,
-			expectRegions: []string{"tags"},
+			expectRegions:  []string{"tags"},
+			expectMinLines: map[string]int{"tags": 4},
 		},
 		{
-			name: "empty block",
+			name: "empty block returns no regions",
 			content: `resource "test" "example" {
 }`,
 			expectRegions: []string{},
@@ -956,21 +959,33 @@ func TestExtractAttrRegions(t *testing.T) {
 			require.False(t, diags.HasErrors())
 
 			body := file.Body.(*hclsyntax.Body)
-			if len(body.Blocks) > 0 {
-				regions := ExtractAttrRegions([]byte(tt.content), body.Blocks[0].Body)
+			require.NotEmpty(t, body.Blocks, "test content should have at least one block")
 
-				// Check expected regions exist
-				for _, name := range tt.expectRegions {
-					assert.Contains(t, regions, name, "region %s should exist", name)
-				}
+			regions := ExtractAttrRegions([]byte(tt.content), body.Blocks[0].Body)
 
-				// Check comments if specified
-				for name, expectedComment := range tt.expectComment {
-					if region, ok := regions[name]; ok {
-						assert.Contains(t, region.LeadingComment, expectedComment,
-							"attribute %s should have comment containing: %s", name, expectedComment)
-					}
-				}
+			// Verify exact count of regions (catches spurious extra regions)
+			assert.Len(t, regions, len(tt.expectRegions),
+				"expected %d regions, got %d", len(tt.expectRegions), len(regions))
+
+			// Check expected regions exist
+			for _, name := range tt.expectRegions {
+				assert.Contains(t, regions, name, "region %s should exist", name)
+			}
+
+			// Check comments if specified
+			for name, expectedComment := range tt.expectComment {
+				region, ok := regions[name]
+				require.True(t, ok, "region %s should exist for comment check", name)
+				assert.Contains(t, region.LeadingComment, expectedComment,
+					"attribute %s should have comment containing: %s", name, expectedComment)
+			}
+
+			// Check multi-line attributes span expected lines
+			for name, minLines := range tt.expectMinLines {
+				region, ok := regions[name]
+				require.True(t, ok, "region %s should exist for line count check", name)
+				assert.GreaterOrEqual(t, len(region.Lines), minLines,
+					"attribute %s should span at least %d lines, got %d", name, minLines, len(region.Lines))
 			}
 		})
 	}
@@ -982,12 +997,13 @@ func TestReorderBlockAttrsPreservingComments(t *testing.T) {
 		content      string
 		firstAttrs   []string
 		lastAttrs    []string
-		expectOrder  []string // expected order of attributes in result
-		expectInline []string // strings that must appear in result (comments, etc.)
+		checkFirst   string // attribute that should appear first
+		checkLast    string // attribute that should appear last
+		expectInline []string
 	}{
 		{
-			name: "reorder with leading comments preserved",
-			//nolint:dupword // HCL content with repeated attribute names is expected
+			name: "for_each moves to first with comment preserved",
+			//nolint:dupword // HCL content intentionally contains repeated identifiers
 			content: `resource "test" "example" {
   # Comment for ami
   ami = "ami-123"
@@ -999,10 +1015,11 @@ func TestReorderBlockAttrsPreservingComments(t *testing.T) {
 }`,
 			firstAttrs:   []string{"for_each"},
 			lastAttrs:    nil,
+			checkFirst:   "for_each",
 			expectInline: []string{"# Comment for for_each", "# Comment for ami"},
 		},
 		{
-			name: "move tags to end preserving comment",
+			name: "tags moves to end with comment preserved",
 			content: `resource "test" "example" {
   # Tags comment
   tags = { Name = "test" }
@@ -1010,16 +1027,17 @@ func TestReorderBlockAttrsPreservingComments(t *testing.T) {
 }`,
 			firstAttrs:   nil,
 			lastAttrs:    []string{"tags"},
+			checkLast:    "tags",
 			expectInline: []string{"# Tags comment"},
 		},
 		{
-			name: "empty orderedNames returns unchanged",
+			name: "firstAttrs targeting absent attribute leaves block unchanged",
 			content: `resource "test" "example" {
   ami = "ami-123"
 }`,
 			firstAttrs:   []string{"for_each"},
 			lastAttrs:    nil,
-			expectInline: []string{"ami"},
+			expectInline: []string{`ami = "ami-123"`},
 		},
 	}
 
@@ -1029,34 +1047,68 @@ func TestReorderBlockAttrsPreservingComments(t *testing.T) {
 			require.False(t, diags.HasErrors())
 
 			body := file.Body.(*hclsyntax.Body)
-			if len(body.Blocks) > 0 {
-				block := body.Blocks[0]
-				orderedNames := GetOrderedAttrNames(block.Body)
+			require.NotEmpty(t, body.Blocks, "test content should have at least one block")
 
-				result := ReorderBlockAttrsPreservingComments(
-					[]byte(tt.content),
-					block.Body,
-					block.Range().Start.Line,
-					block.Range().End.Line,
-					orderedNames,
-					tt.firstAttrs,
-					tt.lastAttrs,
-				)
+			block := body.Blocks[0]
+			orderedNames := GetOrderedAttrNames(block.Body)
 
-				resultStr := string(result)
-				assert.NotEmpty(t, resultStr)
+			result := ReorderBlockAttrsPreservingComments(
+				[]byte(tt.content),
+				block.Body,
+				block.Range().Start.Line,
+				block.Range().End.Line,
+				orderedNames,
+				tt.firstAttrs,
+				tt.lastAttrs,
+			)
 
-				// Check expected content is preserved
-				for _, expected := range tt.expectInline {
-					assert.Contains(t, resultStr, expected, "should contain: %s", expected)
+			resultStr := string(result)
+			assert.NotEmpty(t, resultStr)
+
+			// Verify positional ordering if checkFirst is specified
+			if tt.checkFirst != "" {
+				firstIdx := strings.Index(resultStr, tt.checkFirst)
+				require.NotEqual(t, -1, firstIdx, "%s should be in result", tt.checkFirst)
+
+				// Check it comes before other attributes
+				for _, name := range orderedNames {
+					if name != tt.checkFirst {
+						otherIdx := strings.Index(resultStr, name+" =")
+						if otherIdx != -1 {
+							assert.Less(t, firstIdx, otherIdx,
+								"%s should appear before %s", tt.checkFirst, name)
+						}
+					}
 				}
+			}
+
+			// Verify positional ordering if checkLast is specified
+			if tt.checkLast != "" {
+				lastIdx := strings.Index(resultStr, tt.checkLast)
+				require.NotEqual(t, -1, lastIdx, "%s should be in result", tt.checkLast)
+
+				// Check it comes after other attributes
+				for _, name := range orderedNames {
+					if name != tt.checkLast {
+						otherIdx := strings.Index(resultStr, name+" =")
+						if otherIdx != -1 {
+							assert.Greater(t, lastIdx, otherIdx,
+								"%s should appear after %s", tt.checkLast, name)
+						}
+					}
+				}
+			}
+
+			// Check expected content is preserved
+			for _, expected := range tt.expectInline {
+				assert.Contains(t, resultStr, expected, "should contain: %s", expected)
 			}
 		})
 	}
 }
 
 func TestReorderBlockAttrs_EdgeCases(t *testing.T) {
-	t.Run("empty orderedNames does nothing", func(t *testing.T) {
+	t.Run("empty orderedNames leaves block unchanged", func(t *testing.T) {
 		content := `resource "test" "example" {
   ami = "ami-123"
 }`
@@ -1066,12 +1118,12 @@ func TestReorderBlockAttrs_EdgeCases(t *testing.T) {
 		block := writeFile.Body().Blocks()[0]
 		ReorderBlockAttrs(block.Body(), []string{}, []string{"for_each"}, nil)
 
-		// Should be unchanged
+		// Should be structurally unchanged
 		result := string(writeFile.Bytes())
-		assert.Contains(t, result, "ami")
+		assert.Contains(t, result, `ami = "ami-123"`, "original attribute assignment should be preserved")
 	})
 
-	t.Run("attributes not in body are skipped", func(t *testing.T) {
+	t.Run("nonexistent firstAttrs are skipped without panic", func(t *testing.T) {
 		content := `resource "test" "example" {
   ami = "ami-123"
 }`
@@ -1090,12 +1142,12 @@ func TestReorderBlockAttrs_EdgeCases(t *testing.T) {
 		writeBlock := writeFile.Body().Blocks()[0]
 		ReorderBlockAttrs(writeBlock.Body(), orderedNames, []string{"nonexistent_attr"}, nil)
 
-		// Should not panic and ami should still be there
+		// Should not panic and original content preserved
 		result := string(writeFile.Bytes())
-		assert.Contains(t, result, "ami")
+		assert.Contains(t, result, `ami = "ami-123"`, "original attribute should be preserved")
 	})
 
-	t.Run("sortByPriority with items not in priority list", func(t *testing.T) {
+	t.Run("for_each moves first even when other attrs not in priority list", func(t *testing.T) {
 		content := `resource "test" "example" {
   z_attr = "z"
   a_attr = "a"
@@ -1111,10 +1163,53 @@ func TestReorderBlockAttrs_EdgeCases(t *testing.T) {
 		orderedNames := GetOrderedAttrNames(syntaxBody.Blocks[0].Body)
 
 		writeBlock := writeFile.Body().Blocks()[0]
-		// for_each should come first even though other attrs aren't in the priority list
 		ReorderBlockAttrs(writeBlock.Body(), orderedNames, []string{"for_each"}, nil)
 
 		result := string(writeFile.Bytes())
-		assert.NotEmpty(t, result)
+
+		// Verify for_each appears before other attributes
+		forEachIdx := strings.Index(result, "for_each")
+		zAttrIdx := strings.Index(result, "z_attr")
+		aAttrIdx := strings.Index(result, "a_attr")
+
+		require.NotEqual(t, -1, forEachIdx, "for_each should be in result")
+		require.NotEqual(t, -1, zAttrIdx, "z_attr should be in result")
+		require.NotEqual(t, -1, aAttrIdx, "a_attr should be in result")
+
+		assert.Less(t, forEachIdx, zAttrIdx, "for_each should appear before z_attr")
+		assert.Less(t, forEachIdx, aAttrIdx, "for_each should appear before a_attr")
+	})
+
+	t.Run("lastAttrs moves attribute to end", func(t *testing.T) {
+		content := `resource "test" "example" {
+  tags = { Name = "test" }
+  ami  = "ami-123"
+  name = "example"
+}`
+		syntaxFile, diags := hclsyntax.ParseConfig([]byte(content), "test.tf", hcl.InitialPos)
+		require.False(t, diags.HasErrors())
+
+		writeFile, diags := hclwrite.ParseConfig([]byte(content), "test.tf", hcl.InitialPos)
+		require.False(t, diags.HasErrors())
+
+		syntaxBody := syntaxFile.Body.(*hclsyntax.Body)
+		orderedNames := GetOrderedAttrNames(syntaxBody.Blocks[0].Body)
+
+		writeBlock := writeFile.Body().Blocks()[0]
+		ReorderBlockAttrs(writeBlock.Body(), orderedNames, nil, []string{"tags"})
+
+		result := string(writeFile.Bytes())
+
+		// Verify tags appears after other attributes
+		tagsIdx := strings.Index(result, "tags")
+		amiIdx := strings.Index(result, "ami")
+		nameIdx := strings.Index(result, "name")
+
+		require.NotEqual(t, -1, tagsIdx, "tags should be in result")
+		require.NotEqual(t, -1, amiIdx, "ami should be in result")
+		require.NotEqual(t, -1, nameIdx, "name should be in result")
+
+		assert.Greater(t, tagsIdx, amiIdx, "tags should appear after ami")
+		assert.Greater(t, tagsIdx, nameIdx, "tags should appear after name")
 	})
 }

--- a/internal/engines/style/rules/helpers_test.go
+++ b/internal/engines/style/rules/helpers_test.go
@@ -98,15 +98,45 @@ func TestReorderBlockAttrs(t *testing.T) {
 			require.False(t, diags.HasErrors())
 
 			syntaxBody := syntaxFile.Body.(*hclsyntax.Body)
-			if len(syntaxBody.Blocks) > 0 {
-				orderedNames := GetOrderedAttrNames(syntaxBody.Blocks[0].Body)
+			require.NotEmpty(t, syntaxBody.Blocks, "test content should have at least one block")
 
-				writeBlock := writeFile.Body().Blocks()[0]
-				ReorderBlockAttrs(writeBlock.Body(), orderedNames, tt.firstAttrs, tt.lastAttrs)
+			orderedNames := GetOrderedAttrNames(syntaxBody.Blocks[0].Body)
 
-				// Get the result
-				result := string(writeFile.Bytes())
-				assert.NotEmpty(t, result)
+			writeBlock := writeFile.Body().Blocks()[0]
+			ReorderBlockAttrs(writeBlock.Body(), orderedNames, tt.firstAttrs, tt.lastAttrs)
+
+			result := string(writeFile.Bytes())
+
+			// Verify checkFirst attribute appears before others
+			if tt.checkFirst != "" {
+				firstIdx := strings.Index(result, tt.checkFirst+" =")
+				require.NotEqual(t, -1, firstIdx, "%s should be in result", tt.checkFirst)
+
+				for _, name := range orderedNames {
+					if name != tt.checkFirst {
+						otherIdx := strings.Index(result, name+" =")
+						if otherIdx != -1 {
+							assert.Less(t, firstIdx, otherIdx,
+								"%s should appear before %s", tt.checkFirst, name)
+						}
+					}
+				}
+			}
+
+			// Verify checkLast attribute appears after others
+			if tt.checkLast != "" {
+				lastIdx := strings.LastIndex(result, tt.checkLast+" =")
+				require.NotEqual(t, -1, lastIdx, "%s should be in result", tt.checkLast)
+
+				for _, name := range orderedNames {
+					if name != tt.checkLast {
+						otherIdx := strings.LastIndex(result, name+" =")
+						if otherIdx != -1 {
+							assert.Greater(t, lastIdx, otherIdx,
+								"%s should appear after %s", tt.checkLast, name)
+						}
+					}
+				}
 			}
 		})
 	}
@@ -904,11 +934,11 @@ func TestReorderBlockAttrsPreservesComments(t *testing.T) {
 
 func TestExtractAttrRegions(t *testing.T) {
 	tests := []struct {
-		name           string
-		content        string
-		expectRegions  []string
-		expectComment  map[string]string // attr name -> expected comment content
-		expectMinLines map[string]int    // attr name -> minimum number of lines
+		name            string
+		content         string
+		expectRegions   []string
+		expectComment   map[string]string // attr name -> expected comment content
+		expectLineCount map[string]int    // attr name -> exact number of lines expected
 	}{
 		{
 			name: "attributes with leading comments",
@@ -942,8 +972,8 @@ func TestExtractAttrRegions(t *testing.T) {
     Env  = "prod"
   }
 }`,
-			expectRegions:  []string{"tags"},
-			expectMinLines: map[string]int{"tags": 4},
+			expectRegions:   []string{"tags"},
+			expectLineCount: map[string]int{"tags": 4},
 		},
 		{
 			name: "empty block returns no regions",
@@ -980,12 +1010,12 @@ func TestExtractAttrRegions(t *testing.T) {
 					"attribute %s should have comment containing: %s", name, expectedComment)
 			}
 
-			// Check multi-line attributes span expected lines
-			for name, minLines := range tt.expectMinLines {
+			// Check multi-line attributes span exact expected lines
+			for name, expectedLines := range tt.expectLineCount {
 				region, ok := regions[name]
 				require.True(t, ok, "region %s should exist for line count check", name)
-				assert.GreaterOrEqual(t, len(region.Lines), minLines,
-					"attribute %s should span at least %d lines, got %d", name, minLines, len(region.Lines))
+				assert.Equal(t, expectedLines, len(region.Lines),
+					"attribute %s should span exactly %d lines, got %d", name, expectedLines, len(region.Lines))
 			}
 		})
 	}
@@ -1067,8 +1097,8 @@ func TestReorderBlockAttrsPreservingComments(t *testing.T) {
 
 			// Verify positional ordering if checkFirst is specified
 			if tt.checkFirst != "" {
-				firstIdx := strings.Index(resultStr, tt.checkFirst)
-				require.NotEqual(t, -1, firstIdx, "%s should be in result", tt.checkFirst)
+				firstIdx := strings.Index(resultStr, tt.checkFirst+" =")
+				require.NotEqual(t, -1, firstIdx, "%s assignment should be in result", tt.checkFirst)
 
 				// Check it comes before other attributes
 				for _, name := range orderedNames {
@@ -1084,13 +1114,13 @@ func TestReorderBlockAttrsPreservingComments(t *testing.T) {
 
 			// Verify positional ordering if checkLast is specified
 			if tt.checkLast != "" {
-				lastIdx := strings.Index(resultStr, tt.checkLast)
-				require.NotEqual(t, -1, lastIdx, "%s should be in result", tt.checkLast)
+				lastIdx := strings.LastIndex(resultStr, tt.checkLast+" =")
+				require.NotEqual(t, -1, lastIdx, "%s assignment should be in result", tt.checkLast)
 
 				// Check it comes after other attributes
 				for _, name := range orderedNames {
 					if name != tt.checkLast {
-						otherIdx := strings.Index(resultStr, name+" =")
+						otherIdx := strings.LastIndex(resultStr, name+" =")
 						if otherIdx != -1 {
 							assert.Greater(t, lastIdx, otherIdx,
 								"%s should appear after %s", tt.checkLast, name)
@@ -1168,9 +1198,10 @@ func TestReorderBlockAttrs_EdgeCases(t *testing.T) {
 		result := string(writeFile.Bytes())
 
 		// Verify for_each appears before other attributes
-		forEachIdx := strings.Index(result, "for_each")
-		zAttrIdx := strings.Index(result, "z_attr")
-		aAttrIdx := strings.Index(result, "a_attr")
+		// Note: hclwrite adds alignment padding, so search for "\n  <attr>" to match line start
+		forEachIdx := strings.Index(result, "\n  for_each")
+		zAttrIdx := strings.Index(result, "\n  z_attr")
+		aAttrIdx := strings.Index(result, "\n  a_attr")
 
 		require.NotEqual(t, -1, forEachIdx, "for_each should be in result")
 		require.NotEqual(t, -1, zAttrIdx, "z_attr should be in result")
@@ -1201,9 +1232,10 @@ func TestReorderBlockAttrs_EdgeCases(t *testing.T) {
 		result := string(writeFile.Bytes())
 
 		// Verify tags appears after other attributes
-		tagsIdx := strings.Index(result, "tags")
-		amiIdx := strings.Index(result, "ami")
-		nameIdx := strings.Index(result, "name")
+		// Note: hclwrite adds alignment padding, so search for "\n  <attr>" to match line start
+		tagsIdx := strings.LastIndex(result, "\n  tags")
+		amiIdx := strings.LastIndex(result, "\n  ami")
+		nameIdx := strings.LastIndex(result, "\n  name")
 
 		require.NotEqual(t, -1, tagsIdx, "tags should be in result")
 		require.NotEqual(t, -1, amiIdx, "ami should be in result")

--- a/internal/engines/style/rules/helpers_test.go
+++ b/internal/engines/style/rules/helpers_test.go
@@ -900,3 +900,221 @@ func TestReorderBlockAttrsPreservesComments(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractAttrRegions(t *testing.T) {
+	tests := []struct {
+		name          string
+		content       string
+		expectRegions []string
+		expectComment map[string]string // attr name -> expected comment content
+	}{
+		{
+			name: "attributes with leading comments",
+			//nolint:dupword // HCL content with repeated attribute names is expected
+			content: `resource "test" "example" {
+  # This is a comment for ami
+  ami = "ami-123"
+
+  # Comment for name
+  name = "test"
+}`,
+			expectRegions: []string{"ami", "name"},
+			expectComment: map[string]string{
+				"ami":  "# This is a comment for ami",
+				"name": "# Comment for name",
+			},
+		},
+		{
+			name: "attribute without comment",
+			content: `resource "test" "example" {
+  ami = "ami-123"
+}`,
+			expectRegions: []string{"ami"},
+			expectComment: map[string]string{},
+		},
+		{
+			name: "multi-line attribute",
+			content: `resource "test" "example" {
+  tags = {
+    Name = "test"
+    Env  = "prod"
+  }
+}`,
+			expectRegions: []string{"tags"},
+		},
+		{
+			name: "empty block",
+			content: `resource "test" "example" {
+}`,
+			expectRegions: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, diags := hclsyntax.ParseConfig([]byte(tt.content), "test.tf", hcl.InitialPos)
+			require.False(t, diags.HasErrors())
+
+			body := file.Body.(*hclsyntax.Body)
+			if len(body.Blocks) > 0 {
+				regions := ExtractAttrRegions([]byte(tt.content), body.Blocks[0].Body)
+
+				// Check expected regions exist
+				for _, name := range tt.expectRegions {
+					assert.Contains(t, regions, name, "region %s should exist", name)
+				}
+
+				// Check comments if specified
+				for name, expectedComment := range tt.expectComment {
+					if region, ok := regions[name]; ok {
+						assert.Contains(t, region.LeadingComment, expectedComment,
+							"attribute %s should have comment containing: %s", name, expectedComment)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestReorderBlockAttrsPreservingComments(t *testing.T) {
+	tests := []struct {
+		name         string
+		content      string
+		firstAttrs   []string
+		lastAttrs    []string
+		expectOrder  []string // expected order of attributes in result
+		expectInline []string // strings that must appear in result (comments, etc.)
+	}{
+		{
+			name: "reorder with leading comments preserved",
+			//nolint:dupword // HCL content with repeated attribute names is expected
+			content: `resource "test" "example" {
+  # Comment for ami
+  ami = "ami-123"
+
+  # Comment for for_each
+  for_each = var.items
+
+  name = "test"
+}`,
+			firstAttrs:   []string{"for_each"},
+			lastAttrs:    nil,
+			expectInline: []string{"# Comment for for_each", "# Comment for ami"},
+		},
+		{
+			name: "move tags to end preserving comment",
+			content: `resource "test" "example" {
+  # Tags comment
+  tags = { Name = "test" }
+  ami  = "ami-123"
+}`,
+			firstAttrs:   nil,
+			lastAttrs:    []string{"tags"},
+			expectInline: []string{"# Tags comment"},
+		},
+		{
+			name: "empty orderedNames returns unchanged",
+			content: `resource "test" "example" {
+  ami = "ami-123"
+}`,
+			firstAttrs:   []string{"for_each"},
+			lastAttrs:    nil,
+			expectInline: []string{"ami"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, diags := hclsyntax.ParseConfig([]byte(tt.content), "test.tf", hcl.InitialPos)
+			require.False(t, diags.HasErrors())
+
+			body := file.Body.(*hclsyntax.Body)
+			if len(body.Blocks) > 0 {
+				block := body.Blocks[0]
+				orderedNames := GetOrderedAttrNames(block.Body)
+
+				result := ReorderBlockAttrsPreservingComments(
+					[]byte(tt.content),
+					block.Body,
+					block.Range().Start.Line,
+					block.Range().End.Line,
+					orderedNames,
+					tt.firstAttrs,
+					tt.lastAttrs,
+				)
+
+				resultStr := string(result)
+				assert.NotEmpty(t, resultStr)
+
+				// Check expected content is preserved
+				for _, expected := range tt.expectInline {
+					assert.Contains(t, resultStr, expected, "should contain: %s", expected)
+				}
+			}
+		})
+	}
+}
+
+func TestReorderBlockAttrs_EdgeCases(t *testing.T) {
+	t.Run("empty orderedNames does nothing", func(t *testing.T) {
+		content := `resource "test" "example" {
+  ami = "ami-123"
+}`
+		writeFile, diags := hclwrite.ParseConfig([]byte(content), "test.tf", hcl.InitialPos)
+		require.False(t, diags.HasErrors())
+
+		block := writeFile.Body().Blocks()[0]
+		ReorderBlockAttrs(block.Body(), []string{}, []string{"for_each"}, nil)
+
+		// Should be unchanged
+		result := string(writeFile.Bytes())
+		assert.Contains(t, result, "ami")
+	})
+
+	t.Run("attributes not in body are skipped", func(t *testing.T) {
+		content := `resource "test" "example" {
+  ami = "ami-123"
+}`
+		syntaxFile, diags := hclsyntax.ParseConfig([]byte(content), "test.tf", hcl.InitialPos)
+		require.False(t, diags.HasErrors())
+
+		writeFile, diags := hclwrite.ParseConfig([]byte(content), "test.tf", hcl.InitialPos)
+		require.False(t, diags.HasErrors())
+
+		syntaxBody := syntaxFile.Body.(*hclsyntax.Body)
+		orderedNames := GetOrderedAttrNames(syntaxBody.Blocks[0].Body)
+
+		// Add a name that doesn't exist in the body
+		orderedNames = append(orderedNames, "nonexistent_attr")
+
+		writeBlock := writeFile.Body().Blocks()[0]
+		ReorderBlockAttrs(writeBlock.Body(), orderedNames, []string{"nonexistent_attr"}, nil)
+
+		// Should not panic and ami should still be there
+		result := string(writeFile.Bytes())
+		assert.Contains(t, result, "ami")
+	})
+
+	t.Run("sortByPriority with items not in priority list", func(t *testing.T) {
+		content := `resource "test" "example" {
+  z_attr = "z"
+  a_attr = "a"
+  for_each = var.items
+}`
+		syntaxFile, diags := hclsyntax.ParseConfig([]byte(content), "test.tf", hcl.InitialPos)
+		require.False(t, diags.HasErrors())
+
+		writeFile, diags := hclwrite.ParseConfig([]byte(content), "test.tf", hcl.InitialPos)
+		require.False(t, diags.HasErrors())
+
+		syntaxBody := syntaxFile.Body.(*hclsyntax.Body)
+		orderedNames := GetOrderedAttrNames(syntaxBody.Blocks[0].Body)
+
+		writeBlock := writeFile.Body().Blocks()[0]
+		// for_each should come first even though other attrs aren't in the priority list
+		ReorderBlockAttrs(writeBlock.Body(), orderedNames, []string{"for_each"}, nil)
+
+		result := string(writeFile.Bytes())
+		assert.NotEmpty(t, result)
+	})
+}

--- a/internal/engines/style/rules/ordering.go
+++ b/internal/engines/style/rules/ordering.go
@@ -106,99 +106,99 @@ func (r *ForEachCountFirstRule) fixBlock(
 		return nil, err
 	}
 
-	syntaxBody, writeFile, err := ParseBothFormats(content, filePath)
-	if err != nil {
-		return nil, err
+	// Parse with hclsyntax to get accurate positions
+	syntaxFile, diags := hclsyntax.ParseConfig(content, filePath, hcl.InitialPos)
+	if diags.HasErrors() {
+		return nil, diags
 	}
-	if syntaxBody == nil {
+	syntaxBody, ok := syntaxFile.Body.(*hclsyntax.Body)
+	if !ok {
 		return content, nil
 	}
 
-	// Find syntax body for this block
-	var targetSyntaxBody *hclsyntax.Body
+	// Find the target block
+	var targetBlock *hclsyntax.Block
 	for _, block := range syntaxBody.Blocks {
 		if block.Type != blockType {
 			continue
 		}
 		if MatchBlockLabels(block.Labels, blockLabels) {
-			targetSyntaxBody = block.Body
+			targetBlock = block
 			break
 		}
 	}
-
-	if targetSyntaxBody == nil {
+	if targetBlock == nil {
 		return content, nil
 	}
 
-	// Find the matching block in hclwrite
-	for _, block := range writeFile.Body().Blocks() {
-		if block.Type() != blockType {
-			continue
-		}
-		if !MatchBlockLabels(block.Labels(), blockLabels) {
-			continue
-		}
-
-		orderedNames := GetOrderedAttrNames(targetSyntaxBody)
-		firstAttrs := []string{"for_each", "count"}
-		ReorderBlockAttrs(block.Body(), orderedNames, firstAttrs, nil)
-		break
+	orderedNames := GetOrderedAttrNames(targetBlock.Body)
+	// For modules, also position source/version after for_each/count
+	firstAttrs := []string{"for_each", "count"}
+	if blockType == "module" {
+		firstAttrs = []string{"for_each", "count", "source", "version"}
 	}
+	lastAttrs := []string{"tags", "labels", "tags_all", "depends_on"}
 
-	return FormatAndCleanBlankLines(writeFile.Bytes()), nil
+	// Use line-based reordering to preserve leading comments
+	result := ReorderBlockAttrsPreservingComments(
+		content,
+		targetBlock.Body,
+		targetBlock.Range().Start.Line,
+		targetBlock.Range().End.Line,
+		orderedNames,
+		firstAttrs,
+		lastAttrs,
+	)
+
+	return FormatAndCleanBlankLines(result), nil
 }
 
 // Fix moves for_each/count to be first attribute in each block.
+// Uses line-based reordering to preserve leading comments.
 func (r *ForEachCountFirstRule) Fix(ctx *sdk.Context, file *hcl.File) ([]byte, error) {
 	content, err := os.ReadFile(ctx.File)
 	if err != nil {
 		return nil, err
 	}
 
-	// Parse with hclsyntax to get attribute ordering
-	syntaxFile, ok := file.Body.(*hclsyntax.Body)
+	hclFile, ok := file.Body.(*hclsyntax.Body)
 	if !ok {
 		return nil, nil
 	}
 
-	// Parse with hclwrite for modifications
-	writeFile, diags := hclwrite.ParseConfig(content, ctx.File, hcl.InitialPos)
-	if diags.HasErrors() {
-		return nil, diags
-	}
-
-	// Build a map of block identifiers to their syntax bodies for ordering
-	syntaxBlocks := make(map[string]*hclsyntax.Body)
-	for _, block := range syntaxFile.Blocks {
-		key := BlockKey(block.Type, block.Labels)
-		syntaxBlocks[key] = block.Body
-	}
-
-	for _, block := range writeFile.Body().Blocks() {
-		if block.Type() != "resource" && block.Type() != "module" && block.Type() != "data" {
+	// Process each block that has for_each or count
+	for _, block := range hclFile.Blocks {
+		if block.Type != "resource" && block.Type != "module" && block.Type != "data" {
 			continue
 		}
 
 		// Check if block has for_each or count
-		hasForEach := block.Body().GetAttribute("for_each") != nil
-		hasCount := block.Body().GetAttribute("count") != nil
+		hasForEach := FindAttribute(block.Body.Attributes, "for_each") != nil
+		hasCount := FindAttribute(block.Body.Attributes, "count") != nil
 		if !hasForEach && !hasCount {
 			continue
 		}
 
-		// Get ordering from syntax body
-		key := BlockKey(block.Type(), block.Labels())
-		syntaxBody, ok := syntaxBlocks[key]
-		if !ok {
-			continue
-		}
-
-		orderedNames := GetOrderedAttrNames(syntaxBody)
+		orderedNames := GetOrderedAttrNames(block.Body)
 		firstAttrs := []string{"for_each", "count"}
-		ReorderBlockAttrs(block.Body(), orderedNames, firstAttrs, nil)
+		if block.Type == "module" {
+			firstAttrs = []string{"for_each", "count", "source", "version"}
+		}
+		lastAttrs := []string{"tags", "labels", "tags_all", "depends_on"}
+
+		// Use line-based reordering to preserve leading comments
+		content = ReorderBlockAttrsPreservingComments(
+			content,
+			block.Body,
+			block.Range().Start.Line,
+			block.Range().End.Line,
+			orderedNames,
+			firstAttrs,
+			lastAttrs,
+		)
 	}
 
-	return FormatAndCleanBlankLines(writeFile.Bytes()), nil
+	return FormatAndCleanBlankLines(content), nil
 }
 
 // LifecycleAtEndRule ensures lifecycle block is at the end of resource blocks.
@@ -271,12 +271,18 @@ func (r *LifecycleAtEndRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Find
 }
 
 // fixLifecyclePosition moves lifecycle block to the end of the resource.
+// Used by Check to pre-compute fix content (reads from file).
 func (r *LifecycleAtEndRule) fixLifecyclePosition(filePath string, blockLabels []string) ([]byte, error) {
 	content, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}
+	return r.fixLifecyclePositionContent(content, filePath, blockLabels)
+}
 
+// fixLifecyclePositionContent moves lifecycle block to the end of the resource.
+// Works entirely in memory - takes content as input.
+func (r *LifecycleAtEndRule) fixLifecyclePositionContent(content []byte, filePath string, blockLabels []string) ([]byte, error) {
 	writeFile, diags := hclwrite.ParseConfig(content, filePath, hcl.InitialPos)
 	if diags.HasErrors() {
 		return nil, diags
@@ -320,6 +326,7 @@ func (r *LifecycleAtEndRule) fixLifecyclePosition(filePath string, blockLabels [
 }
 
 // Fix moves lifecycle blocks to the end of resource blocks.
+// Works entirely in memory - does NOT write to disk.
 func (r *LifecycleAtEndRule) Fix(ctx *sdk.Context, file *hcl.File) ([]byte, error) {
 	if ctx == nil || file == nil {
 		return nil, nil
@@ -335,7 +342,8 @@ func (r *LifecycleAtEndRule) Fix(ctx *sdk.Context, file *hcl.File) ([]byte, erro
 		return nil, nil
 	}
 
-	// Process each resource block
+	// Collect block labels before modifying content
+	var blocksToFix [][]string
 	for _, block := range hclFile.Blocks {
 		if block.Type != "resource" {
 			continue
@@ -361,15 +369,17 @@ func (r *LifecycleAtEndRule) Fix(ctx *sdk.Context, file *hcl.File) ([]byte, erro
 		}
 
 		if lifecycleBlock != nil && lifecycleBlock.Range().End.Line < lastLine {
-			content, err = r.fixLifecyclePosition(ctx.File, block.Labels)
-			if err != nil {
-				return nil, err
-			}
-			// Write intermediate result
-			if err := os.WriteFile(ctx.File, content, 0o600); err != nil {
-				return nil, err
-			}
+			blocksToFix = append(blocksToFix, block.Labels)
 		}
+	}
+
+	// Process each block (re-parse after each modification)
+	for _, labels := range blocksToFix {
+		content, err = r.fixLifecyclePositionContent(content, ctx.File, labels)
+		if err != nil {
+			return nil, err
+		}
+		// Do NOT write to disk - work entirely in memory
 	}
 
 	return content, nil
@@ -481,7 +491,7 @@ func (r *TagsAtEndRule) fixTagsBlock(filePath, blockType string, blockLabels []s
 
 	orderedNames := GetOrderedAttrNames(targetSyntaxBody)
 	// tags/labels should be at the end
-	lastAttrs := []string{"tags", "labels", "tags_all"}
+	lastAttrs := []string{"tags", "labels", "tags_all", "depends_on"}
 	ReorderBlockAttrs(targetBlock.Body(), orderedNames, nil, lastAttrs)
 
 	return FormatAndCleanBlankLines(writeFile.Bytes()), nil
@@ -507,57 +517,49 @@ func countAttrsAfterTags(attrs hclsyntax.Attributes, tagsLine int) int {
 }
 
 // Fix moves tags/labels to the end of blocks (before lifecycle if present).
+// Uses line-based reordering to preserve leading comments.
 func (r *TagsAtEndRule) Fix(ctx *sdk.Context, file *hcl.File) ([]byte, error) {
 	content, err := os.ReadFile(ctx.File)
 	if err != nil {
 		return nil, err
 	}
 
-	syntaxFile, ok := file.Body.(*hclsyntax.Body)
+	hclFile, ok := file.Body.(*hclsyntax.Body)
 	if !ok {
 		return nil, nil
 	}
 
-	writeFile, diags := hclwrite.ParseConfig(content, ctx.File, hcl.InitialPos)
-	if diags.HasErrors() {
-		return nil, diags
-	}
-
-	// Build a map of block identifiers to their syntax bodies
-	syntaxBlocks := make(map[string]*hclsyntax.Body)
-	for _, block := range syntaxFile.Blocks {
-		if block.Type == "resource" || block.Type == "module" {
-			key := BlockKey(block.Type, block.Labels)
-			syntaxBlocks[key] = block.Body
-		}
-	}
-
-	for _, block := range writeFile.Body().Blocks() {
-		if block.Type() != "resource" && block.Type() != "module" {
+	// Process each block that has tags
+	for _, block := range hclFile.Blocks {
+		if block.Type != "resource" && block.Type != "module" {
 			continue
 		}
 
 		// Check if block has tags
-		hasTags := block.Body().GetAttribute("tags") != nil ||
-			block.Body().GetAttribute("labels") != nil ||
-			block.Body().GetAttribute("tags_all") != nil
+		hasTags := FindAttribute(block.Body.Attributes, "tags") != nil ||
+			FindAttribute(block.Body.Attributes, "labels") != nil ||
+			FindAttribute(block.Body.Attributes, "tags_all") != nil
 		if !hasTags {
 			continue
 		}
 
-		key := BlockKey(block.Type(), block.Labels())
-		syntaxBody, ok := syntaxBlocks[key]
-		if !ok {
-			continue
-		}
+		orderedNames := GetOrderedAttrNames(block.Body)
+		// tags/labels should be at the end (before depends_on)
+		lastAttrs := []string{"tags", "labels", "tags_all", "depends_on"}
 
-		orderedNames := GetOrderedAttrNames(syntaxBody)
-		// tags/labels should be at the end
-		lastAttrs := []string{"tags", "labels", "tags_all"}
-		ReorderBlockAttrs(block.Body(), orderedNames, nil, lastAttrs)
+		// Use line-based reordering to preserve leading comments
+		content = ReorderBlockAttrsPreservingComments(
+			content,
+			block.Body,
+			block.Range().Start.Line,
+			block.Range().End.Line,
+			orderedNames,
+			nil,
+			lastAttrs,
+		)
 	}
 
-	return FormatAndCleanBlankLines(writeFile.Bytes()), nil
+	return FormatAndCleanBlankLines(content), nil
 }
 
 // DependsOnOrderRule ensures depends_on is at the end of blocks.
@@ -681,13 +683,14 @@ func (r *DependsOnOrderRule) fixDependsOnOrder(filePath, blockType string, block
 
 	orderedNames := GetOrderedAttrNames(targetSyntaxBody)
 	// depends_on should be near the end (before tags)
-	lastAttrs := []string{"depends_on", "tags", "labels", "tags_all"}
+	lastAttrs := []string{"tags", "labels", "tags_all", "depends_on"}
 	ReorderBlockAttrs(targetBlock.Body(), orderedNames, nil, lastAttrs)
 
 	return FormatAndCleanBlankLines(writeFile.Bytes()), nil
 }
 
 // Fix moves depends_on to be near the end of blocks.
+// Uses line-based reordering to preserve leading comments.
 func (r *DependsOnOrderRule) Fix(ctx *sdk.Context, file *hcl.File) ([]byte, error) {
 	if ctx == nil || file == nil {
 		return nil, nil
@@ -698,47 +701,39 @@ func (r *DependsOnOrderRule) Fix(ctx *sdk.Context, file *hcl.File) ([]byte, erro
 		return nil, err
 	}
 
-	syntaxFile, ok := file.Body.(*hclsyntax.Body)
+	hclFile, ok := file.Body.(*hclsyntax.Body)
 	if !ok {
 		return nil, nil
 	}
 
-	writeFile, diags := hclwrite.ParseConfig(content, ctx.File, hcl.InitialPos)
-	if diags.HasErrors() {
-		return nil, diags
-	}
-
-	// Build a map of block identifiers to their syntax bodies
-	syntaxBlocks := make(map[string]*hclsyntax.Body)
-	for _, block := range syntaxFile.Blocks {
-		if IsDependsOnRelevantBlock(block.Type) {
-			key := BlockKey(block.Type, block.Labels)
-			syntaxBlocks[key] = block.Body
-		}
-	}
-
-	for _, block := range writeFile.Body().Blocks() {
-		if !IsDependsOnRelevantBlock(block.Type()) {
+	// Process each block that has depends_on
+	for _, block := range hclFile.Blocks {
+		if !IsDependsOnRelevantBlock(block.Type) {
 			continue
 		}
 
 		// Check if block has depends_on
-		if block.Body().GetAttribute("depends_on") == nil {
+		if FindAttribute(block.Body.Attributes, "depends_on") == nil {
 			continue
 		}
 
-		key := BlockKey(block.Type(), block.Labels())
-		syntaxBody, ok := syntaxBlocks[key]
-		if !ok {
-			continue
-		}
+		orderedNames := GetOrderedAttrNames(block.Body)
+		// depends_on should be at the very end
+		lastAttrs := []string{"tags", "labels", "tags_all", "depends_on"}
 
-		orderedNames := GetOrderedAttrNames(syntaxBody)
-		lastAttrs := []string{"depends_on", "tags", "labels", "tags_all"}
-		ReorderBlockAttrs(block.Body(), orderedNames, nil, lastAttrs)
+		// Use line-based reordering to preserve leading comments
+		content = ReorderBlockAttrsPreservingComments(
+			content,
+			block.Body,
+			block.Range().Start.Line,
+			block.Range().End.Line,
+			orderedNames,
+			nil,
+			lastAttrs,
+		)
 	}
 
-	return FormatAndCleanBlankLines(writeFile.Bytes()), nil
+	return FormatAndCleanBlankLines(content), nil
 }
 
 // SourceVersionGroupedRule ensures source and version are grouped together in module blocks.
@@ -810,32 +805,48 @@ func (r *SourceVersionGroupedRule) fixModuleBlock(filePath string, blockLabels [
 		return nil, err
 	}
 
-	syntaxBody, writeFile, err := ParseBothFormats(content, filePath)
-	if err != nil {
-		return nil, err
+	// Parse with hclsyntax to get accurate positions
+	syntaxFile, diags := hclsyntax.ParseConfig(content, filePath, hcl.InitialPos)
+	if diags.HasErrors() {
+		return nil, diags
 	}
-	if syntaxBody == nil {
+	syntaxBody, ok := syntaxFile.Body.(*hclsyntax.Body)
+	if !ok {
 		return content, nil
 	}
 
-	// Find syntax body for this block
-	targetSyntaxBody := FindSyntaxBody(syntaxBody, "module", blockLabels)
-	if targetSyntaxBody == nil {
-		return content, nil
+	// Find the target block
+	var targetBlock *hclsyntax.Block
+	for _, block := range syntaxBody.Blocks {
+		if block.Type != "module" {
+			continue
+		}
+		if MatchBlockLabels(block.Labels, blockLabels) {
+			targetBlock = block
+			break
+		}
 	}
-
-	// Find the matching block in hclwrite
-	targetBlock := FindWriteBlock(writeFile, "module", blockLabels)
 	if targetBlock == nil {
 		return content, nil
 	}
 
-	orderedNames := GetOrderedAttrNames(targetSyntaxBody)
+	orderedNames := GetOrderedAttrNames(targetBlock.Body)
 	// source and version should come after for_each/count but before everything else
 	firstAttrs := []string{"for_each", "count", "source", "version"}
-	ReorderBlockAttrs(targetBlock.Body(), orderedNames, firstAttrs, nil)
+	lastAttrs := []string{"tags", "labels", "tags_all", "depends_on"}
 
-	return FormatAndCleanBlankLines(writeFile.Bytes()), nil
+	// Use line-based reordering to preserve leading comments
+	result := ReorderBlockAttrsPreservingComments(
+		content,
+		targetBlock.Body,
+		targetBlock.Range().Start.Line,
+		targetBlock.Range().End.Line,
+		orderedNames,
+		firstAttrs,
+		lastAttrs,
+	)
+
+	return FormatAndCleanBlankLines(result), nil
 }
 
 func (r *SourceVersionGroupedRule) checkSourcePosition(
@@ -886,54 +897,47 @@ func (r *SourceVersionGroupedRule) checkVersionFollowsSource(
 }
 
 // Fix reorders source/version to be at the start of module blocks (after for_each/count).
+// Uses line-based reordering to preserve leading comments.
 func (r *SourceVersionGroupedRule) Fix(ctx *sdk.Context, file *hcl.File) ([]byte, error) {
 	content, err := os.ReadFile(ctx.File)
 	if err != nil {
 		return nil, err
 	}
 
-	syntaxFile, ok := file.Body.(*hclsyntax.Body)
+	hclFile, ok := file.Body.(*hclsyntax.Body)
 	if !ok {
 		return nil, nil
 	}
 
-	writeFile, diags := hclwrite.ParseConfig(content, ctx.File, hcl.InitialPos)
-	if diags.HasErrors() {
-		return nil, diags
-	}
-
-	// Build a map of block identifiers to their syntax bodies
-	syntaxBlocks := make(map[string]*hclsyntax.Body)
-	for _, block := range syntaxFile.Blocks {
-		if block.Type == "module" {
-			key := BlockKey(block.Type, block.Labels)
-			syntaxBlocks[key] = block.Body
-		}
-	}
-
-	for _, block := range writeFile.Body().Blocks() {
-		if block.Type() != "module" {
+	// Process each module block that has source
+	for _, block := range hclFile.Blocks {
+		if block.Type != "module" {
 			continue
 		}
 
 		// Check if block has source
-		if block.Body().GetAttribute("source") == nil {
+		if FindAttribute(block.Body.Attributes, "source") == nil {
 			continue
 		}
 
-		key := BlockKey(block.Type(), block.Labels())
-		syntaxBody, ok := syntaxBlocks[key]
-		if !ok {
-			continue
-		}
-
-		orderedNames := GetOrderedAttrNames(syntaxBody)
+		orderedNames := GetOrderedAttrNames(block.Body)
 		// source and version should come after for_each/count but before everything else
 		firstAttrs := []string{"for_each", "count", "source", "version"}
-		ReorderBlockAttrs(block.Body(), orderedNames, firstAttrs, nil)
+		lastAttrs := []string{"tags", "labels", "tags_all", "depends_on"}
+
+		// Use line-based reordering to preserve leading comments
+		content = ReorderBlockAttrsPreservingComments(
+			content,
+			block.Body,
+			block.Range().Start.Line,
+			block.Range().End.Line,
+			orderedNames,
+			firstAttrs,
+			lastAttrs,
+		)
 	}
 
-	return FormatAndCleanBlankLines(writeFile.Bytes()), nil
+	return FormatAndCleanBlankLines(content), nil
 }
 
 // VariableOrderRule ensures variable blocks follow standard ordering.
@@ -1078,62 +1082,49 @@ func (r *VariableOrderRule) checkAttrPair(ctx *sdk.Context, block *hclsyntax.Blo
 }
 
 // Fix reorders variable attributes to match the standard order.
+// Uses line-based reordering to preserve leading comments.
 func (r *VariableOrderRule) Fix(ctx *sdk.Context, _ *hcl.File) ([]byte, error) {
 	content, err := os.ReadFile(ctx.File)
 	if err != nil {
 		return nil, err
 	}
 
-	f, diags := hclwrite.ParseConfig(content, ctx.File, hcl.InitialPos)
+	// Parse with hclsyntax to get block positions
+	syntaxFile, diags := hclsyntax.ParseConfig(content, ctx.File, hcl.InitialPos)
 	if diags.HasErrors() {
 		return nil, diags
+	}
+
+	hclFile, ok := syntaxFile.Body.(*hclsyntax.Body)
+	if !ok {
+		return nil, nil
 	}
 
 	// Expected order for variable attributes
 	attrOrder := []string{"description", "type", "default", "sensitive", "nullable"}
 
-	for _, block := range f.Body().Blocks() {
-		if block.Type() != "variable" {
+	// Process each variable block
+	for _, block := range hclFile.Blocks {
+		if block.Type != "variable" {
 			continue
 		}
 
-		body := block.Body()
+		orderedNames := GetOrderedAttrNames(block.Body)
 
-		// Collect all attributes with their expressions and trailing comments
-		attrExprs := make(map[string]hclwrite.Tokens)
-		for name, attr := range body.Attributes() {
-			attrExprs[name] = getExprTokensWithTrailingComment(attr)
-		}
-
-		// Remove all known-order attributes
-		for _, name := range attrOrder {
-			body.RemoveAttribute(name)
-		}
-
-		// Re-add in correct order
-		for _, name := range attrOrder {
-			if tokens, ok := attrExprs[name]; ok {
-				body.SetAttributeRaw(name, tokens)
-			}
-		}
-
-		// Add back any other attributes that weren't in the order list
-		for name, tokens := range attrExprs {
-			found := false
-			for _, orderedName := range attrOrder {
-				if name == orderedName {
-					found = true
-					break
-				}
-			}
-			if !found {
-				body.SetAttributeRaw(name, tokens)
-			}
-		}
+		// Use line-based reordering to preserve leading comments
+		// For variables, the standard attrs come first in order, everything else after
+		content = ReorderBlockAttrsPreservingComments(
+			content,
+			block.Body,
+			block.Range().Start.Line,
+			block.Range().End.Line,
+			orderedNames,
+			attrOrder,
+			nil,
+		)
 	}
 
-	// Clean up any leading/trailing blank lines that may have been introduced
-	return FormatAndCleanBlankLines(f.Bytes()), nil
+	return FormatAndCleanBlankLines(content), nil
 }
 
 // OutputOrderRule ensures output blocks follow standard ordering.
@@ -1254,62 +1245,49 @@ func (r *OutputOrderRule) checkOutputAttrPair(ctx *sdk.Context, block *hclsyntax
 }
 
 // Fix reorders output attributes to match the standard order.
+// Uses line-based reordering to preserve leading comments.
 func (r *OutputOrderRule) Fix(ctx *sdk.Context, _ *hcl.File) ([]byte, error) {
 	content, err := os.ReadFile(ctx.File)
 	if err != nil {
 		return nil, err
 	}
 
-	f, diags := hclwrite.ParseConfig(content, ctx.File, hcl.InitialPos)
+	// Parse with hclsyntax to get block positions
+	syntaxFile, diags := hclsyntax.ParseConfig(content, ctx.File, hcl.InitialPos)
 	if diags.HasErrors() {
 		return nil, diags
+	}
+
+	hclFile, ok := syntaxFile.Body.(*hclsyntax.Body)
+	if !ok {
+		return nil, nil
 	}
 
 	// Expected order for output attributes
 	attrOrder := []string{"description", "value", "sensitive", "depends_on"}
 
-	for _, block := range f.Body().Blocks() {
-		if block.Type() != "output" {
+	// Process each output block
+	for _, block := range hclFile.Blocks {
+		if block.Type != "output" {
 			continue
 		}
 
-		body := block.Body()
+		orderedNames := GetOrderedAttrNames(block.Body)
 
-		// Collect all attributes with their expressions and trailing comments
-		attrExprs := make(map[string]hclwrite.Tokens)
-		for name, attr := range body.Attributes() {
-			attrExprs[name] = getExprTokensWithTrailingComment(attr)
-		}
-
-		// Remove all known-order attributes
-		for _, name := range attrOrder {
-			body.RemoveAttribute(name)
-		}
-
-		// Re-add in correct order
-		for _, name := range attrOrder {
-			if tokens, ok := attrExprs[name]; ok {
-				body.SetAttributeRaw(name, tokens)
-			}
-		}
-
-		// Add back any other attributes that weren't in the order list
-		for name, tokens := range attrExprs {
-			found := false
-			for _, orderedName := range attrOrder {
-				if name == orderedName {
-					found = true
-					break
-				}
-			}
-			if !found {
-				body.SetAttributeRaw(name, tokens)
-			}
-		}
+		// Use line-based reordering to preserve leading comments
+		// For outputs, the standard attrs come first in order, everything else after
+		content = ReorderBlockAttrsPreservingComments(
+			content,
+			block.Body,
+			block.Range().Start.Line,
+			block.Range().End.Line,
+			orderedNames,
+			attrOrder,
+			nil,
+		)
 	}
 
-	// Clean up any leading/trailing blank lines that may have been introduced
-	return FormatAndCleanBlankLines(f.Bytes()), nil
+	return FormatAndCleanBlankLines(content), nil
 }
 
 // TerraformBlockFirstRule ensures terraform block is first in the file.
@@ -1687,13 +1665,9 @@ func (r *AttributeGroupSpacingRule) checkBlock(ctx *sdk.Context, block *hclsynta
 	return findings
 }
 
-// fixBlock adds blank lines between attribute groups in a block.
-func (r *AttributeGroupSpacingRule) fixBlock(filePath, blockType string, blockLabels []string) ([]byte, error) {
-	content, err := os.ReadFile(filePath)
-	if err != nil {
-		return nil, err
-	}
-
+// fixBlockContent adds blank lines between attribute groups in a block.
+// Works entirely in memory - takes content as input and returns modified content.
+func (r *AttributeGroupSpacingRule) fixBlockContent(content []byte, filePath, blockType string, blockLabels []string) ([]byte, error) {
 	lines := SplitLines(content)
 
 	// Parse to find the block and its attributes
@@ -1805,6 +1779,7 @@ func (r *AttributeGroupSpacingRule) fixBlock(filePath, blockType string, blockLa
 }
 
 // fixAllBlocks fixes attribute group spacing in all blocks in the file.
+// Works entirely in memory - does NOT write to disk.
 func (r *AttributeGroupSpacingRule) fixAllBlocks(filePath string) ([]byte, error) {
 	content, err := os.ReadFile(filePath)
 	if err != nil {
@@ -1822,29 +1797,34 @@ func (r *AttributeGroupSpacingRule) fixAllBlocks(filePath string) ([]byte, error
 		return content, nil
 	}
 
-	// Process each block that needs spacing
+	// Collect block info before modifying content (line numbers will change)
+	type blockInfo struct {
+		blockType string
+		labels    []string
+	}
+	var blocks []blockInfo
 	for _, block := range syntaxBody.Blocks {
 		if block.Type != "resource" && block.Type != "module" && block.Type != "data" &&
 			block.Type != "variable" && block.Type != "output" {
 			continue
 		}
+		blocks = append(blocks, blockInfo{blockType: block.Type, labels: block.Labels})
+	}
 
-		// Fix this block
-		content, err = r.fixBlock(filePath, block.Type, block.Labels)
+	// Process each block that needs spacing (re-parse after each modification)
+	for _, bi := range blocks {
+		content, err = r.fixBlockContent(content, filePath, bi.blockType, bi.labels)
 		if err != nil {
 			return nil, err
 		}
-
-		// Write intermediate result so next fixBlock sees updated line numbers
-		if err := os.WriteFile(filePath, content, 0o600); err != nil {
-			return nil, err
-		}
+		// Do NOT write to disk - work entirely in memory
 	}
 
 	return content, nil
 }
 
 // Fix adds blank lines between attribute groups.
+// Works entirely in memory - does NOT write to disk.
 func (r *AttributeGroupSpacingRule) Fix(ctx *sdk.Context, file *hcl.File) ([]byte, error) {
 	content, err := os.ReadFile(ctx.File)
 	if err != nil {
@@ -1856,23 +1836,27 @@ func (r *AttributeGroupSpacingRule) Fix(ctx *sdk.Context, file *hcl.File) ([]byt
 		return content, nil
 	}
 
-	// Process each block
+	// Collect block info before modifying content (line numbers will change)
+	type blockInfo struct {
+		blockType string
+		labels    []string
+	}
+	var blocks []blockInfo
 	for _, block := range hclFile.Blocks {
 		if block.Type != "resource" && block.Type != "module" && block.Type != "data" &&
 			block.Type != "variable" && block.Type != "output" {
 			continue
 		}
+		blocks = append(blocks, blockInfo{blockType: block.Type, labels: block.Labels})
+	}
 
-		// Fix this block
-		content, err = r.fixBlock(ctx.File, block.Type, block.Labels)
+	// Process each block (re-parse after each modification)
+	for _, bi := range blocks {
+		content, err = r.fixBlockContent(content, ctx.File, bi.blockType, bi.labels)
 		if err != nil {
 			return nil, err
 		}
-
-		// Write intermediate result for next iteration
-		if err := os.WriteFile(ctx.File, content, 0o600); err != nil {
-			return nil, err
-		}
+		// Do NOT write to disk - work entirely in memory
 	}
 
 	return content, nil

--- a/internal/engines/style/rules/ordering_test.go
+++ b/internal/engines/style/rules/ordering_test.go
@@ -153,6 +153,50 @@ func TestForEachCountFirstRule(t *testing.T) {
 		amiIdx := indexOf(resultStr, "ami")
 		assert.Less(t, forEachIdx, amiIdx)
 	})
+
+	t.Run("Fix preserves leading comments on attributes", func(t *testing.T) {
+		content := `module "example" {
+  for_each = var.instances
+  depends_on = [module.other]
+  # This is an important comment about the instance
+  # It spans multiple lines
+  instance_type = "t3.micro"
+  source = "./module"
+  tags = { Name = "test" }
+}
+`
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "test.tf")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+
+		file, diags := hclsyntax.ParseConfig([]byte(content), tmpFile, hcl.InitialPos)
+		require.False(t, diags.HasErrors())
+
+		hclFile := &hcl.File{Body: file.Body}
+		ctx := &sdk.Context{File: tmpFile}
+
+		result, err := rule.Fix(ctx, hclFile)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		resultStr := string(result)
+		// Comments should be preserved
+		assert.Contains(t, resultStr, "# This is an important comment about the instance")
+		assert.Contains(t, resultStr, "# It spans multiple lines")
+		// Comment should appear before instance_type
+		commentIdx := indexOf(resultStr, "# This is an important comment")
+		instanceTypeIdx := indexOf(resultStr, "instance_type")
+		assert.Less(t, commentIdx, instanceTypeIdx, "comment should appear before instance_type")
+		// Ordering should be correct: for_each, source, instance_type, tags, depends_on
+		forEachIdx := indexOf(resultStr, "for_each")
+		sourceIdx := indexOf(resultStr, "source")
+		tagsIdx := indexOf(resultStr, "tags")
+		dependsOnIdx := indexOf(resultStr, "depends_on")
+		assert.Less(t, forEachIdx, sourceIdx, "for_each should be before source")
+		assert.Less(t, sourceIdx, instanceTypeIdx, "source should be before instance_type")
+		assert.Less(t, instanceTypeIdx, tagsIdx, "instance_type should be before tags")
+		assert.Less(t, tagsIdx, dependsOnIdx, "tags should be before depends_on")
+	})
 }
 
 func TestLifecycleAtEndRule(t *testing.T) {
@@ -405,6 +449,39 @@ func TestTagsAtEndRule(t *testing.T) {
 		amiIdx := indexOf(resultStr, "ami")
 		assert.Greater(t, tagsIdx, amiIdx, "tags should be after ami")
 	})
+
+	t.Run("Fix preserves leading comments on attributes", func(t *testing.T) {
+		content := `resource "aws_instance" "example" {
+  tags = { Name = "test" }
+  # This comment describes the AMI
+  ami = "ami-123"
+  # This comment describes the instance type
+  instance_type = "t3.micro"
+}
+`
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "test.tf")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+
+		file, diags := hclsyntax.ParseConfig([]byte(content), tmpFile, hcl.InitialPos)
+		require.False(t, diags.HasErrors())
+
+		hclFile := &hcl.File{Body: file.Body}
+		ctx := &sdk.Context{File: tmpFile}
+
+		result, err := rule.Fix(ctx, hclFile)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		resultStr := string(result)
+		// Comments should be preserved
+		assert.Contains(t, resultStr, "# This comment describes the AMI")
+		assert.Contains(t, resultStr, "# This comment describes the instance type")
+		// Tags should be at end, ami should be before tags
+		tagsIdx := indexOf(resultStr, "tags")
+		amiIdx := indexOf(resultStr, "ami")
+		assert.Less(t, amiIdx, tagsIdx, "ami should be before tags")
+	})
 }
 
 func TestDependsOnOrderRule(t *testing.T) {
@@ -490,6 +567,39 @@ func TestDependsOnOrderRule(t *testing.T) {
 
 		// Verify depends_on is now after ami
 		resultStr := string(result)
+		dependsOnIdx := indexOf(resultStr, "depends_on")
+		amiIdx := indexOf(resultStr, "ami")
+		assert.Greater(t, dependsOnIdx, amiIdx, "depends_on should be after ami")
+	})
+
+	t.Run("Fix preserves leading comments on attributes", func(t *testing.T) {
+		content := `resource "aws_instance" "example" {
+  depends_on = [aws_vpc.main]
+  # This is the AMI comment
+  ami = "ami-123"
+  # This describes the instance type
+  instance_type = "t3.micro"
+}
+`
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "test.tf")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+
+		file, diags := hclsyntax.ParseConfig([]byte(content), tmpFile, hcl.InitialPos)
+		require.False(t, diags.HasErrors())
+
+		hclFile := &hcl.File{Body: file.Body}
+		ctx := &sdk.Context{File: tmpFile}
+
+		result, err := rule.Fix(ctx, hclFile)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		resultStr := string(result)
+		// Comments should be preserved
+		assert.Contains(t, resultStr, "# This is the AMI comment")
+		assert.Contains(t, resultStr, "# This describes the instance type")
+		// depends_on should be at end
 		dependsOnIdx := indexOf(resultStr, "depends_on")
 		amiIdx := indexOf(resultStr, "ami")
 		assert.Greater(t, dependsOnIdx, amiIdx, "depends_on should be after ami")
@@ -597,6 +707,40 @@ func TestSourceVersionGroupedRule(t *testing.T) {
 		resultStr := string(result)
 		sourceIdx := indexOf(resultStr, "source")
 		nameIdx := indexOf(resultStr, "name")
+		assert.Less(t, sourceIdx, nameIdx, "source should be before name")
+	})
+
+	t.Run("Fix preserves leading comments on attributes", func(t *testing.T) {
+		content := `module "example" {
+  # Comment about module identifier
+  name = "test"
+  source = "./module"
+  version = "1.0.0"
+  # Comment about settings
+  config = {}
+}
+`
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "test.tf")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+
+		file, diags := hclsyntax.ParseConfig([]byte(content), tmpFile, hcl.InitialPos)
+		require.False(t, diags.HasErrors())
+
+		hclFile := &hcl.File{Body: file.Body}
+		ctx := &sdk.Context{File: tmpFile}
+
+		result, err := rule.Fix(ctx, hclFile)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		resultStr := string(result)
+		// Comments should be preserved
+		assert.Contains(t, resultStr, "# Comment about module identifier")
+		assert.Contains(t, resultStr, "# Comment about settings")
+		// source should be before name after fix
+		sourceIdx := indexOf(resultStr, "source")
+		nameIdx := indexOf(resultStr, "name =")
 		assert.Less(t, sourceIdx, nameIdx, "source should be before name")
 	})
 }

--- a/internal/engines/style/style.go
+++ b/internal/engines/style/style.go
@@ -106,9 +106,7 @@ func (e *Engine) Run(ctx context.Context, files []string) ([]sdk.Finding, error)
 		default:
 		}
 
-		// Create fresh parser per file to avoid cached state issues
-		parser := hclparse.NewParser()
-		findings, err := e.checkFile(parser, file)
+		findings, err := e.checkFile(file)
 		if err != nil {
 			return nil, fmt.Errorf("checking %s: %w", file, err)
 		}
@@ -120,7 +118,7 @@ func (e *Engine) Run(ctx context.Context, files []string) ([]sdk.Finding, error)
 }
 
 // checkFile checks a single file against all enabled rules
-func (e *Engine) checkFile(parser *hclparse.Parser, path string) ([]sdk.Finding, error) {
+func (e *Engine) checkFile(path string) ([]sdk.Finding, error) {
 	// Create context for rule execution
 	ruleCtx := &sdk.Context{
 		Context: context.Background(),
@@ -141,7 +139,7 @@ func (e *Engine) checkFile(parser *hclparse.Parser, path string) ([]sdk.Finding,
 
 	var allFindings []sdk.Finding
 	var suppressions []annotations.Suppression
-	maxPasses := 3 // Limit passes to prevent infinite loops
+	maxPasses := 10 // Limit passes to prevent infinite loops (enough for typical ordering + spacing fixes)
 
 	for pass := 0; pass < maxPasses; pass++ {
 		// Always read fresh content for each pass
@@ -155,7 +153,8 @@ func (e *Engine) checkFile(parser *hclparse.Parser, path string) ([]sdk.Finding,
 			suppressions = annotations.Parse(content)
 		}
 
-		// Parse HCL fresh for each pass
+		// Create fresh parser for each pass to avoid cached results
+		parser := hclparse.NewParser()
 		file, diags := parser.ParseHCL(content, path)
 		if diags.HasErrors() {
 			// Try as JSON for .tf.json files

--- a/internal/engines/style/style_test.go
+++ b/internal/engines/style/style_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
@@ -1218,4 +1219,92 @@ resource "aws_instance" "MyServer" { }
 			}
 		})
 	}
+}
+
+func TestEngine_FixPreservesComments(t *testing.T) {
+	t.Run("single block with comments", func(t *testing.T) {
+		content := `module "example" {
+  source = "./module"
+  depends_on = [module.other]
+  # This is an important comment
+  # that spans multiple lines
+  instance_type = "t3.micro"
+  for_each = var.instances
+  tags = { Name = "test" }
+}
+`
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "test.tf")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+
+		engine := New(&Config{Fix: true})
+		_, err := engine.Run(context.Background(), []string{tmpFile})
+		require.NoError(t, err)
+
+		result, err := os.ReadFile(tmpFile)
+		require.NoError(t, err)
+
+		resultStr := string(result)
+		// Comments must be preserved
+		assert.Contains(t, resultStr, "# This is an important comment")
+		assert.Contains(t, resultStr, "# that spans multiple lines")
+		// Order must be correct: for_each, source, regular attrs, tags, depends_on
+		forEachIdx := strings.Index(resultStr, "for_each")
+		sourceIdx := strings.Index(resultStr, "source")
+		instanceIdx := strings.Index(resultStr, "instance_type")
+		tagsIdx := strings.Index(resultStr, "tags")
+		dependsOnIdx := strings.Index(resultStr, "depends_on")
+		assert.Less(t, forEachIdx, sourceIdx, "for_each should be before source")
+		assert.Less(t, sourceIdx, instanceIdx, "source should be before instance_type")
+		assert.Less(t, instanceIdx, tagsIdx, "instance_type should be before tags")
+		assert.Less(t, tagsIdx, dependsOnIdx, "tags should be before depends_on")
+	})
+
+	t.Run("multiple blocks with comments in single pass", func(t *testing.T) {
+		content := `module "first" {
+  source = "./first"
+  depends_on = [module.zero]
+  # Comment on first module
+  attr1 = "value1"
+  for_each = var.first
+  tags = { Name = "first" }
+}
+
+module "second" {
+  source = "./second"
+  depends_on = [module.first]
+  # Comment on second module
+  attr2 = "value2"
+  for_each = var.second
+  tags = { Name = "second" }
+}
+`
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "test.tf")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+
+		engine := New(&Config{Fix: true})
+		_, err := engine.Run(context.Background(), []string{tmpFile})
+		require.NoError(t, err)
+
+		result, err := os.ReadFile(tmpFile)
+		require.NoError(t, err)
+
+		resultStr := string(result)
+		// Both comments must be preserved
+		assert.Contains(t, resultStr, "# Comment on first module")
+		assert.Contains(t, resultStr, "# Comment on second module")
+		// Both blocks must be correctly ordered (check depends_on is last in each)
+		// Find the two depends_on occurrences
+		firstDepends := strings.Index(resultStr, "depends_on = [module.zero]")
+		secondDepends := strings.Index(resultStr, "depends_on = [module.first]")
+		assert.Greater(t, firstDepends, 0, "first depends_on should exist")
+		assert.Greater(t, secondDepends, firstDepends, "second depends_on should be after first")
+
+		// Verify no issues remain after fix
+		engine2 := New(&Config{Fix: false})
+		findings, err := engine2.Run(context.Background(), []string{tmpFile})
+		require.NoError(t, err)
+		assert.Empty(t, findings, "should have no issues after fix")
+	})
 }


### PR DESCRIPTION
## What and why

Fix style engine to preserve comments when reordering attributes, addressing the issue where module `source` and `version` were being mixed with other attributes.

**Why:** When the style engine reordered attributes (like moving `source` to the top or `depends_on` to the end), it was losing or misplacing comments attached to those attributes. This made the tool unusable for codebases with inline documentation.

Fixes #121

## How to test

1. Create a module block with source in wrong position and comments:
```hcl
module "example" {
  depends_on = [module.other]

  # Important config
  some_var = "value"
  
  # Source will be moved to the top and this comment will be preserved
  source = "./modules/example"
}
```

2. Run `terratidy style --fix`

3. Verify source moves to top AND comments are preserved:
```hcl
module "example" {
  # Source will be moved to the top and this comment will be preserved
  source = "./modules/example"

  # Important config
  some_var = "value"
  
  depends_on = [module.other]
}
```

## Notes for reviewers

- Switched from AST-based to line-based reordering to preserve comment associations
- Increased max fix passes from 3 to 10 to handle complex files in one run
- Added `ExtractAttrRegions` and `ReorderBlockAttrsPreservingComments` helpers

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.ai/code)
