### PR TITLE
feat(cli): add --no-parallel flag to check command

### DIFF
--- a/cmd/terratidy/check.go
+++ b/cmd/terratidy/check.go
@@ -24,6 +24,7 @@ var (
 	checkSkipLint   bool
 	checkSkipPolicy bool
 	checkParallel   bool
+	checkNoParallel bool
 )
 
 var checkCmd = &cobra.Command{
@@ -45,8 +46,11 @@ Use --skip-* flags to skip specific engines.`,
   # Skip policy checks
   terratidy check --skip-policy
 
-  # Run engines in parallel for faster execution
-  terratidy check --parallel`,
+  # Force parallel execution (engines already run in parallel by default)
+  terratidy check --parallel
+
+  # Force sequential execution (useful with fail_fast: true)
+  terratidy check --no-parallel`,
 	RunE: runCheck,
 }
 
@@ -55,7 +59,8 @@ func init() {
 	checkCmd.Flags().BoolVar(&checkSkipStyle, "skip-style", false, "skip style checks")
 	checkCmd.Flags().BoolVar(&checkSkipLint, "skip-lint", false, "skip linting")
 	checkCmd.Flags().BoolVar(&checkSkipPolicy, "skip-policy", false, "skip policy checks")
-	checkCmd.Flags().BoolVar(&checkParallel, "parallel", false, "run engines in parallel")
+	checkCmd.Flags().BoolVar(&checkParallel, "parallel", false, "force parallel engine execution (already enabled by default config)")
+	checkCmd.Flags().BoolVar(&checkNoParallel, "no-parallel", false, "force sequential engine execution (overrides --parallel and config)")
 	rootCmd.AddCommand(checkCmd)
 }
 
@@ -176,7 +181,7 @@ func runAllChecksWithConfig(cfg *config.Config, files []string, quiet bool, plug
 	ctx := context.Background()
 
 	// Determine if parallel execution should be used
-	useParallel := getEffectiveParallel(cfg, checkParallel)
+	useParallel := getEffectiveParallel(cfg, checkParallel, checkNoParallel)
 
 	if useParallel {
 		return runAllChecksParallelWithConfig(ctx, cfg, files, quiet, pluginRules)

--- a/cmd/terratidy/check_integration_test.go
+++ b/cmd/terratidy/check_integration_test.go
@@ -161,6 +161,24 @@ func TestRunAllChecksWithConfig(t *testing.T) {
 		require.NoError(t, err)
 		_ = findings
 	})
+
+	t.Run("no-parallel forces sequential despite config parallel: true", func(t *testing.T) {
+		oldParallel := checkParallel
+		oldNoParallel := checkNoParallel
+		checkParallel = true
+		checkNoParallel = true
+		defer func() {
+			checkParallel = oldParallel
+			checkNoParallel = oldNoParallel
+		}()
+
+		parallelCfg := config.DefaultConfig()
+		parallelCfg.Parallel = config.BoolPtr(true)
+
+		findings, err := runAllChecksWithConfig(parallelCfg, []string{tmpFile}, true, nil)
+		require.NoError(t, err)
+		_ = findings
+	})
 }
 
 func TestPrintCheckHeader(t *testing.T) {

--- a/cmd/terratidy/check_integration_test.go
+++ b/cmd/terratidy/check_integration_test.go
@@ -1073,14 +1073,22 @@ func TestRootConfigFieldsAffectRuntime(t *testing.T) {
 
 		// Config parallel=true, CLI parallel=false -> use config (true)
 		cfg.Parallel = config.BoolPtr(true)
-		assert.True(t, getEffectiveParallel(cfg, false), "should use config when CLI flag false")
+		assert.True(t, getEffectiveParallel(cfg, false, false), "should use config when CLI flag false")
 
 		// Config parallel=false, CLI parallel=true -> CLI wins
 		cfg.Parallel = config.BoolPtr(false)
-		assert.True(t, getEffectiveParallel(cfg, true), "CLI flag should override config")
+		assert.True(t, getEffectiveParallel(cfg, true, false), "CLI flag should override config")
 
 		// Both false
-		assert.False(t, getEffectiveParallel(cfg, false), "both false should return false")
+		assert.False(t, getEffectiveParallel(cfg, false, false), "both false should return false")
+
+		// --no-parallel beats config parallel: true
+		cfg.Parallel = config.BoolPtr(true)
+		assert.False(t, getEffectiveParallel(cfg, false, true), "--no-parallel should override config parallel: true")
+
+		// --no-parallel beats --parallel
+		cfg.Parallel = config.BoolPtr(false)
+		assert.False(t, getEffectiveParallel(cfg, true, true), "--no-parallel should override --parallel")
 	})
 
 	t.Run("imports merge config correctly", func(t *testing.T) {

--- a/cmd/terratidy/check_test.go
+++ b/cmd/terratidy/check_test.go
@@ -44,6 +44,12 @@ func TestCheckCmd(t *testing.T) {
 		assert.NotNil(t, flag)
 		assert.Equal(t, "false", flag.DefValue)
 	})
+
+	t.Run("has no-parallel flag", func(t *testing.T) {
+		flag := checkCmd.Flags().Lookup("no-parallel")
+		assert.NotNil(t, flag)
+		assert.Equal(t, "false", flag.DefValue)
+	})
 }
 
 func TestCountBySeverity(t *testing.T) {

--- a/cmd/terratidy/helpers.go
+++ b/cmd/terratidy/helpers.go
@@ -566,8 +566,11 @@ func getEffectiveSeverityThreshold(cfg *config.Config) string {
 }
 
 // getEffectiveParallel returns whether parallel execution should be used.
-// CLI flag takes precedence over config file setting.
-func getEffectiveParallel(cfg *config.Config, cliParallel bool) bool {
+// Precedence: --no-parallel > --parallel > config > default (false).
+func getEffectiveParallel(cfg *config.Config, cliParallel, cliNoParallel bool) bool {
+	if cliNoParallel {
+		return false
+	}
 	if cliParallel {
 		return true
 	}

--- a/cmd/terratidy/helpers_coverage_test.go
+++ b/cmd/terratidy/helpers_coverage_test.go
@@ -10,21 +10,25 @@ import (
 
 func TestGetEffectiveParallel(t *testing.T) {
 	tests := []struct {
-		name        string
-		cfg         *config.Config
-		cliParallel bool
-		want        bool
+		name          string
+		cfg           *config.Config
+		cliParallel   bool
+		cliNoParallel bool
+		want          bool
 	}{
-		{"cli flag true overrides config", &config.Config{Parallel: config.BoolPtr(false)}, true, true},
-		{"cli flag false uses config true", &config.Config{Parallel: config.BoolPtr(true)}, false, true},
-		{"both false", &config.Config{Parallel: config.BoolPtr(false)}, false, false},
-		{"nil config cli false", nil, false, false},
-		{"nil config cli true", nil, true, true},
+		{"cli flag true overrides config", &config.Config{Parallel: config.BoolPtr(false)}, true, false, true},
+		{"cli flag false uses config true", &config.Config{Parallel: config.BoolPtr(true)}, false, false, true},
+		{"both false", &config.Config{Parallel: config.BoolPtr(false)}, false, false, false},
+		{"nil config cli false", nil, false, false, false},
+		{"nil config cli true", nil, true, false, true},
+		{"no-parallel overrides config true", &config.Config{Parallel: config.BoolPtr(true)}, false, true, false},
+		{"no-parallel overrides --parallel", &config.Config{Parallel: config.BoolPtr(false)}, true, true, false},
+		{"no-parallel with nil config", nil, false, true, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, getEffectiveParallel(tt.cfg, tt.cliParallel))
+			assert.Equal(t, tt.want, getEffectiveParallel(tt.cfg, tt.cliParallel, tt.cliNoParallel))
 		})
 	}
 }

--- a/docs/site/docs/getting-started/configuration.md
+++ b/docs/site/docs/getting-started/configuration.md
@@ -346,7 +346,8 @@ parallel: false  # Run engines sequentially (fmt -> style -> lint -> policy)
 Parallel mode is faster but output order is non-deterministic. Sequential mode is useful
 for debugging or when `fail_fast` is enabled (fail_fast only works in sequential mode).
 
-Can be overridden with `--parallel` CLI flag.
+Can be overridden with `--parallel` (force on) or `--no-parallel` (force off) CLI flags.
+`--no-parallel` takes precedence over both `--parallel` and the config setting.
 
 ### fail_fast
 

--- a/docs/site/docs/user-guide/commands.md
+++ b/docs/site/docs/user-guide/commands.md
@@ -212,15 +212,18 @@ terratidy check [paths...] [flags]
 
 **Flags:**
 
-| Flag            | Description                     |
-| --------------- | ------------------------------- |
-| `--parallel`    | Run engines in parallel         |
-| `--skip-fmt`    | Skip formatting checks          |
-| `--skip-style`  | Skip style checks               |
-| `--skip-lint`   | Skip linting checks             |
-| `--skip-policy` | Skip policy checks              |
+| Flag            | Description                                                 |
+| --------------- | ----------------------------------------------------------- |
+| `--parallel`    | Run engines in parallel                                     |
+| `--no-parallel` | Force sequential execution (overrides `--parallel` and config) |
+| `--skip-fmt`    | Skip formatting checks                                      |
+| `--skip-style`  | Skip style checks                                           |
+| `--skip-lint`   | Skip linting checks                                         |
+| `--skip-policy` | Skip policy checks                                          |
 
 When `fail_fast` is enabled in config, the check stops after the first engine that reports errors.
+`fail_fast` only takes effect in sequential mode; combine it with `--no-parallel` (or
+`parallel: false` in config) to make it active.
 
 **Examples:**
 
@@ -237,8 +240,11 @@ terratidy check --profile ci
 # Output as JSON
 terratidy check --format json
 
-# Run in parallel for faster execution
+# Run in parallel for faster execution (default)
 terratidy check --parallel
+
+# Force sequential execution (e.g. to combine with fail_fast: true)
+terratidy check --no-parallel
 
 # Skip policy checks
 terratidy check --skip-policy

--- a/docs/site/docs/user-guide/performance.md
+++ b/docs/site/docs/user-guide/performance.md
@@ -19,12 +19,14 @@ parallel: true
 Parallel mode runs all enabled engines (fmt, style, lint, policy) simultaneously using
 goroutines. This is most effective when multiple engines are enabled.
 
-**Default behavior:** The config default is `parallel: true`, but the `--parallel` CLI flag
-is additive (it enables parallel when your config has it disabled). If you haven't changed
-the default config, engines already run in parallel.
+**Default behavior:** Parallel execution is on by default. When no config file is present,
+or when `parallel` is omitted from config, TerraTidy runs engines in parallel. Use `--parallel`
+to force parallel when config has explicitly disabled it, and `--no-parallel` to force
+sequential execution regardless of config.
 
-**Note:** `fail_fast` only works in sequential mode. When using `--parallel`, all engines
-run to completion regardless of errors.
+**Note:** `fail_fast` only works in sequential mode. When running in parallel, all engines
+run to completion regardless of errors. Pair `--no-parallel` with `fail_fast: true` to stop
+on the first engine that reports errors.
 
 ## Engine Selection
 


### PR DESCRIPTION
## What and why

Adds a `--no-parallel` boolean flag to `terratidy check` that forces sequential engine execution, overriding both `--parallel` and the config-level `parallel: true` setting. `getEffectiveParallel` is updated to take the new flag and short-circuit to `false` when set.

**Why:** `fail_fast` only triggers in sequential mode, but the config default is `parallel: true`. Without an off-switch flag, users had to edit their config (or maintain a CI-only profile) just to combine `fail_fast: true` with their default config. `--no-parallel` gives a one-shot CLI override with a clear precedence rule: `--no-parallel` > `--parallel` > config > default.

## How to test

```bash
mise run build
./bin/terratidy check --help                        # --no-parallel listed
./bin/terratidy check --parallel --no-parallel .    # runs sequentially
mise run check
mise run test:integration
```

Verify the flag descriptions cross-reference each other in `--help` output and that the new precedence assertions in `helpers_coverage_test.go` and `check_integration_test.go` pass.

## Notes for reviewers

- `--no-parallel` is a `check`-only flag. `fmt` processes files sequentially in its own loop and has no parallel knob, so the flag would be a no-op there. `cmd/terratidy/fmt.go` was inspected and confirmed to have zero references to `parallel`/`Parallel`.
- The GitHub Action (`action.yml`) was deliberately not updated: its existing `parallel` input defaults to `false`, so Action users already get sequential by default. A `no-parallel` Action input can wait for a concrete user request.
- Docs touched: `commands.md` (flag table + Example block + `fail_fast` caveat), `performance.md` ("Default behavior" paragraph rewritten to lead with parallel-by-default), `configuration.md` (precedence note added). Incidental `--parallel` mentions in `troubleshooting.md`, `upgrade.md`, `ci-cd.md`, and `monorepos.md` were left alone — they are usage examples, not flag references.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
