### PR TITLE
refactor(style): remove 16 no-op Fix methods from non-fixer rules

### DIFF
--- a/internal/engines/style/rules/advanced_naming.go
+++ b/internal/engines/style/rules/advanced_naming.go
@@ -163,11 +163,6 @@ func (r *ResourceNameMatchesTypeRule) nameJustRepeatsType(name string, typeWords
 	return allFromType && len(nameParts) > 0
 }
 
-// Fix is a no-op for this rule as renaming resources requires manual review.
-func (r *ResourceNameMatchesTypeRule) Fix(_ *sdk.Context, _ *hcl.File) ([]byte, error) {
-	return nil, nil
-}
-
 // OutputPrefixRule ensures outputs follow a naming pattern.
 type OutputPrefixRule struct{}
 
@@ -250,11 +245,6 @@ func (r *OutputPrefixRule) getPatternConfig(config map[string]any) (prefix, suff
 	return prefix, suffix
 }
 
-// Fix is a no-op for this rule as renaming outputs requires manual review.
-func (r *OutputPrefixRule) Fix(_ *sdk.Context, _ *hcl.File) ([]byte, error) {
-	return nil, nil
-}
-
 // ModuleNameConventionRule ensures module names follow conventions.
 type ModuleNameConventionRule struct{}
 
@@ -316,9 +306,4 @@ func (r *ModuleNameConventionRule) Check(ctx *sdk.Context, file *hcl.File) ([]sd
 	}
 
 	return findings, nil
-}
-
-// Fix is a no-op for this rule as renaming modules requires manual review.
-func (r *ModuleNameConventionRule) Fix(_ *sdk.Context, _ *hcl.File) ([]byte, error) {
-	return nil, nil
 }

--- a/internal/engines/style/rules/advanced_naming_test.go
+++ b/internal/engines/style/rules/advanced_naming_test.go
@@ -118,12 +118,6 @@ func TestResourceNameMatchesTypeRule(t *testing.T) {
 			assert.Len(t, findings, tt.wantFindings)
 		})
 	}
-
-	t.Run("Fix returns nil", func(t *testing.T) {
-		result, err := rule.Fix(nil, nil)
-		assert.NoError(t, err)
-		assert.Nil(t, result)
-	})
 }
 
 func TestResourceNameMatchesTypeRule_ExtractTypeWords(t *testing.T) {
@@ -301,12 +295,6 @@ func TestOutputPrefixRule(t *testing.T) {
 			assert.Len(t, findings, tt.wantFindings)
 		})
 	}
-
-	t.Run("Fix returns nil", func(t *testing.T) {
-		result, err := rule.Fix(nil, nil)
-		assert.NoError(t, err)
-		assert.Nil(t, result)
-	})
 }
 
 func TestModuleNameConventionRule(t *testing.T) {
@@ -404,10 +392,4 @@ func TestModuleNameConventionRule(t *testing.T) {
 			assert.Len(t, findings, tt.wantFindings)
 		})
 	}
-
-	t.Run("Fix returns nil", func(t *testing.T) {
-		result, err := rule.Fix(nil, nil)
-		assert.NoError(t, err)
-		assert.Nil(t, result)
-	})
 }

--- a/internal/engines/style/rules/block_organization.go
+++ b/internal/engines/style/rules/block_organization.go
@@ -400,11 +400,6 @@ func (r *NestedBlockOrderRule) checkNestedBlocks(ctx *sdk.Context, block *hclsyn
 	return findings
 }
 
-// Fix is a no-op for this rule as reordering nested blocks is complex.
-func (r *NestedBlockOrderRule) Fix(_ *sdk.Context, _ *hcl.File) ([]byte, error) {
-	return nil, nil
-}
-
 // OneLineAttributeSpacingRule ensures one-line attributes are grouped together.
 // This is a variant of attribute-group-spacing specifically for one-line vs block attributes.
 type OneLineAttributeSpacingRule struct{}
@@ -514,9 +509,4 @@ func (r *OneLineAttributeSpacingRule) checkBlock(ctx *sdk.Context, block *hclsyn
 	}
 
 	return findings
-}
-
-// Fix is a no-op for this rule as it provides informational suggestions.
-func (r *OneLineAttributeSpacingRule) Fix(_ *sdk.Context, _ *hcl.File) ([]byte, error) {
-	return nil, nil
 }

--- a/internal/engines/style/rules/block_organization_test.go
+++ b/internal/engines/style/rules/block_organization_test.go
@@ -427,12 +427,6 @@ func TestNestedBlockOrderRule(t *testing.T) {
 			assert.Len(t, findings, tt.wantFindings)
 		})
 	}
-
-	t.Run("Fix returns nil", func(t *testing.T) {
-		result, err := rule.Fix(nil, nil)
-		assert.NoError(t, err)
-		assert.Nil(t, result)
-	})
 }
 
 func TestOneLineAttributeSpacingRule(t *testing.T) {
@@ -509,10 +503,4 @@ func TestOneLineAttributeSpacingRule(t *testing.T) {
 			assert.Len(t, findings, tt.wantFindings)
 		})
 	}
-
-	t.Run("Fix returns nil", func(t *testing.T) {
-		result, err := rule.Fix(nil, nil)
-		assert.NoError(t, err)
-		assert.Nil(t, result)
-	})
 }

--- a/internal/engines/style/rules/comments.go
+++ b/internal/engines/style/rules/comments.go
@@ -298,11 +298,6 @@ func (r *ConsistentQuotesRule) hasSingleQuotedValue(line string) bool {
 	return false
 }
 
-// Fix is a no-op for this rule as quote style fixing is complex.
-func (r *ConsistentQuotesRule) Fix(_ *sdk.Context, _ *hcl.File) ([]byte, error) {
-	return nil, nil
-}
-
 // NoConsecutiveBlankLinesRule ensures no more than one consecutive blank line.
 type NoConsecutiveBlankLinesRule struct{}
 

--- a/internal/engines/style/rules/comments_test.go
+++ b/internal/engines/style/rules/comments_test.go
@@ -272,12 +272,6 @@ resource "aws_instance" "web" {
 			assert.Len(t, findings, tt.wantFindings)
 		})
 	}
-
-	t.Run("Fix returns nil", func(t *testing.T) {
-		result, err := rule.Fix(nil, nil)
-		assert.NoError(t, err)
-		assert.Nil(t, result)
-	})
 }
 
 func TestNoConsecutiveBlankLinesRule(t *testing.T) {

--- a/internal/engines/style/rules/file_structure.go
+++ b/internal/engines/style/rules/file_structure.go
@@ -142,11 +142,6 @@ func (r *ScopedFileOrganizationRule) getResourceScope(resourceType string) strin
 	return ""
 }
 
-// Fix is a no-op for this rule as moving resources between files requires manual review.
-func (r *ScopedFileOrganizationRule) Fix(_ *sdk.Context, _ *hcl.File) ([]byte, error) {
-	return nil, nil
-}
-
 // TerraformFilesStructureRule ensures standard file structure is followed.
 // Standard files: variables.tf, outputs.tf, providers.tf, versions.tf, main.tf, locals.tf
 type TerraformFilesStructureRule struct{}
@@ -228,9 +223,4 @@ func (r *TerraformFilesStructureRule) shouldSuggestStandardFile(blockType string
 		"provider": true,
 	}
 	return commonTypes[blockType]
-}
-
-// Fix is a no-op for this rule as moving blocks between files requires manual review.
-func (r *TerraformFilesStructureRule) Fix(_ *sdk.Context, _ *hcl.File) ([]byte, error) {
-	return nil, nil
 }

--- a/internal/engines/style/rules/file_structure_test.go
+++ b/internal/engines/style/rules/file_structure_test.go
@@ -152,12 +152,6 @@ resource "aws_vpc" "main" {
 			assert.Len(t, findings, tt.wantFindings)
 		})
 	}
-
-	t.Run("Fix returns nil", func(t *testing.T) {
-		result, err := rule.Fix(nil, nil)
-		assert.NoError(t, err)
-		assert.Nil(t, result)
-	})
 }
 
 func TestScopedFileOrganizationRule_GetFileScope(t *testing.T) {
@@ -411,12 +405,6 @@ func TestTerraformFilesStructureRule(t *testing.T) {
 			assert.Len(t, findings, tt.wantFindings)
 		})
 	}
-
-	t.Run("Fix returns nil", func(t *testing.T) {
-		result, err := rule.Fix(nil, nil)
-		assert.NoError(t, err)
-		assert.Nil(t, result)
-	})
 }
 
 func TestTerraformFilesStructureRule_FileExists(t *testing.T) {

--- a/internal/engines/style/rules/naming.go
+++ b/internal/engines/style/rules/naming.go
@@ -73,11 +73,6 @@ func (r *BlockLabelCaseRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Find
 	return findings, nil
 }
 
-// Fix is a no-op for this rule as block label renaming requires manual review.
-func (r *BlockLabelCaseRule) Fix(_ *sdk.Context, _ *hcl.File) ([]byte, error) {
-	return nil, nil
-}
-
 // VariableNamingRule ensures variable names follow naming conventions.
 type VariableNamingRule struct{}
 
@@ -126,11 +121,6 @@ func (r *VariableNamingRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Find
 	}
 
 	return findings, nil
-}
-
-// Fix is a no-op for this rule as renaming requires manual review.
-func (r *VariableNamingRule) Fix(_ *sdk.Context, _ *hcl.File) ([]byte, error) {
-	return nil, nil
 }
 
 // OutputNamingRule ensures output names follow naming conventions.
@@ -183,11 +173,6 @@ func (r *OutputNamingRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Findin
 	return findings, nil
 }
 
-// Fix is a no-op for this rule as renaming requires manual review.
-func (r *OutputNamingRule) Fix(_ *sdk.Context, _ *hcl.File) ([]byte, error) {
-	return nil, nil
-}
-
 // LocalNamingRule ensures local value names follow naming conventions.
 type LocalNamingRule struct{}
 
@@ -234,9 +219,4 @@ func (r *LocalNamingRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Finding
 	}
 
 	return findings, nil
-}
-
-// Fix is a no-op for this rule as renaming requires manual review.
-func (r *LocalNamingRule) Fix(_ *sdk.Context, _ *hcl.File) ([]byte, error) {
-	return nil, nil
 }

--- a/internal/engines/style/rules/naming_test.go
+++ b/internal/engines/style/rules/naming_test.go
@@ -97,12 +97,6 @@ func TestBlockLabelCaseRule(t *testing.T) {
 			assert.Len(t, findings, tt.wantFindings)
 		})
 	}
-
-	t.Run("Fix returns nil", func(t *testing.T) {
-		result, err := rule.Fix(nil, nil)
-		assert.NoError(t, err)
-		assert.Nil(t, result)
-	})
 }
 
 func TestVariableNamingRule(t *testing.T) {
@@ -164,12 +158,6 @@ func TestVariableNamingRule(t *testing.T) {
 			assert.Len(t, findings, tt.wantFindings)
 		})
 	}
-
-	t.Run("Fix returns nil", func(t *testing.T) {
-		result, err := rule.Fix(nil, nil)
-		assert.NoError(t, err)
-		assert.Nil(t, result)
-	})
 }
 
 func TestOutputNamingRule(t *testing.T) {
@@ -231,12 +219,6 @@ func TestOutputNamingRule(t *testing.T) {
 			assert.Len(t, findings, tt.wantFindings)
 		})
 	}
-
-	t.Run("Fix returns nil", func(t *testing.T) {
-		result, err := rule.Fix(nil, nil)
-		assert.NoError(t, err)
-		assert.Nil(t, result)
-	})
 }
 
 func TestLocalNamingRule(t *testing.T) {
@@ -300,12 +282,6 @@ func TestLocalNamingRule(t *testing.T) {
 			assert.Len(t, findings, tt.wantFindings)
 		})
 	}
-
-	t.Run("Fix returns nil", func(t *testing.T) {
-		result, err := rule.Fix(nil, nil)
-		assert.NoError(t, err)
-		assert.Nil(t, result)
-	})
 }
 
 // TestNamingRulesWithConfig tests naming rules with different naming conventions from config.

--- a/internal/engines/style/rules/organization.go
+++ b/internal/engines/style/rules/organization.go
@@ -56,11 +56,6 @@ func (r *VariablesInFileRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Fin
 	return findings, nil
 }
 
-// Fix is a no-op for this rule as moving blocks requires manual review.
-func (r *VariablesInFileRule) Fix(_ *sdk.Context, _ *hcl.File) ([]byte, error) {
-	return nil, nil
-}
-
 // OutputsInFileRule ensures outputs are defined in outputs.tf.
 type OutputsInFileRule struct{}
 
@@ -109,11 +104,6 @@ func (r *OutputsInFileRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Findi
 	return findings, nil
 }
 
-// Fix is a no-op for this rule as moving blocks requires manual review.
-func (r *OutputsInFileRule) Fix(_ *sdk.Context, _ *hcl.File) ([]byte, error) {
-	return nil, nil
-}
-
 // ProvidersInFileRule ensures providers are defined in providers.tf or versions.tf.
 type ProvidersInFileRule struct{}
 
@@ -160,9 +150,4 @@ func (r *ProvidersInFileRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Fin
 	}
 
 	return findings, nil
-}
-
-// Fix is a no-op for this rule as moving blocks requires manual review.
-func (r *ProvidersInFileRule) Fix(_ *sdk.Context, _ *hcl.File) ([]byte, error) {
-	return nil, nil
 }

--- a/internal/engines/style/rules/organization_test.go
+++ b/internal/engines/style/rules/organization_test.go
@@ -84,12 +84,6 @@ variable "var2" {
 			assert.Len(t, findings, tt.wantFindings)
 		})
 	}
-
-	t.Run("Fix returns nil", func(t *testing.T) {
-		result, err := rule.Fix(nil, nil)
-		assert.NoError(t, err)
-		assert.Nil(t, result)
-	})
 }
 
 func TestOutputsInFileRule(t *testing.T) {
@@ -152,12 +146,6 @@ func TestOutputsInFileRule(t *testing.T) {
 			assert.Len(t, findings, tt.wantFindings)
 		})
 	}
-
-	t.Run("Fix returns nil", func(t *testing.T) {
-		result, err := rule.Fix(nil, nil)
-		assert.NoError(t, err)
-		assert.Nil(t, result)
-	})
 }
 
 func TestProvidersInFileRule(t *testing.T) {
@@ -228,10 +216,4 @@ func TestProvidersInFileRule(t *testing.T) {
 			assert.Len(t, findings, tt.wantFindings)
 		})
 	}
-
-	t.Run("Fix returns nil", func(t *testing.T) {
-		result, err := rule.Fix(nil, nil)
-		assert.NoError(t, err)
-		assert.Nil(t, result)
-	})
 }

--- a/internal/engines/style/rules/spacing.go
+++ b/internal/engines/style/rules/spacing.go
@@ -442,8 +442,3 @@ func (r *NoEmptyBlocksRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Findi
 
 	return findings, nil
 }
-
-// Fix is a no-op for this rule as empty blocks require manual review.
-func (r *NoEmptyBlocksRule) Fix(_ *sdk.Context, _ *hcl.File) ([]byte, error) {
-	return nil, nil
-}

--- a/internal/engines/style/rules/spacing_test.go
+++ b/internal/engines/style/rules/spacing_test.go
@@ -296,12 +296,6 @@ func TestNoEmptyBlocksRule(t *testing.T) {
 			assert.Len(t, findings, tt.wantFindings)
 		})
 	}
-
-	t.Run("Fix returns nil", func(t *testing.T) {
-		result, err := rule.Fix(nil, nil)
-		assert.NoError(t, err)
-		assert.Nil(t, result)
-	})
 }
 
 func TestBlankLineBetweenBlocksRule_FixMultipleConsecutiveBlanks(t *testing.T) {


### PR DESCRIPTION
## What and why

Removes 16 no-op `Fix()` methods (`return nil, nil`) from style rules that never actually implemented auto-fix, plus the matching tautological `Fix returns nil` subtests. Net diff: 14 files, **-176 lines**.

Affected rules:

- `naming.go`: BlockLabelCase, VariableNaming, OutputNaming, LocalNaming
- `advanced_naming.go`: ResourceNameMatchesType, OutputPrefix, ModuleNameConvention
- `organization.go`: VariablesInFile, OutputsInFile, ProvidersInFile
- `file_structure.go`: ScopedFileOrganization, TerraformFilesStructure
- `block_organization.go`: NestedBlockOrder, OneLineAttributeSpacing
- `comments.go`: ConsistentQuotes
- `spacing.go`: NoEmptyBlocks

**Why:** Before #140 / #141, every rule was forced to satisfy `sdk.Fixer` even if it had nothing to fix, so 16 rules carried stub bodies. After those refactors, the engine type-asserts `rule.(sdk.Fixer)` at `internal/engines/style/style.go:208` and stamps `Fixable=true` only for real fixers — the stubs are now dead weight. Deleting them lets the rule types drop the interface, removes a class of bugs ("forgot to stamp the sentinel"), and shrinks the rule files by their no-op surface.

## How to test

```bash
mise run check          # fmt + vet + lint + test (passes locally; lint 0 issues)
mise run test           # all rule tests + engine dispatch tests
```

The behavioral guarantee is already covered by `TestEngineDispatch_NonFixerFindingsHaveNilFix` in `internal/engines/style/style_coverage_test.go:258`, which verifies the engine forces `Fixable=false` for findings from non-`Fixer` rules.

## Notes for reviewers

- Pure deletion. No production code change beyond removing the stub bodies.
- The deleted subtests were tautological: `rule.Fix(nil, nil)` of a `return nil, nil` stub asserted to return `nil, nil`. They could not have caught any real bug.
- `MetaArgumentsOrderRule.Check()` was confirmed not in the precompute group — its real `Fix()` remains the only fix path.
- Validated by tt-reviewer (no orphaned tests, no external references), tt-engines (dispatch model correct, output layer uses `Fixable bool`), and tt-tests (no detection-path coverage lost).
- Part of the `.plans/fmt-style-polish.md` Phase 1 cleanup. Next on that plan: hash-based fixed-point detection in the multi-pass loop, in a separate PR.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works (existing engine dispatch tests cover the behavior)
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test)
- [x] I have updated documentation as needed (no public docs reference the removed stubs)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
