### PR TITLE
refactor(style): own Fixable signal in engine, dispatch fixes lazily

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <b>A comprehensive quality platform for Terraform and Terragrunt</b>
 
-[![Latest Release](https://img.shields.io/github/v/release/santosr2/terratidy)](https://github.com/santosr2/TerraTidy/releases/latest)
+[![Latest Release](https://img.shields.io/github/v/release/santosr2/terratidy?include_prereleases)](https://github.com/santosr2/TerraTidy/releases/latest)
 [![Build Status](https://github.com/santosr2/TerraTidy/workflows/Test/badge.svg)](https://github.com/santosr2/TerraTidy/actions)
 [![codecov](https://codecov.io/gh/santosr2/terratidy/branch/main/graph/badge.svg)](https://codecov.io/gh/santosr2/terratidy)
 [![Go Report Card](https://goreportcard.com/badge/github.com/santosr2/TerraTidy)](https://goreportcard.com/report/github.com/santosr2/TerraTidy)

--- a/internal/engines/style/style.go
+++ b/internal/engines/style/style.go
@@ -202,6 +202,19 @@ func (e *Engine) checkFile(path string) ([]sdk.Finding, error) {
 				}
 			}
 
+			// Stamp Fix sentinel: engine owns the Fixable signal, not the rule.
+			// For Fixer rules, set Fix to an empty FixResult (Content stays nil; the engine
+			// dispatches to Fixer.Fix(ctx, file) lazily in applyFixes). For non-Fixer rules,
+			// force Fix to nil regardless of what the rule may have set.
+			_, isFixer := rule.(sdk.Fixer)
+			for i := range ruleFindings {
+				if isFixer {
+					ruleFindings[i].Fix = &sdk.FixResult{}
+				} else {
+					ruleFindings[i].Fix = nil
+				}
+			}
+
 			findings = append(findings, ruleFindings...)
 		}
 
@@ -288,20 +301,57 @@ func (e *Engine) generateDiff(path string, originalContent []byte) (*sdk.Finding
 
 // applyFixes applies ONE auto-fix to the file per pass.
 // Returns the number of fixes applied (0 or 1).
-// The multi-pass loop in Run will re-read the file and re-run rules after each fix,
-// ensuring subsequent fixes are computed against the updated content.
-func (e *Engine) applyFixes(ctx *sdk.Context, _ *hcl.File, findings []sdk.Finding) (int, error) {
-	// Find the first fixable finding
+//
+// Dispatch: for each finding marked fixable (Fix != nil), look up the originating
+// rule by name and invoke its Fixer.Fix(ctx, file) method. The first non-nil byte
+// content returned wins; it is written to disk and the loop returns 1. The multi-pass
+// loop in Run will re-read the file and re-run rules after each fix, ensuring
+// subsequent fixes are computed against the updated content.
+//
+// Note: rules' Fix() methods are responsible for idempotence — if Fix(Fix(x)) != Fix(x),
+// the multi-pass loop will keep applying fixes until the loop guard fires.
+func (e *Engine) applyFixes(ctx *sdk.Context, file *hcl.File, findings []sdk.Finding) (int, error) {
 	for i := range findings {
-		if findings[i].Fix != nil && findings[i].Fix.Content != nil {
-			if err := os.WriteFile(ctx.File, findings[i].Fix.Content, 0o600); err != nil {
-				return 0, fmt.Errorf("writing fix for %s: %w", findings[i].Rule, err)
-			}
-			return 1, nil
+		if findings[i].Fix == nil {
+			continue
 		}
+
+		fixer := e.findFixerByRuleName(findings[i].Rule)
+		if fixer == nil {
+			continue
+		}
+
+		content, err := fixer.Fix(ctx, file)
+		if err != nil {
+			return 0, fmt.Errorf("computing fix for %s: %w", findings[i].Rule, err)
+		}
+		if content == nil {
+			continue
+		}
+
+		if err := os.WriteFile(ctx.File, content, 0o600); err != nil {
+			return 0, fmt.Errorf("writing fix for %s: %w", findings[i].Rule, err)
+		}
+		return 1, nil
 	}
 
 	return 0, nil
+}
+
+// findFixerByRuleName returns the rule registered under the given name as an
+// sdk.Fixer, or nil if no rule with that name is registered or it does not
+// implement Fixer.
+func (e *Engine) findFixerByRuleName(name string) sdk.Fixer {
+	for _, r := range e.rules {
+		if r.Name() != name {
+			continue
+		}
+		if f, ok := r.(sdk.Fixer); ok {
+			return f
+		}
+		return nil
+	}
+	return nil
 }
 
 // getRuleConfig returns the configuration for a rule

--- a/internal/engines/style/style_coverage_test.go
+++ b/internal/engines/style/style_coverage_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/santosr2/TerraTidy/internal/config"
 	"github.com/santosr2/TerraTidy/pkg/sdk"
 	"github.com/stretchr/testify/assert"
@@ -169,12 +170,14 @@ resource "aws_instance" "test2" {
 	findings, err := checkEngine.Run(context.Background(), []string{tmpFile})
 	require.NoError(t, err)
 
-	// Verify we have at least one finding with Fix populated
+	// Verify we have at least one finding with Fix populated (sentinel set by engine).
+	// Fix.Content must NOT be set: the engine dispatches to Fixer.Fix(ctx, file) lazily
+	// in applyFixes — Check() never carries fix bytes through Fix.Content.
 	hasFixableFinding := false
 	for _, f := range findings {
 		if f.Fix != nil {
 			hasFixableFinding = true
-			assert.NotNil(t, f.Fix.Content, "Fix.Content should be set")
+			assert.Nil(t, f.Fix.Content, "Fix.Content must NOT be set; engine dispatches to Fix() lazily")
 			break
 		}
 	}
@@ -193,6 +196,86 @@ resource "aws_instance" "test2" {
 	require.NoError(t, err)
 	assert.NotEqual(t, content, string(modified), "fix should modify the file")
 	assert.Contains(t, string(modified), "\n\nresource", "should have blank line between blocks")
+}
+
+// stubNonFixerRule is a rule that does not implement sdk.Fixer; used to verify
+// that the engine forces Fix to nil on findings from non-Fixer rules.
+type stubNonFixerRule struct{}
+
+func (r *stubNonFixerRule) Name() string        { return "test.stub-non-fixer" }
+func (r *stubNonFixerRule) Description() string { return "Test rule that is not a Fixer" }
+
+func (r *stubNonFixerRule) Check(ctx *sdk.Context, _ *hcl.File) ([]sdk.Finding, error) {
+	return []sdk.Finding{{
+		Rule:     r.Name(),
+		Message:  "stub finding from non-fixer",
+		File:     ctx.File,
+		Severity: sdk.SeverityWarning,
+		// Intentionally set Fix to a non-nil value here; the engine must overwrite
+		// it with nil because this rule does not implement Fixer.
+		Fix: &sdk.FixResult{Content: []byte("garbage")},
+	}}, nil
+}
+
+// stubErroringFixerRule is a Fixer rule whose Fix() always returns an error;
+// used to verify that applyFixes wraps and propagates Fix() errors.
+type stubErroringFixerRule struct{}
+
+func (r *stubErroringFixerRule) Name() string        { return "test.stub-erroring-fixer" }
+func (r *stubErroringFixerRule) Description() string { return "Test rule that errors in Fix()" }
+
+func (r *stubErroringFixerRule) Check(ctx *sdk.Context, _ *hcl.File) ([]sdk.Finding, error) {
+	return []sdk.Finding{{
+		Rule:     r.Name(),
+		Message:  "stub finding",
+		File:     ctx.File,
+		Severity: sdk.SeverityWarning,
+	}}, nil
+}
+
+func (r *stubErroringFixerRule) Fix(_ *sdk.Context, _ *hcl.File) ([]byte, error) {
+	return nil, assert.AnError
+}
+
+func TestEngineDispatch_PropagatesFixerError(t *testing.T) {
+	dir := t.TempDir()
+	tmpFile := filepath.Join(dir, "test.tf")
+	// Empty file produces no findings from any built-in rule, so the stub is the
+	// only finding-generator the engine sees. This keeps the test from depending
+	// on the rule registration order or the set of enabled-by-default rules.
+	require.NoError(t, os.WriteFile(tmpFile, []byte("\n"), 0o644))
+
+	engine := New(&Config{
+		Fix:   true,
+		Rules: make(map[string]RuleConfig),
+	}, &stubErroringFixerRule{})
+
+	_, err := engine.Run(context.Background(), []string{tmpFile})
+	require.Error(t, err, "applyFixes must propagate errors from Fixer.Fix()")
+	assert.Contains(t, err.Error(), "test.stub-erroring-fixer",
+		"propagated error should name the failing rule")
+}
+
+func TestEngineDispatch_NonFixerFindingsHaveNilFix(t *testing.T) {
+	dir := t.TempDir()
+	tmpFile := filepath.Join(dir, "test.tf")
+	require.NoError(t, os.WriteFile(tmpFile, []byte("resource \"aws_instance\" \"x\" {}\n"), 0o644))
+
+	// Inject the stub via the plugin slot so it runs through the regular Check path.
+	engine := New(&Config{Rules: make(map[string]RuleConfig)}, &stubNonFixerRule{})
+	findings, err := engine.Run(context.Background(), []string{tmpFile})
+	require.NoError(t, err)
+
+	var stubFinding *sdk.Finding
+	for i := range findings {
+		if findings[i].Rule == "test.stub-non-fixer" {
+			stubFinding = &findings[i]
+			break
+		}
+	}
+	require.NotNil(t, stubFinding, "stub rule should produce a finding")
+	assert.Nil(t, stubFinding.Fix,
+		"engine must force Fix to nil for findings from non-Fixer rules, even if the rule sets it")
 }
 
 func TestRun_RuleDisabling(t *testing.T) {


### PR DESCRIPTION
## What and why

Refactor the style engine so the `Fixable` signal is engine-owned rather than rule-reported. Findings from `sdk.Fixer` rules now get a sentinel `Fix` stamped by the engine; findings from non-`Fixer` rules have `Fix` forced to `nil` even if the rule populates it. `applyFixes` dispatches to `Fixer.Fix(ctx, file)` lazily via a new `findFixerByRuleName` helper instead of reading bytes off `Fix.Content`.

Also includes a drive-by README change appending `?include_prereleases` to the shields.io release badge so alpha tags surface while the project is pre-1.0.

**Why:** `Fix.Content` was a leaky channel. Rules could mark themselves fixable without implementing `sdk.Fixer`, and `Fix.Content` had to be computed eagerly inside `Check()` on every pass even when the engine wasn't going to apply fixes. Owning the signal in the engine keeps rule authors honest and makes fix computation lazy.

## How to test

```bash
mise run check
```

New tests in `internal/engines/style/style_coverage_test.go`:

- `TestEngineDispatch_PropagatesFixerError` — verifies `applyFixes` wraps and propagates errors from `Fixer.Fix()`.
- `TestEngineDispatch_NonFixerFindingsHaveNilFix` — verifies the engine forces `Fix=nil` for non-`Fixer` rules even when the rule sets it.

The existing fix-application test was updated to assert `Fix.Content == nil` (sentinel-only); the engine no longer carries fix bytes through `Check()`.

## Notes for reviewers

- `sdk.Fixer.Fix(ctx, file)` signature is unchanged; only the dispatch site moved.
- Rule authors implementing `Fixer` no longer need to populate `Fix.Content` from `Check()`; the engine calls `Fix()` itself when applying.
- Multi-pass fix loop semantics are unchanged: one fix per pass, file re-read on next pass.
- Idempotence remains the rule's responsibility — if `Fix(Fix(x)) != Fix(x)`, the multi-pass loop guard fires.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test)
- [ ] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
