### PR TITLE
feat(style): detect fix loops via content hashing

### DIFF
--- a/internal/engines/style/style.go
+++ b/internal/engines/style/style.go
@@ -4,6 +4,7 @@ package style
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"os"
 
@@ -140,14 +141,43 @@ func (e *Engine) checkFile(path string) ([]sdk.Finding, error) {
 
 	var allFindings []sdk.Finding
 	var suppressions []annotations.Suppression
-	maxPasses := 10 // Limit passes to prevent infinite loops (enough for typical ordering + spacing fixes)
+	// Hash-based fixed-point detection. The set of pre-fix file states we have
+	// seen during this checkFile invocation. If a later pass reads content whose
+	// hash is already in this set, we have cycled back to a state we have been
+	// in before — typically a rule whose Fix() re-triggers its own finding, or
+	// two rules ping-ponging the same content. Aborting on the cycle is the
+	// right behavior: we emit a style.fix-loop error finding instead of either
+	// silently truncating (the old 10-pass cap) or looping forever.
+	seenHashes := make(map[[sha256.Size]byte]struct{})
+	var lastAppliedRule string
 
-	for pass := 0; pass < maxPasses; pass++ {
+	for pass := 0; ; pass++ {
 		// Always read fresh content for each pass
 		content, err := os.ReadFile(path)
 		if err != nil {
 			return nil, fmt.Errorf("reading file: %w", err)
 		}
+
+		contentHash := sha256.Sum256(content)
+		if _, seen := seenHashes[contentHash]; seen {
+			// The hash check runs before applying a fix this pass, so a repeat
+			// implies that at least one prior pass applied a fix — therefore
+			// lastAppliedRule is always populated when this branch fires.
+			allFindings = append(allFindings, sdk.Finding{
+				Rule: "style.fix-loop",
+				Message: fmt.Sprintf(
+					"fix loop detected: applying %q reproduced a previously-seen file state. "+
+						"This is the last rule applied before the cycle was detected; another "+
+						"rule may also be involved in a ping-pong cycle. Aborting to avoid an "+
+						"infinite fix loop.",
+					lastAppliedRule,
+				),
+				File:     path,
+				Severity: sdk.SeverityError,
+			})
+			break
+		}
+		seenHashes[contentHash] = struct{}{}
 
 		// Parse suppression annotations on first pass
 		if pass == 0 {
@@ -180,37 +210,9 @@ func (e *Engine) checkFile(path string) ([]sdk.Finding, error) {
 			}}, nil
 		}
 
-		// Run all enabled rules
-		var findings []sdk.Finding
-		for _, rule := range e.rules {
-			ruleConfig := e.getRuleConfig(rule.Name())
-			if !ruleConfig.IsEnabled(true) { // Default enabled if not explicitly set
-				continue
-			}
-
-			ruleCtx.Options = ruleConfig.Options
-
-			ruleFindings, err := rule.Check(ruleCtx, file)
-			if err != nil {
-				return nil, fmt.Errorf("rule %s: %w", rule.Name(), err)
-			}
-
-			// Apply severity override from config if specified
-			if ruleConfig.Severity != "" {
-				for i := range ruleFindings {
-					ruleFindings[i].Severity = sdk.ParseSeverity(ruleConfig.Severity, ruleFindings[i].Severity)
-				}
-			}
-
-			// Stamp Fixable: engine owns the signal, not the rule. Set true for Fixer
-			// rules (engine dispatches to Fixer.Fix(ctx, file) lazily in applyFixes);
-			// false otherwise, regardless of what the rule may have set.
-			_, isFixer := rule.(sdk.Fixer)
-			for i := range ruleFindings {
-				ruleFindings[i].Fixable = isFixer
-			}
-
-			findings = append(findings, ruleFindings...)
+		findings, err := e.runEnabledRules(ruleCtx, file)
+		if err != nil {
+			return nil, err
 		}
 
 		// On first pass, collect all findings for reporting
@@ -222,13 +224,14 @@ func (e *Engine) checkFile(path string) ([]sdk.Finding, error) {
 		// In fix mode or diff preview mode, apply fixes and potentially loop for another pass
 		// When Diff=true with Fix=false, we still apply fixes to generate preview diff
 		if (e.config.Fix || e.config.Diff) && len(findings) > 0 {
-			fixedCount, err := e.applyFixes(ruleCtx, file, findings)
+			appliedRule, err := e.applyFixes(ruleCtx, file, findings)
 			if err != nil {
 				return nil, fmt.Errorf("applying fixes: %w", err)
 			}
 
-			// If we applied fixes, continue to next pass to catch any new issues
-			if fixedCount > 0 {
+			// If we applied a fix, loop again to catch any new issues
+			if appliedRule != "" {
+				lastAppliedRule = appliedRule
 				continue
 			}
 		}
@@ -258,6 +261,43 @@ func (e *Engine) checkFile(path string) ([]sdk.Finding, error) {
 	}
 
 	return allFindings, nil
+}
+
+// runEnabledRules invokes Check() on every enabled rule against the parsed file
+// and returns the aggregated findings. It applies the per-rule severity override
+// from config and stamps Fixable based on whether the rule implements sdk.Fixer.
+func (e *Engine) runEnabledRules(ruleCtx *sdk.Context, file *hcl.File) ([]sdk.Finding, error) {
+	var findings []sdk.Finding
+	for _, rule := range e.rules {
+		ruleConfig := e.getRuleConfig(rule.Name())
+		if !ruleConfig.IsEnabled(true) { // Default enabled if not explicitly set
+			continue
+		}
+
+		ruleCtx.Options = ruleConfig.Options
+
+		ruleFindings, err := rule.Check(ruleCtx, file)
+		if err != nil {
+			return nil, fmt.Errorf("rule %s: %w", rule.Name(), err)
+		}
+
+		if ruleConfig.Severity != "" {
+			for i := range ruleFindings {
+				ruleFindings[i].Severity = sdk.ParseSeverity(ruleConfig.Severity, ruleFindings[i].Severity)
+			}
+		}
+
+		// Stamp Fixable: engine owns the signal, not the rule. Set true for Fixer
+		// rules (engine dispatches to Fixer.Fix(ctx, file) lazily in applyFixes);
+		// false otherwise, regardless of what the rule may have set.
+		_, isFixer := rule.(sdk.Fixer)
+		for i := range ruleFindings {
+			ruleFindings[i].Fixable = isFixer
+		}
+
+		findings = append(findings, ruleFindings...)
+	}
+	return findings, nil
 }
 
 // generateDiff creates a diff finding comparing original content with the current file.
@@ -295,17 +335,19 @@ func (e *Engine) generateDiff(path string, originalContent []byte) (*sdk.Finding
 }
 
 // applyFixes applies ONE auto-fix to the file per pass.
-// Returns the number of fixes applied (0 or 1).
+// Returns the name of the rule whose fix was applied, or "" if no fix ran.
 //
 // Dispatch: for each finding marked Fixable, look up the originating rule by name
 // and invoke its Fixer.Fix(ctx, file) method. The first non-nil byte content
-// returned wins; it is written to disk and the loop returns 1. The multi-pass
-// loop in Run will re-read the file and re-run rules after each fix, ensuring
-// subsequent fixes are computed against the updated content.
+// returned wins; it is written to disk and the rule name is returned. The
+// multi-pass loop in checkFile re-reads the file and re-runs rules after each
+// fix, so subsequent fixes are computed against the updated content.
 //
-// Note: rules' Fix() methods are responsible for idempotence — if Fix(Fix(x)) != Fix(x),
-// the multi-pass loop will keep applying fixes until the loop guard fires.
-func (e *Engine) applyFixes(ctx *sdk.Context, file *hcl.File, findings []sdk.Finding) (int, error) {
+// Note: each rule's Fix() must converge — repeated applications must eventually
+// reach a fixed point. If the file returns to a previously-seen state, the
+// multi-pass loop's hash-based cycle detector fires and emits a style.fix-loop
+// error finding instead of looping forever.
+func (e *Engine) applyFixes(ctx *sdk.Context, file *hcl.File, findings []sdk.Finding) (string, error) {
 	for i := range findings {
 		if !findings[i].Fixable {
 			continue
@@ -318,19 +360,19 @@ func (e *Engine) applyFixes(ctx *sdk.Context, file *hcl.File, findings []sdk.Fin
 
 		content, err := fixer.Fix(ctx, file)
 		if err != nil {
-			return 0, fmt.Errorf("computing fix for %s: %w", findings[i].Rule, err)
+			return "", fmt.Errorf("computing fix for %s: %w", findings[i].Rule, err)
 		}
 		if content == nil {
 			continue
 		}
 
 		if err := os.WriteFile(ctx.File, content, 0o600); err != nil {
-			return 0, fmt.Errorf("writing fix for %s: %w", findings[i].Rule, err)
+			return "", fmt.Errorf("writing fix for %s: %w", findings[i].Rule, err)
 		}
-		return 1, nil
+		return findings[i].Rule, nil
 	}
 
-	return 0, nil
+	return "", nil
 }
 
 // findFixerByRuleName returns the rule registered under the given name as an

--- a/internal/engines/style/style_coverage_test.go
+++ b/internal/engines/style/style_coverage_test.go
@@ -2,8 +2,10 @@ package style
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
@@ -522,4 +524,243 @@ resource "aws_instance" "test2" {
 	for _, f := range findings {
 		assert.NotEqual(t, "style.diff", f.Rule, "no diff finding expected when file has no issues")
 	}
+}
+
+// stubMarkerRemoverRule reports one finding per "# REMOVE_ME" comment in the file
+// and removes a single marker on each Fix() call. Used to verify that the
+// multi-pass loop converges past the old 10-pass cap.
+type stubMarkerRemoverRule struct{}
+
+func (r *stubMarkerRemoverRule) Name() string { return "test.stub-marker-remover" }
+func (r *stubMarkerRemoverRule) Description() string {
+	return "Removes one REMOVE_ME comment per Fix call"
+}
+
+func (r *stubMarkerRemoverRule) Check(ctx *sdk.Context, _ *hcl.File) ([]sdk.Finding, error) {
+	content, err := os.ReadFile(ctx.File)
+	if err != nil {
+		return nil, err
+	}
+	var findings []sdk.Finding
+	for i, line := range strings.Split(string(content), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "# REMOVE_ME") {
+			findings = append(findings, sdk.Finding{
+				Rule:     r.Name(),
+				Message:  fmt.Sprintf("REMOVE_ME marker on line %d", i+1),
+				File:     ctx.File,
+				Location: sdk.Location{StartLine: i + 1, EndLine: i + 1},
+				Severity: sdk.SeverityWarning,
+			})
+		}
+	}
+	return findings, nil
+}
+
+func (r *stubMarkerRemoverRule) Fix(ctx *sdk.Context, _ *hcl.File) ([]byte, error) {
+	content, err := os.ReadFile(ctx.File)
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Split(string(content), "\n")
+	for i, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "# REMOVE_ME") {
+			out := append([]string{}, lines[:i]...)
+			out = append(out, lines[i+1:]...)
+			return []byte(strings.Join(out, "\n")), nil
+		}
+	}
+	return nil, nil
+}
+
+// TestCheckFile_ConvergesBeyond10Passes verifies that the multi-pass fix loop no
+// longer truncates at 10 passes. We seed a file with 12 markers and let the stub
+// rule remove one per pass; convergence proves the old `maxPasses := 10` cap is
+// gone and replaced by hash-based fixed-point detection.
+func TestCheckFile_ConvergesBeyond10Passes(t *testing.T) {
+	dir := t.TempDir()
+	const markerCount = 12
+	var b strings.Builder
+	for i := 1; i <= markerCount; i++ {
+		fmt.Fprintf(&b, "# REMOVE_ME %d\n", i)
+	}
+	b.WriteString("resource \"aws_instance\" \"test\" {\n  ami = \"ami-x\"\n}\n")
+	tmpFile := filepath.Join(dir, "many_passes.tf")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(b.String()), 0o644))
+
+	engine := New(&Config{
+		Fix:   true,
+		Rules: make(map[string]RuleConfig),
+	}, &stubMarkerRemoverRule{})
+
+	_, err := engine.Run(context.Background(), []string{tmpFile})
+	require.NoError(t, err)
+
+	// All 12 markers must be gone — proves the loop ran more than 10 passes.
+	final, err := os.ReadFile(tmpFile)
+	require.NoError(t, err)
+	assert.NotContains(t, string(final), "REMOVE_ME",
+		"all markers should be removed, proving the multi-pass loop ran past the old 10-pass cap")
+}
+
+// stubSelfTriggeringFixerRule always reports a finding and its Fix() returns the
+// file content unchanged. The hash-based fix-loop guard must detect this self-loop.
+type stubSelfTriggeringFixerRule struct{}
+
+func (r *stubSelfTriggeringFixerRule) Name() string        { return "test.stub-self-trigger" }
+func (r *stubSelfTriggeringFixerRule) Description() string { return "Always reports, Fix is a no-op" }
+
+func (r *stubSelfTriggeringFixerRule) Check(ctx *sdk.Context, _ *hcl.File) ([]sdk.Finding, error) {
+	return []sdk.Finding{{
+		Rule:     r.Name(),
+		Message:  "always reports",
+		File:     ctx.File,
+		Severity: sdk.SeverityWarning,
+	}}, nil
+}
+
+func (r *stubSelfTriggeringFixerRule) Fix(ctx *sdk.Context, _ *hcl.File) ([]byte, error) {
+	// Return content unchanged: the rule's Check() will keep reporting the same
+	// finding on the next pass, which is exactly the self-loop pattern the
+	// hash-based guard exists to catch.
+	return os.ReadFile(ctx.File)
+}
+
+// TestCheckFile_FixLoopGuard_DetectsSelfLoop verifies that a rule whose Fix()
+// re-triggers its own finding (here, by returning unchanged content) causes the
+// engine to emit a single style.fix-loop error finding naming the offending rule
+// and abort the multi-pass loop instead of looping forever.
+func TestCheckFile_FixLoopGuard_DetectsSelfLoop(t *testing.T) {
+	dir := t.TempDir()
+	// Plain file with no built-in rule fixes available — the stub is the only
+	// fixer the engine will dispatch to.
+	content := `resource "aws_instance" "test" {
+  ami = "ami-x"
+}
+`
+	tmpFile := filepath.Join(dir, "self_loop.tf")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+
+	engine := New(&Config{
+		Fix:   true,
+		Rules: make(map[string]RuleConfig),
+	}, &stubSelfTriggeringFixerRule{})
+
+	findings, err := engine.Run(context.Background(), []string{tmpFile})
+	require.NoError(t, err, "self-loop must terminate cleanly, not error or hang")
+
+	var loopFinding *sdk.Finding
+	for i := range findings {
+		if findings[i].Rule == "style.fix-loop" {
+			loopFinding = &findings[i]
+			break
+		}
+	}
+	require.NotNil(t, loopFinding, "engine must emit a style.fix-loop finding when a fix cycles")
+	assert.Equal(t, sdk.SeverityError, loopFinding.Severity,
+		"fix-loop finding must be an error, not a warning")
+	assert.Contains(t, loopFinding.Message, "test.stub-self-trigger",
+		"fix-loop message must name the rule that caused the loop")
+}
+
+// stubSwapRuleAToB rewrites PING_A → PING_B. Paired with stubSwapRuleBToA, the
+// two rules form a deterministic ping-pong cycle: one rule fires per pass, each
+// undoing the other.
+type stubSwapRuleAToB struct{}
+
+func (r *stubSwapRuleAToB) Name() string        { return "test.stub-swap-a-to-b" }
+func (r *stubSwapRuleAToB) Description() string { return "Rewrites PING_A to PING_B" }
+
+func (r *stubSwapRuleAToB) Check(ctx *sdk.Context, _ *hcl.File) ([]sdk.Finding, error) {
+	content, err := os.ReadFile(ctx.File)
+	if err != nil {
+		return nil, err
+	}
+	if !strings.Contains(string(content), "PING_A") {
+		return nil, nil
+	}
+	return []sdk.Finding{{
+		Rule:     r.Name(),
+		Message:  "PING_A present",
+		File:     ctx.File,
+		Severity: sdk.SeverityWarning,
+	}}, nil
+}
+
+func (r *stubSwapRuleAToB) Fix(ctx *sdk.Context, _ *hcl.File) ([]byte, error) {
+	content, err := os.ReadFile(ctx.File)
+	if err != nil {
+		return nil, err
+	}
+	return []byte(strings.Replace(string(content), "PING_A", "PING_B", 1)), nil
+}
+
+// stubSwapRuleBToA mirrors stubSwapRuleAToB in the opposite direction.
+type stubSwapRuleBToA struct{}
+
+func (r *stubSwapRuleBToA) Name() string        { return "test.stub-swap-b-to-a" }
+func (r *stubSwapRuleBToA) Description() string { return "Rewrites PING_B to PING_A" }
+
+func (r *stubSwapRuleBToA) Check(ctx *sdk.Context, _ *hcl.File) ([]sdk.Finding, error) {
+	content, err := os.ReadFile(ctx.File)
+	if err != nil {
+		return nil, err
+	}
+	if !strings.Contains(string(content), "PING_B") {
+		return nil, nil
+	}
+	return []sdk.Finding{{
+		Rule:     r.Name(),
+		Message:  "PING_B present",
+		File:     ctx.File,
+		Severity: sdk.SeverityWarning,
+	}}, nil
+}
+
+func (r *stubSwapRuleBToA) Fix(ctx *sdk.Context, _ *hcl.File) ([]byte, error) {
+	content, err := os.ReadFile(ctx.File)
+	if err != nil {
+		return nil, err
+	}
+	return []byte(strings.Replace(string(content), "PING_B", "PING_A", 1)), nil
+}
+
+// TestCheckFile_FixLoopGuard_DetectsPingPong verifies that the hash-based guard
+// fires on a two-rule ping-pong cycle (rule A undoes rule B and vice versa) the
+// same way it fires on a single-rule self-loop. The fix-loop finding's message
+// must name one of the cycling rules — specifically the last rule that applied
+// a fix before the cycle was detected.
+func TestCheckFile_FixLoopGuard_DetectsPingPong(t *testing.T) {
+	dir := t.TempDir()
+	content := `# PING_A
+resource "aws_instance" "test" {
+  ami = "ami-x"
+}
+`
+	tmpFile := filepath.Join(dir, "ping_pong.tf")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+
+	engine := New(&Config{
+		Fix:   true,
+		Rules: make(map[string]RuleConfig),
+	}, &stubSwapRuleAToB{}, &stubSwapRuleBToA{})
+
+	findings, err := engine.Run(context.Background(), []string{tmpFile})
+	require.NoError(t, err, "ping-pong cycle must terminate cleanly")
+
+	var loopFinding *sdk.Finding
+	for i := range findings {
+		if findings[i].Rule == "style.fix-loop" {
+			loopFinding = &findings[i]
+			break
+		}
+	}
+	require.NotNil(t, loopFinding, "ping-pong cycle must produce a style.fix-loop finding")
+	assert.Equal(t, sdk.SeverityError, loopFinding.Severity)
+	// lastAppliedRule names whichever rule fired most recently before the
+	// cycle was detected. Either is acceptable; the test asserts only that
+	// the message names one of the two cycling rules.
+	matches := strings.Contains(loopFinding.Message, "test.stub-swap-a-to-b") ||
+		strings.Contains(loopFinding.Message, "test.stub-swap-b-to-a")
+	assert.True(t, matches, "fix-loop message must name one of the cycling rules; got: %s",
+		loopFinding.Message)
 }


### PR DESCRIPTION
## What and why

Replace the silent 10-pass cap in the multi-pass style fix loop with hash-based fixed-point detection. Each pass hashes pre-fix content; if a hash repeats, the engine emits a `style.fix-loop` error finding (naming the last-applied rule) and aborts.

**Why:** The hard 10-pass cap had two failure modes: (1) files that legitimately need more than 10 fixes were silently truncated, and (2) two rules ping-ponging the same content would loop until the cap and produce no signal about why. Hash-based detection converges naturally on legitimate cases and surfaces actual cycles as a diagnosable finding instead of hiding them.

## How to test

- `mise run test` (covers new `style_coverage_test.go` cases for the cycle path and the convergence path)
- `mise run check` (fmt + vet + lint + test)

## Notes for reviewers

- The cycle check runs before applying a fix on each pass, so when the loop-detection branch fires `lastAppliedRule` is guaranteed populated (a repeat hash implies a prior pass applied a fix).
- The pass loop is now unbounded; correctness relies on the hash set being monotonic. Memory grows with the number of distinct intermediate states, which is bounded by the number of rules in practice.
- Rule extraction into `runEnabledRules` is incidental — it was getting cramped inside the pass loop.
- This is a stepping stone toward a larger redesign where rule fixes return byte-range edits (`[]TextEdit`) instead of whole-file bytes, letting the engine apply non-conflicting fixes in a single pass and skip the re-read/re-parse cycle. That work is out of scope here; this PR makes the current multi-pass model safe and observable in the meantime.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
