### PR TITLE
feat(engines): preserve original file permissions on fmt and style writes

### DIFF
--- a/internal/engines/format/fmt.go
+++ b/internal/engines/format/fmt.go
@@ -135,8 +135,9 @@ func (e *Engine) formatFile(path string) (*sdk.Finding, error) {
 		}, nil
 	}
 
-	// In normal mode, write the formatted content
-	if err := os.WriteFile(path, formatted, 0o600); err != nil {
+	// In normal mode, write the formatted content while preserving the file's
+	// existing permission bits. Fall back to 0o600 if Stat fails.
+	if err := writeFilePreservingMode(path, formatted); err != nil {
 		return nil, fmt.Errorf("writing formatted file: %w", err)
 	}
 
@@ -161,4 +162,20 @@ func isHCLFile(path string) bool {
 // Format formats the given content and returns the formatted result
 func Format(content []byte) []byte {
 	return hclwrite.Format(content)
+}
+
+// writeFilePreservingMode writes content to path, preserving the file's
+// existing permission bits. If Stat fails (e.g., a concurrent modification or
+// permissions issue), it falls back to mode 0o600. A trailing Chmod ensures
+// the captured mode wins even on the rare path where WriteFile recreates the
+// file (and any umask would otherwise apply).
+func writeFilePreservingMode(path string, content []byte) error {
+	mode := os.FileMode(0o600)
+	if info, err := os.Stat(path); err == nil {
+		mode = info.Mode().Perm()
+	}
+	if err := os.WriteFile(path, content, mode); err != nil {
+		return err
+	}
+	return os.Chmod(path, mode)
 }

--- a/internal/engines/format/fmt_test.go
+++ b/internal/engines/format/fmt_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/santosr2/TerraTidy/internal/config"
@@ -271,6 +272,36 @@ ami="ami-12345678"
 			}
 		})
 	}
+}
+
+// TestEngine_PreservesFileMode verifies that running fmt on a file with a
+// non-default permission mode (0o755) does not change the mode after the
+// formatted bytes are written back. Skipped on Windows where Unix-style
+// permission bits don't apply.
+func TestEngine_PreservesFileMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-style file permissions don't apply on Windows")
+	}
+
+	unformatted := `resource "aws_instance" "example" {
+ami="ami-12345678"
+}
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "test.tf")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(unformatted), 0o755))
+	require.NoError(t, os.Chmod(tmpFile, 0o755), "ensure mode is set even if umask altered WriteFile's perm")
+
+	engine := New(&Config{})
+	findings, err := engine.Run(context.Background(), []string{tmpFile})
+	require.NoError(t, err)
+	require.Len(t, findings, 1, "unformatted file should produce a finding")
+	assert.Equal(t, "fmt.formatted", findings[0].Rule)
+
+	info, err := os.Stat(tmpFile)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o755), info.Mode().Perm(),
+		"fmt must preserve original file mode after writing formatted content")
 }
 
 // TestEngine_IsDiff_NoFinding_AlreadyFormatted verifies that an already-formatted

--- a/internal/engines/format/fmt_test.go
+++ b/internal/engines/format/fmt_test.go
@@ -304,6 +304,37 @@ ami="ami-12345678"
 		"fmt must preserve original file mode after writing formatted content")
 }
 
+// TestEngine_WriteFileError verifies that a write failure during formatting
+// surfaces as an error from Engine.Run. Setup: a read-only fixture (0o400) lets
+// ReadFile succeed (owner has read) but causes os.WriteFile to fail with
+// EACCES, exercising the error branches in writeFilePreservingMode and the
+// outer formatFile wrapper. Skipped on Windows and when running as root, where
+// mode-based access control does not apply.
+func TestEngine_WriteFileError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-style file permissions don't apply on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses mode-based access control")
+	}
+
+	unformatted := `resource "aws_instance" "example" {
+ami="ami-12345678"
+}
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "test.tf")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(unformatted), 0o644))
+	require.NoError(t, os.Chmod(tmpFile, 0o400), "make file read-only so WriteFile fails")
+
+	engine := New(&Config{})
+	findings, err := engine.Run(context.Background(), []string{tmpFile})
+	require.Error(t, err, "expected error from read-only file write")
+	assert.Contains(t, err.Error(), "writing formatted file",
+		"error should be wrapped with the write context")
+	assert.Empty(t, findings, "no findings should be returned on write failure")
+}
+
 // TestEngine_IsDiff_NoFinding_AlreadyFormatted verifies that an already-formatted
 // file produces no finding at all (so IsDiff doesn't even apply). Guards against
 // a regression where the engine might emit a stub finding with IsDiff=false.

--- a/internal/engines/style/style.go
+++ b/internal/engines/style/style.go
@@ -128,6 +128,14 @@ func (e *Engine) checkFile(path string) ([]sdk.Finding, error) {
 		File:    path,
 	}
 
+	// Capture the original file mode once. All write paths below (preview
+	// restore and per-pass fix apply) honor it. Falls back to 0o600 if Stat
+	// fails so we still produce a sensibly-permissioned file.
+	mode := os.FileMode(0o600)
+	if info, err := os.Stat(path); err == nil {
+		mode = info.Mode().Perm()
+	}
+
 	// Capture original content before any fixes for diff generation
 	// When Diff=true, we capture content regardless of Fix flag to support preview mode
 	var originalContent []byte
@@ -224,7 +232,7 @@ func (e *Engine) checkFile(path string) ([]sdk.Finding, error) {
 		// In fix mode or diff preview mode, apply fixes and potentially loop for another pass
 		// When Diff=true with Fix=false, we still apply fixes to generate preview diff
 		if (e.config.Fix || e.config.Diff) && len(findings) > 0 {
-			appliedRule, err := e.applyFixes(ruleCtx, file, findings)
+			appliedRule, err := e.applyFixes(ruleCtx, file, findings, mode)
 			if err != nil {
 				return nil, fmt.Errorf("applying fixes: %w", err)
 			}
@@ -246,8 +254,11 @@ func (e *Engine) checkFile(path string) ([]sdk.Finding, error) {
 		// even if diff generation fails - the preview contract guarantees no file changes
 		if !e.config.Fix {
 			defer func() {
-				// Restore is best-effort in defer; primary error takes precedence
-				_ = os.WriteFile(path, originalContent, 0o600)
+				// Errors are silent by design: the preview contract prefers
+				// returning the diff finding over surfacing restore failures.
+				// Both calls preserve the captured original mode.
+				_ = os.WriteFile(path, originalContent, mode)
+				_ = os.Chmod(path, mode)
 			}()
 		}
 
@@ -348,7 +359,7 @@ func (e *Engine) generateDiff(path string, originalContent []byte) (*sdk.Finding
 // reach a fixed point. If the file returns to a previously-seen state, the
 // multi-pass loop's hash-based cycle detector fires and emits a style.fix-loop
 // error finding instead of looping forever.
-func (e *Engine) applyFixes(ctx *sdk.Context, file *hcl.File, findings []sdk.Finding) (string, error) {
+func (e *Engine) applyFixes(ctx *sdk.Context, file *hcl.File, findings []sdk.Finding, mode os.FileMode) (string, error) {
 	for i := range findings {
 		if !findings[i].Fixable {
 			continue
@@ -367,8 +378,13 @@ func (e *Engine) applyFixes(ctx *sdk.Context, file *hcl.File, findings []sdk.Fin
 			continue
 		}
 
-		if err := os.WriteFile(ctx.File, content, 0o600); err != nil {
+		if err := os.WriteFile(ctx.File, content, mode); err != nil {
 			return "", fmt.Errorf("writing fix for %s: %w", findings[i].Rule, err)
+		}
+		// Defensive Chmod: WriteFile preserves mode on truncation, but if the
+		// file was recreated for any reason, ensure original mode wins over umask.
+		if err := os.Chmod(ctx.File, mode); err != nil {
+			return "", fmt.Errorf("restoring mode after fix for %s: %w", findings[i].Rule, err)
 		}
 		return findings[i].Rule, nil
 	}

--- a/internal/engines/style/style_test.go
+++ b/internal/engines/style/style_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -1307,4 +1308,77 @@ module "second" {
 		require.NoError(t, err)
 		assert.Empty(t, findings, "should have no issues after fix")
 	})
+}
+
+// TestEngine_PreservesFileMode_OnFix verifies that the per-pass fix-apply path
+// preserves the file's original permission mode after writing fixed content.
+// Skipped on Windows where Unix-style permission bits don't apply.
+func TestEngine_PreservesFileMode_OnFix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-style file permissions don't apply on Windows")
+	}
+
+	// Two adjacent blocks lacking a blank-line separator triggers a fixable
+	// style finding. We need a fix to actually run so the WriteFile path is
+	// exercised.
+	content := `resource "aws_instance" "test1" {
+  ami = "ami-123"
+}
+resource "aws_instance" "test2" {
+  ami = "ami-456"
+}
+`
+	dir := t.TempDir()
+	tmpFile := filepath.Join(dir, "test.tf")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o755))
+	require.NoError(t, os.Chmod(tmpFile, 0o755), "ensure mode is set even if umask altered WriteFile's perm")
+
+	engine := New(&Config{Fix: true, Rules: make(map[string]RuleConfig)})
+	_, err := engine.Run(context.Background(), []string{tmpFile})
+	require.NoError(t, err)
+
+	modified, err := os.ReadFile(tmpFile)
+	require.NoError(t, err)
+	require.NotEqual(t, content, string(modified), "test precondition: fix must have actually modified the file")
+
+	info, err := os.Stat(tmpFile)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o755), info.Mode().Perm(),
+		"style fix must preserve original file mode after writing fixed content")
+}
+
+// TestEngine_PreservesFileMode_OnDiffPreviewRestore verifies that diff preview
+// mode (Diff=true, Fix=false) restores the file to its original content AND
+// preserves the original permission mode after applying-then-restoring.
+// Skipped on Windows.
+func TestEngine_PreservesFileMode_OnDiffPreviewRestore(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-style file permissions don't apply on Windows")
+	}
+
+	content := `resource "aws_instance" "test1" {
+  ami = "ami-123"
+}
+resource "aws_instance" "test2" {
+  ami = "ami-456"
+}
+`
+	dir := t.TempDir()
+	tmpFile := filepath.Join(dir, "test.tf")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o755))
+	require.NoError(t, os.Chmod(tmpFile, 0o755), "ensure mode is set even if umask altered WriteFile's perm")
+
+	engine := New(&Config{Fix: false, Diff: true, Rules: make(map[string]RuleConfig)})
+	_, err := engine.Run(context.Background(), []string{tmpFile})
+	require.NoError(t, err)
+
+	// Preview contract: file content unchanged after run.
+	restored, err := os.ReadFile(tmpFile)
+	require.NoError(t, err)
+	assert.Equal(t, content, string(restored), "diff preview must leave file content unchanged")
+
+	info, err := os.Stat(tmpFile)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o755), info.Mode().Perm(),
+		"diff preview restore must preserve original file mode")
 }

--- a/internal/engines/style/style_test.go
+++ b/internal/engines/style/style_test.go
@@ -1382,3 +1382,37 @@ resource "aws_instance" "test2" {
 	assert.Equal(t, os.FileMode(0o755), info.Mode().Perm(),
 		"diff preview restore must preserve original file mode")
 }
+
+// TestEngine_WriteFileError verifies that a write failure during fix-apply
+// surfaces as an error from Engine.Run. Setup: a read-only fixture (0o400)
+// lets ReadFile succeed (owner has read) and the rules detect a fixable
+// finding, but os.WriteFile in applyFixes fails with EACCES, exercising the
+// "writing fix" error branch. Skipped on Windows and when running as root,
+// where mode-based access control does not apply.
+func TestEngine_WriteFileError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-style file permissions don't apply on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses mode-based access control")
+	}
+
+	// Two adjacent blocks → fixable style finding → applyFixes runs.
+	content := `resource "aws_instance" "test1" {
+  ami = "ami-123"
+}
+resource "aws_instance" "test2" {
+  ami = "ami-456"
+}
+`
+	dir := t.TempDir()
+	tmpFile := filepath.Join(dir, "test.tf")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+	require.NoError(t, os.Chmod(tmpFile, 0o400), "make file read-only so WriteFile fails")
+
+	engine := New(&Config{Fix: true, Rules: make(map[string]RuleConfig)})
+	_, err := engine.Run(context.Background(), []string{tmpFile})
+	require.Error(t, err, "expected error from read-only file write")
+	assert.Contains(t, err.Error(), "writing fix for",
+		"error should be wrapped with the rule context from applyFixes")
+}


### PR DESCRIPTION
## What and why

The `fmt` and `style` engines now preserve a file's original permission bits when writing fixed/formatted content. Mode is captured via `os.Stat` before the first write and re-applied via `os.Chmod` after, with a `0o600` fallback if Stat fails.

The change is extension-agnostic and applies to every file the engines write — Terraform `.tf`, Terragrunt `.hcl`, and `.tfvars`.

- `internal/engines/format/fmt.go` — extracted `writeFilePreservingMode(path, content)` helper, called from `formatFile`.
- `internal/engines/style/style.go` — captured `mode` once at the top of `checkFile` and threaded it through both the deferred preview-mode restore and the per-pass `applyFixes` write (now takes a `mode os.FileMode` parameter).

**Why:** Users who chmod a file to a non-default mode (for example `0o755`) previously had that mode silently clobbered to `0o600` on the rare path where `WriteFile` recreated the file.

## How to test

```bash
mise run check              # fmt + vet + lint + test, all pass
mise run test:integration   # passes
```

Targeted regression tests added:

- `TestEngine_PreservesFileMode` (`internal/engines/format/fmt_test.go`) — chmod fixture to `0o755`, run fmt, assert mode unchanged.
- `TestEngine_PreservesFileMode_OnFix` (`internal/engines/style/style_test.go`) — same for the style fix path.
- `TestEngine_PreservesFileMode_OnDiffPreviewRestore` — same for the diff-preview restore path; also asserts the preview contract (file content unchanged).

All three are skipped on Windows where Unix-style permission bits don't apply.

## Notes for reviewers

- `applyFixes` signature changed (added `mode os.FileMode` parameter). The function is unexported, so no public API impact.
- The style engine has two write+chmod call sites with intentionally different error-handling semantics: the deferred preview-restore silences errors (the preview contract prefers returning the diff finding over surfacing restore failures), while `applyFixes` propagates them.
- Single-extension fixtures in the new tests are intentional: the production code is extension-agnostic by construction (no branching on extension), so iterating across `.tf`/`.hcl`/`.tfvars` would only re-test Go's `os.Stat`/`os.Chmod`.
- No documentation changes — engine write internals are not user-facing.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
