### PR TITLE
fix(style): improve rule accuracy, preserve comments and nested blocks

### DIFF
--- a/cmd/terratidy/check_coverage_test.go
+++ b/cmd/terratidy/check_coverage_test.go
@@ -445,7 +445,8 @@ func TestChangedFlagConsistency(t *testing.T) {
 	runGit := func(args ...string) {
 		cmd := exec.Command("git", args...)
 		cmd.Dir = dir
-		cmd.Env = append(os.Environ(),
+		cmd.Env = append(
+			os.Environ(),
 			"GIT_AUTHOR_NAME=test",
 			"GIT_AUTHOR_EMAIL=test@test.com",
 			"GIT_COMMITTER_NAME=test",
@@ -568,7 +569,8 @@ func TestChangedFlagWithNestedDirectories(t *testing.T) {
 	runGit := func(args ...string) {
 		cmd := exec.Command("git", args...)
 		cmd.Dir = dir
-		cmd.Env = append(os.Environ(),
+		cmd.Env = append(
+			os.Environ(),
 			"GIT_AUTHOR_NAME=test",
 			"GIT_AUTHOR_EMAIL=test@test.com",
 			"GIT_COMMITTER_NAME=test",

--- a/cmd/terratidy/check_integration_test.go
+++ b/cmd/terratidy/check_integration_test.go
@@ -2031,7 +2031,8 @@ func TestNoRecurseWithChangedScansChangedFileDirsOnly(t *testing.T) {
 	runGit := func(args ...string) {
 		cmd := exec.Command("git", args...)
 		cmd.Dir = dir
-		cmd.Env = append(os.Environ(),
+		cmd.Env = append(
+			os.Environ(),
 			"GIT_AUTHOR_NAME=test",
 			"GIT_AUTHOR_EMAIL=test@test.com",
 			"GIT_COMMITTER_NAME=test",

--- a/cmd/terratidy/plugins.go
+++ b/cmd/terratidy/plugins.go
@@ -64,7 +64,8 @@ var pluginsListCmd = &cobra.Command{
 		_, _ = fmt.Fprintln(w, "----\t-------\t----\t-----------")
 
 		for _, p := range pluginList {
-			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+			_, _ = fmt.Fprintf(
+				w, "%s\t%s\t%s\t%s\n",
 				p.Metadata.Name,
 				p.Metadata.Version,
 				p.Metadata.Type,

--- a/internal/engines/lint/lint.go
+++ b/internal/engines/lint/lint.go
@@ -282,7 +282,8 @@ func (e *Engine) getRuleConfig(ruleName string) RuleConfig {
 
 // registerRules registers all built-in lint rules
 func (e *Engine) registerRules() {
-	e.rules = append(e.rules,
+	e.rules = append(
+		e.rules,
 		&TerraformRequiredVersionRule{},
 		&TerraformRequiredProvidersRule{},
 		&TerraformDeprecatedSyntaxRule{},

--- a/internal/engines/style/rules/comments.go
+++ b/internal/engines/style/rules/comments.go
@@ -19,7 +19,7 @@ func (r *CommentSyntaxRule) Name() string {
 
 // Description returns a human-readable description of the rule.
 func (r *CommentSyntaxRule) Description() string {
-	return "Ensures comments use # syntax instead of //"
+	return "Ensures full-line comments use # syntax instead of // (trailing // after a value is not flagged)"
 }
 
 // Check examines the file for // style comments.
@@ -58,33 +58,13 @@ func (r *CommentSyntaxRule) Check(ctx *sdk.Context, _ *hcl.File) ([]sdk.Finding,
 	return findings, nil
 }
 
-// hasDoubleSlashComment checks if a line has a // comment outside of strings
+// hasDoubleSlashComment reports whether a line is a full-line `//` comment (after
+// trimming leading whitespace). Lines starting with `#` are never flagged, even if
+// their body contains `//` (e.g. URLs like `# https://example.com/path`). Trailing
+// `//` after a value (e.g. `key = "x" // note`) is not flagged either; the rule's
+// scope is full-line comments only.
 func (r *CommentSyntaxRule) hasDoubleSlashComment(line string) bool {
-	inString := false
-	stringChar := rune(0)
-
-	for i := 0; i < len(line)-1; i++ {
-		c := rune(line[i])
-		next := rune(line[i+1])
-
-		// Handle string boundaries
-		if (c == '"' || c == '\'') && (i == 0 || line[i-1] != '\\') {
-			if !inString {
-				inString = true
-				stringChar = c
-			} else if c == stringChar {
-				inString = false
-			}
-			continue
-		}
-
-		// Check for // outside strings
-		if !inString && c == '/' && next == '/' {
-			return true
-		}
-	}
-
-	return false
+	return strings.HasPrefix(strings.TrimSpace(line), "//")
 }
 
 func (r *CommentSyntaxRule) fixFile(filePath string) ([]byte, error) {
@@ -107,36 +87,19 @@ func (r *CommentSyntaxRule) fixContent(content []byte) []byte {
 	return []byte(strings.Join(result, "\n") + "\n")
 }
 
+// fixLine converts a full-line `//` comment to `#` (preserving leading whitespace).
+// Lines that are not full-line `//` comments are returned unchanged — `#` comments
+// containing `//` (e.g. URLs) and inline `//` after a value both pass through.
+//
+// hasDoubleSlashComment guarantees the first `//` in the raw line is the comment
+// delimiter (the trimmed line starts with `//`, so leading whitespace is the only
+// thing that can precede it), so strings.Index is safe to use here without a guard.
 func (r *CommentSyntaxRule) fixLine(line string) string {
-	// Only replace // with # when it's at the start of a comment (not inside strings)
-	inString := false
-	stringChar := rune(0)
-	result := []byte(line)
-
-	for i := 0; i < len(line)-1; i++ {
-		c := rune(line[i])
-		next := rune(line[i+1])
-
-		if (c == '"' || c == '\'') && (i == 0 || line[i-1] != '\\') {
-			if !inString {
-				inString = true
-				stringChar = c
-			} else if c == stringChar {
-				inString = false
-			}
-			continue
-		}
-
-		if !inString && c == '/' && next == '/' {
-			// Replace // with #
-			result[i] = '#'
-			// Remove the second /
-			result = append(result[:i+1], result[i+2:]...)
-			break
-		}
+	if !r.hasDoubleSlashComment(line) {
+		return line
 	}
-
-	return string(result)
+	idx := strings.Index(line, "//")
+	return line[:idx] + "#" + line[idx+2:]
 }
 
 // Fix replaces // comments with # comments.

--- a/internal/engines/style/rules/comments_test.go
+++ b/internal/engines/style/rules/comments_test.go
@@ -45,11 +45,13 @@ resource "aws_instance" "web" {
 			wantFindings: 1,
 		},
 		{
-			name: "inline // comment",
+			// Inline trailing `// comment` is no longer flagged: the rule's scope is full-line
+			// `//` comments only (per fmt-style-polish Phase 4 scope narrowing).
+			name: "trailing // comment is not flagged",
 			content: `resource "aws_instance" "web" {
   ami = "ami-123" // inline comment
 }`,
-			wantFindings: 1,
+			wantFindings: 0,
 		},
 		{
 			name: "// inside string is ignored",
@@ -74,6 +76,51 @@ resource "aws_instance" "web" {
 			content: `# Valid comment
 // Invalid comment
 resource "aws_instance" "web" {
+  ami = "ami-123"
+}`,
+			wantFindings: 1,
+		},
+		{
+			// Regression: # comment containing a URL with `//` must not be flagged.
+			name: "hash comment containing URL is not flagged",
+			content: `# https://github.com/hashicorp/terraform
+resource "aws_instance" "web" {
+  ami = "ami-123"
+}`,
+			wantFindings: 0,
+		},
+		{
+			// Regression: # comment with arbitrary `//` content is not flagged.
+			name: "hash comment containing double-slash is not flagged",
+			content: `# you can use // to do X
+resource "aws_instance" "web" {
+  ami = "ami-123"
+}`,
+			wantFindings: 0,
+		},
+		{
+			// Regression: line with `//` after a value (inside a string-position context)
+			// is treated as not-a-full-line comment.
+			name: "url inside string with // is not flagged",
+			content: `output "u" { value = "url://example.com" }
+`,
+			wantFindings: 0,
+		},
+		{
+			// Indented `//` at line start is still flagged.
+			name: "indented // comment is flagged",
+			content: `resource "x" "y" {
+  // indented full-line comment
+  ami = "ami-123"
+}`,
+			wantFindings: 1,
+		},
+		{
+			// `// foo // bar`: first `//` is the comment delimiter; second is body content.
+			// Only the line itself is flagged once; on Fix, only the FIRST `//` is rewritten.
+			name: "multiple // on same comment line is flagged once",
+			content: `// foo // bar
+resource "x" "y" {
   ami = "ami-123"
 }`,
 			wantFindings: 1,
@@ -120,6 +167,83 @@ resource "aws_instance" "web" {
 		require.NoError(t, err)
 		assert.Contains(t, string(result), "# This should be fixed")
 		assert.NotContains(t, string(result), "// This should be fixed")
+	})
+
+	t.Run("Fix preserves hash comments containing URLs verbatim", func(t *testing.T) {
+		// Regression lock: the buggy old scanner would convert the `//` inside the URL.
+		// Use the exact hashicorp URL form called out in the plan.
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "test.tf")
+		content := `# https://github.com/hashicorp/terraform
+# also fine: // does not break me
+resource "aws_instance" "web" {
+  ami = "ami-123" // trailing remains as // because the rule is full-line only
+}
+`
+		require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+
+		ctx := &sdk.Context{File: tmpFile}
+		result, err := rule.Fix(ctx, nil)
+		require.NoError(t, err)
+		out := string(result)
+
+		// Hash comments untouched.
+		assert.Contains(t, out, "# https://github.com/hashicorp/terraform")
+		assert.Contains(t, out, "# also fine: // does not break me")
+		// Trailing `//` after a value is intentionally NOT rewritten (scope: full-line only).
+		assert.Contains(t, out, `ami = "ami-123" // trailing remains as //`)
+	})
+
+	t.Run("Fix preserves leading whitespace when converting // to #", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "test.tf")
+		content := `resource "x" "y" {
+  // indented comment
+  ami = "ami-123"
+}
+`
+		require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+
+		ctx := &sdk.Context{File: tmpFile}
+		result, err := rule.Fix(ctx, nil)
+		require.NoError(t, err)
+		assert.Contains(t, string(result), "  # indented comment")
+		assert.NotContains(t, string(result), "  // indented comment")
+	})
+
+	t.Run("Fix rewrites only the first // on a multi-slash comment line", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "test.tf")
+		content := "// foo // bar\n"
+		require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+
+		ctx := &sdk.Context{File: tmpFile}
+		result, err := rule.Fix(ctx, nil)
+		require.NoError(t, err)
+		// First `//` becomes `#`; the second `//` (inside the comment body) is preserved.
+		assert.Contains(t, string(result), "# foo // bar")
+	})
+
+	t.Run("Fix is idempotent", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "test.tf")
+		content := `// to convert
+# https://example.com/url-stays
+# normal hash
+resource "x" "y" {
+  ami = "ami-123" // trailing left alone
+}
+`
+		require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+		ctx := &sdk.Context{File: tmpFile}
+
+		first, err := rule.Fix(ctx, nil)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(tmpFile, first, 0o644))
+
+		second, err := rule.Fix(ctx, nil)
+		require.NoError(t, err)
+		assert.Equal(t, string(first), string(second), "Fix(Fix(x)) must equal Fix(x)")
 	})
 }
 

--- a/internal/engines/style/rules/file_structure.go
+++ b/internal/engines/style/rules/file_structure.go
@@ -156,7 +156,7 @@ func (r *TerraformFilesStructureRule) Description() string {
 	return "Ensures standard Terraform file structure (variables.tf, outputs.tf, providers.tf, etc.)"
 }
 
-// standardFileBlocks maps standard file names to expected block types
+// standardFileBlocks maps canonical standard file names to expected block types.
 var standardFileBlocks = map[string][]string{
 	"variables.tf": {"variable"},
 	"outputs.tf":   {"output"},
@@ -164,6 +164,30 @@ var standardFileBlocks = map[string][]string{
 	"versions.tf":  {"terraform"},
 	"locals.tf":    {"locals"},
 	"data.tf":      {"data"},
+}
+
+// standardFileAliases maps canonical standard file names to acceptable alternate basenames.
+// Both forms are recognized as valid containers; suggestions always use the canonical key.
+var standardFileAliases = map[string][]string{
+	"variables.tf": {"variable.tf"},
+	"outputs.tf":   {"output.tf"},
+	"providers.tf": {"provider.tf"},
+}
+
+// isStandardFileOrAlias reports whether basename is a recognized standard file
+// or one of its accepted alternate basenames.
+func isStandardFileOrAlias(basename string) bool {
+	if _, ok := standardFileBlocks[basename]; ok {
+		return true
+	}
+	for _, aliases := range standardFileAliases {
+		for _, alias := range aliases {
+			if basename == alias {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // Check examines files for blocks that should be in standard files.
@@ -177,22 +201,18 @@ func (r *TerraformFilesStructureRule) Check(ctx *sdk.Context, file *hcl.File) ([
 
 	fileName := filepath.Base(ctx.File)
 
-	// Get list of expected block types for this file
-	expectedTypes := standardFileBlocks[fileName]
-
-	// Skip if this is a standard file
-	if len(expectedTypes) > 0 {
+	// Skip if this is a standard file or one of its accepted aliases
+	if isStandardFileOrAlias(fileName) {
 		return findings, nil
 	}
 
 	// Check if blocks in this file should be in a standard file
+	dir := filepath.Dir(ctx.File)
 	for _, block := range hclFile.Blocks {
 		for standardFile, types := range standardFileBlocks {
 			for _, blockType := range types {
 				if block.Type == blockType {
-					// Check if the standard file exists
-					standardPath := filepath.Join(filepath.Dir(ctx.File), standardFile)
-					if r.fileExists(standardPath) || r.shouldSuggestStandardFile(block.Type) {
+					if r.standardFileOrAliasExists(dir, standardFile) || r.shouldSuggestStandardFile(block.Type) {
 						findings = append(findings, sdk.Finding{
 							Rule:     r.Name(),
 							Message:  block.Type + " block should be in " + standardFile,
@@ -212,6 +232,20 @@ func (r *TerraformFilesStructureRule) Check(ctx *sdk.Context, file *hcl.File) ([
 func (r *TerraformFilesStructureRule) fileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+// standardFileOrAliasExists reports whether the canonical standardFile or any
+// of its accepted aliases exists in dir.
+func (r *TerraformFilesStructureRule) standardFileOrAliasExists(dir, standardFile string) bool {
+	if r.fileExists(filepath.Join(dir, standardFile)) {
+		return true
+	}
+	for _, alias := range standardFileAliases[standardFile] {
+		if r.fileExists(filepath.Join(dir, alias)) {
+			return true
+		}
+	}
+	return false
 }
 
 // shouldSuggestStandardFile returns true if this block type is commonly placed in standard files

--- a/internal/engines/style/rules/file_structure_test.go
+++ b/internal/engines/style/rules/file_structure_test.go
@@ -287,6 +287,15 @@ func TestTerraformFilesStructureRule(t *testing.T) {
 			wantFindings: 0,
 		},
 		{
+			name:     "variables in singular variable.tf is fine",
+			fileName: "variable.tf",
+			content: `variable "region" {
+  type    = string
+  default = "us-east-1"
+}`,
+			wantFindings: 0,
+		},
+		{
 			name:     "outputs in outputs.tf is fine",
 			fileName: "outputs.tf",
 			content: `output "vpc_id" {
@@ -295,8 +304,24 @@ func TestTerraformFilesStructureRule(t *testing.T) {
 			wantFindings: 0,
 		},
 		{
+			name:     "outputs in singular output.tf is fine",
+			fileName: "output.tf",
+			content: `output "vpc_id" {
+  value = aws_vpc.main.id
+}`,
+			wantFindings: 0,
+		},
+		{
 			name:     "providers in providers.tf is fine",
 			fileName: "providers.tf",
+			content: `provider "aws" {
+  region = "us-east-1"
+}`,
+			wantFindings: 0,
+		},
+		{
+			name:     "providers in singular provider.tf is fine",
+			fileName: "provider.tf",
 			content: `provider "aws" {
   region = "us-east-1"
 }`,
@@ -328,6 +353,15 @@ func TestTerraformFilesStructureRule(t *testing.T) {
 			wantFindings: 1,
 		},
 		{
+			name:     "variable in main.tf when singular variable.tf exists",
+			fileName: "main.tf",
+			content: `variable "region" {
+  type = string
+}`,
+			setupFiles:   []string{"variable.tf"},
+			wantFindings: 1,
+		},
+		{
 			name:     "output in main.tf when outputs.tf exists",
 			fileName: "main.tf",
 			content: `output "vpc_id" {
@@ -337,12 +371,52 @@ func TestTerraformFilesStructureRule(t *testing.T) {
 			wantFindings: 1,
 		},
 		{
+			name:     "output in main.tf when singular output.tf exists",
+			fileName: "main.tf",
+			content: `output "vpc_id" {
+  value = aws_vpc.main.id
+}`,
+			setupFiles:   []string{"output.tf"},
+			wantFindings: 1,
+		},
+		{
 			name:     "provider in main.tf when providers.tf exists",
 			fileName: "main.tf",
 			content: `provider "aws" {
   region = "us-east-1"
 }`,
 			setupFiles:   []string{"providers.tf"},
+			wantFindings: 1,
+		},
+		{
+			name:     "provider in main.tf when singular provider.tf exists",
+			fileName: "main.tf",
+			content: `provider "aws" {
+  region = "us-east-1"
+}`,
+			setupFiles:   []string{"provider.tf"},
+			wantFindings: 1,
+		},
+		{
+			name:     "variable in main.tf when both variables.tf and variable.tf exist (no double-finding)",
+			fileName: "main.tf",
+			content: `variable "region" {
+  type = string
+}`,
+			setupFiles:   []string{"variables.tf", "variable.tf"},
+			wantFindings: 1,
+		},
+		{
+			name:     "terraform block in singular version.tf is treated as ordinary file (not aliased to versions.tf)",
+			fileName: "version.tf",
+			content: `terraform {
+  required_version = ">= 1.0"
+}`,
+			setupFiles: []string{"versions.tf"},
+			// version.tf is not an alias of versions.tf; rule treats it as a non-standard
+			// file. With versions.tf present, the terraform block produces a single finding
+			// pointing at versions.tf (providers.tf path is gated off by the absent file +
+			// !shouldSuggestStandardFile("terraform")).
 			wantFindings: 1,
 		},
 		{
@@ -405,6 +479,64 @@ func TestTerraformFilesStructureRule(t *testing.T) {
 			assert.Len(t, findings, tt.wantFindings)
 		})
 	}
+}
+
+func TestIsStandardFileOrAlias(t *testing.T) {
+	tests := []struct {
+		basename string
+		expected bool
+	}{
+		// Canonical plural forms
+		{"variables.tf", true},
+		{"outputs.tf", true},
+		{"providers.tf", true},
+		{"versions.tf", true},
+		{"locals.tf", true},
+		{"data.tf", true},
+		// Accepted singular aliases
+		{"variable.tf", true},
+		{"output.tf", true},
+		{"provider.tf", true},
+		// Non-standard files
+		{"main.tf", false},
+		{"network.tf", false},
+		{"random.tf", false},
+		{"version.tf", false}, // intentionally not aliased (versions.tf is canonical)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.basename, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isStandardFileOrAlias(tt.basename))
+		})
+	}
+}
+
+func TestTerraformFilesStructureRule_StandardFileOrAliasExists(t *testing.T) {
+	rule := &TerraformFilesStructureRule{}
+
+	t.Run("singular alias satisfies plural existence", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "variable.tf"), []byte("# alias"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "output.tf"), []byte("# alias"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "provider.tf"), []byte("# alias"), 0o644))
+
+		assert.True(t, rule.standardFileOrAliasExists(tmpDir, "variables.tf"))
+		assert.True(t, rule.standardFileOrAliasExists(tmpDir, "outputs.tf"))
+		assert.True(t, rule.standardFileOrAliasExists(tmpDir, "providers.tf"))
+	})
+
+	t.Run("absent file returns false", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		assert.False(t, rule.standardFileOrAliasExists(tmpDir, "outputs.tf"))
+	})
+
+	t.Run("canonical without alias entry still works", func(t *testing.T) {
+		// versions.tf has no aliases registered; verify nil-slice range is safe.
+		tmpDir := t.TempDir()
+		assert.False(t, rule.standardFileOrAliasExists(tmpDir, "versions.tf"))
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "versions.tf"), []byte("# canonical"), 0o644))
+		assert.True(t, rule.standardFileOrAliasExists(tmpDir, "versions.tf"))
+	})
 }
 
 func TestTerraformFilesStructureRule_FileExists(t *testing.T) {

--- a/internal/engines/style/rules/helpers.go
+++ b/internal/engines/style/rules/helpers.go
@@ -107,13 +107,45 @@ type AttrRegion struct {
 	EndLine        int      // 1-indexed line number where region ends
 }
 
+// collectLeadingComments walks backwards from startLine-1 (exclusive) down to searchStart
+// (inclusive), collecting consecutive `#` and `//` comment lines. Blank lines are passed
+// through without being collected and without terminating the scan, matching long-standing
+// behavior across other style rules. Non-comment content terminates the scan.
+// Returns comment lines in source order (top-down).
+//
+// Note on blank-line passthrough: a comment separated from the next region by one or more
+// blank lines is still claimed as that region's leading comment. The motivating reason is
+// damage control: the reassembly path emits only content attached to a region or captured
+// by collectOrphanLines, so a stricter "stop on blank" rule would silently drop comments
+// the author placed visually above a target region. Section-header comments above blank
+// lines therefore travel with the following region; users who want them stationary should
+// place them outside the block or attach them inline.
+func collectLeadingComments(lines []string, startLine, searchStart int) []string {
+	var leading []string
+	for lineNum := startLine - 1; lineNum >= searchStart; lineNum-- {
+		if lineNum-1 >= len(lines) || lineNum-1 < 0 {
+			continue
+		}
+		line := lines[lineNum-1]
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "//") {
+			leading = append([]string{line}, leading...)
+			continue
+		}
+		break
+	}
+	return leading
+}
+
 // ExtractAttrRegions extracts attribute regions (including leading comments) from content.
 // syntaxBody provides accurate line numbers for attributes.
 func ExtractAttrRegions(content []byte, syntaxBody *hclsyntax.Body) map[string]*AttrRegion {
 	lines := SplitLines(content)
 	regions := make(map[string]*AttrRegion)
 
-	// Get attributes sorted by line number
 	type attrPos struct {
 		name      string
 		startLine int
@@ -138,39 +170,18 @@ func ExtractAttrRegions(content []byte, syntaxBody *hclsyntax.Body) map[string]*
 			EndLine:   attr.endLine,
 		}
 
-		// Find leading comments by scanning backwards from the attribute
-		// Stop at the previous attribute's end line or block start
+		// Stop the comment scan at the previous attribute's end line (or block start).
 		searchStart := 1
 		if i > 0 {
 			searchStart = attrs[i-1].endLine + 1
 		}
 
-		// Collect leading comment lines
-		var leadingCommentLines []string
-		for lineNum := attr.startLine - 1; lineNum >= searchStart; lineNum-- {
-			if lineNum-1 >= len(lines) {
-				continue
-			}
-			line := lines[lineNum-1]
-			trimmed := strings.TrimSpace(line)
-			if trimmed == "" {
-				// Skip blank lines but stop collecting comments
-				continue
-			}
-			if strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "//") {
-				leadingCommentLines = append([]string{line}, leadingCommentLines...)
-			} else {
-				// Hit non-comment content, stop
-				break
-			}
-		}
+		leadingCommentLines := collectLeadingComments(lines, attr.startLine, searchStart)
 		if len(leadingCommentLines) > 0 {
 			region.LeadingComment = strings.Join(leadingCommentLines, "\n") + "\n"
-			// Adjust StartLine to include comments
 			region.StartLine = attr.startLine - len(leadingCommentLines)
 		}
 
-		// Collect attribute lines
 		for lineNum := attr.startLine; lineNum <= attr.endLine && lineNum-1 < len(lines); lineNum++ {
 			region.Lines = append(region.Lines, lines[lineNum-1])
 		}
@@ -259,9 +270,63 @@ func ReorderBlockAttrs(body *hclwrite.Body, orderedNames, firstAttrs, lastAttrs 
 	}
 }
 
+// markConsumedAttrLines marks the source lines covered by the given attribute regions
+// (including their captured leading comments) so the caller can later identify content
+// that belongs to no region. Safe to call alongside markConsumedBlockLines on the same
+// map: well-formed HCL guarantees attr and block ranges do not overlap, but writing the
+// same true value twice for a line is idempotent regardless.
+func markConsumedAttrLines(regions map[string]*AttrRegion, consumed map[int]bool) {
+	for _, region := range regions {
+		if region == nil {
+			continue
+		}
+		for line := region.StartLine; line <= region.EndLine; line++ {
+			consumed[line] = true
+		}
+	}
+}
+
+// markConsumedBlockLines marks the source lines covered by the given block regions.
+func markConsumedBlockLines(regions []*BlockRegion, consumed map[int]bool) {
+	for _, region := range regions {
+		if region == nil {
+			continue
+		}
+		for line := region.StartLine; line <= region.EndLine; line++ {
+			consumed[line] = true
+		}
+	}
+}
+
+// collectOrphanLines returns non-blank lines in the (blockStart, blockEnd) interior whose
+// source line number is not in `consumed`. These are comments or other content that no
+// region claimed as part of its leading-comment block. Preserving them protects against
+// silent data loss when reassembling a reordered body.
+//
+// Position semantics (trailing-orphan): callers emit these lines after all regions and
+// before the closing brace. In real pipelines orphans only arise when a comment appears
+// after the last region with no following sibling — comments interleaved between regions
+// are claimed as leading-comments of the region that follows them by collectLeadingComments.
+func collectOrphanLines(lines []string, blockStartLine, blockEndLine int, consumed map[int]bool) []string {
+	var orphans []string
+	for line := blockStartLine + 1; line < blockEndLine; line++ {
+		if consumed[line] {
+			continue
+		}
+		if line-1 < 0 || line-1 >= len(lines) {
+			continue
+		}
+		if strings.TrimSpace(lines[line-1]) == "" {
+			continue
+		}
+		orphans = append(orphans, lines[line-1])
+	}
+	return orphans
+}
+
 // ReorderBlockAttrsPreservingComments reorders attributes while preserving leading comments.
-// This is a line-based approach that works with raw content.
-// Returns the modified content.
+// Non-blank lines inside the block that no region claimed (orphan comments after the last
+// attribute, for example) are emitted before the closing brace so they are never silently lost.
 func ReorderBlockAttrsPreservingComments(
 	content []byte,
 	syntaxBody *hclsyntax.Body,
@@ -272,10 +337,8 @@ func ReorderBlockAttrsPreservingComments(
 		return content
 	}
 
-	// Extract attribute regions with leading comments
 	regions := ExtractAttrRegions(content, syntaxBody)
 
-	// Build sets for quick lookup
 	firstSet := make(map[string]bool)
 	for _, name := range firstAttrs {
 		firstSet[name] = true
@@ -285,7 +348,6 @@ func ReorderBlockAttrsPreservingComments(
 		lastSet[name] = true
 	}
 
-	// Categorize attribute names
 	var first, middle, last []string
 	for _, name := range orderedNames {
 		if _, exists := regions[name]; !exists {
@@ -300,7 +362,6 @@ func ReorderBlockAttrsPreservingComments(
 		}
 	}
 
-	// Sort first and last attributes by priority order
 	sortByPriority := func(names []string, priority []string) {
 		prioMap := make(map[string]int)
 		for i, name := range priority {
@@ -322,45 +383,232 @@ func ReorderBlockAttrsPreservingComments(
 	sortByPriority(first, firstAttrs)
 	sortByPriority(last, lastAttrs)
 
-	// Build the new block content in order
 	lines := SplitLines(content)
+	consumed := make(map[int]bool)
+	markConsumedAttrLines(regions, consumed)
+	orphans := collectOrphanLines(lines, blockStartLine, blockEndLine, consumed)
+
 	var newBlockContent []string
 
-	// Get block opening line
 	if blockStartLine-1 < len(lines) {
 		newBlockContent = append(newBlockContent, lines[blockStartLine-1])
 	}
 
-	// Add attributes in new order
 	reorderedNames := append(append(first, middle...), last...)
 	for _, name := range reorderedNames {
 		region := regions[name]
 		if region == nil {
 			continue
 		}
-		// Add leading comment if present
 		if region.LeadingComment != "" {
 			commentLines := strings.Split(strings.TrimSuffix(region.LeadingComment, "\n"), "\n")
 			newBlockContent = append(newBlockContent, commentLines...)
 		}
-		// Add attribute lines
 		newBlockContent = append(newBlockContent, region.Lines...)
 	}
 
-	// Get block closing line
+	newBlockContent = append(newBlockContent, orphans...)
+
 	if blockEndLine-1 < len(lines) {
 		newBlockContent = append(newBlockContent, lines[blockEndLine-1])
 	}
 
-	// Rebuild full content
 	var result []string
-	// Lines before block
 	for i := 0; i < blockStartLine-1 && i < len(lines); i++ {
 		result = append(result, lines[i])
 	}
-	// New block content
 	result = append(result, newBlockContent...)
-	// Lines after block
+	for i := blockEndLine; i < len(lines); i++ {
+		result = append(result, lines[i])
+	}
+
+	return []byte(strings.Join(result, "\n") + "\n")
+}
+
+// BlockRegion represents a nested block with its leading comments.
+type BlockRegion struct {
+	Type           string
+	Labels         []string
+	LeadingComment string   // Comments on lines before the block (may be empty)
+	Lines          []string // The block's source lines (opening header through closing brace)
+	StartLine      int      // 1-indexed line number where region starts (includes leading comments)
+	EndLine        int      // 1-indexed line number where region ends
+}
+
+// ExtractBlockRegions extracts nested block regions (including leading comments) from content.
+// syntaxBody provides accurate line numbers for blocks. Regions are returned in source order.
+//
+// Leading-comment scan stops at the closest prior body item (attribute or block), so blocks
+// sandwiched between attributes pick up only comments that belong to them.
+func ExtractBlockRegions(content []byte, syntaxBody *hclsyntax.Body) []*BlockRegion {
+	if len(syntaxBody.Blocks) == 0 {
+		return nil
+	}
+	lines := SplitLines(content)
+
+	// Collect all body item end lines so each block can find its immediate prior boundary
+	// regardless of body element kind.
+	endLines := make([]int, 0, len(syntaxBody.Attributes)+len(syntaxBody.Blocks))
+	for _, attr := range syntaxBody.Attributes {
+		endLines = append(endLines, attr.Range().End.Line)
+	}
+	for _, b := range syntaxBody.Blocks {
+		endLines = append(endLines, b.Range().End.Line)
+	}
+	sort.Ints(endLines)
+
+	blocks := make([]*hclsyntax.Block, len(syntaxBody.Blocks))
+	copy(blocks, syntaxBody.Blocks)
+	sort.Slice(blocks, func(i, j int) bool {
+		return blocks[i].Range().Start.Line < blocks[j].Range().Start.Line
+	})
+
+	regions := make([]*BlockRegion, 0, len(blocks))
+	for _, blk := range blocks {
+		startLine := blk.Range().Start.Line
+		endLine := blk.Range().End.Line
+
+		searchStart := priorBoundary(endLines, startLine)
+
+		leadingCommentLines := collectLeadingComments(lines, startLine, searchStart)
+
+		region := &BlockRegion{
+			Type:      blk.Type,
+			Labels:    append([]string(nil), blk.Labels...),
+			StartLine: startLine,
+			EndLine:   endLine,
+		}
+		if len(leadingCommentLines) > 0 {
+			region.LeadingComment = strings.Join(leadingCommentLines, "\n") + "\n"
+			region.StartLine = startLine - len(leadingCommentLines)
+		}
+		for lineNum := startLine; lineNum <= endLine && lineNum-1 < len(lines); lineNum++ {
+			region.Lines = append(region.Lines, lines[lineNum-1])
+		}
+		regions = append(regions, region)
+	}
+
+	return regions
+}
+
+// priorBoundary returns the line immediately after the largest end-line in sortedEndLines
+// that is strictly less than startLine. Returns 1 if no such end-line exists.
+func priorBoundary(sortedEndLines []int, startLine int) int {
+	boundary := 1
+	for _, end := range sortedEndLines {
+		if end >= startLine {
+			break
+		}
+		if end+1 > boundary {
+			boundary = end + 1
+		}
+	}
+	return boundary
+}
+
+// ReorderBlockBodyPreservingAll reorders attributes AND nested blocks in a block body,
+// preserving leading comments on each. The desired output structure is:
+//
+//  1. Attributes named in attrOrder (in that order).
+//  2. Nested blocks whose type is in nestedBlockOrder (in that order; multiple blocks of the
+//     same type keep their original relative order).
+//  3. Remaining attributes (in their original source order).
+//  4. Remaining nested blocks (in their original source order).
+//
+// Items not present in the body are silently skipped.
+func ReorderBlockBodyPreservingAll(
+	content []byte,
+	syntaxBody *hclsyntax.Body,
+	blockStartLine, blockEndLine int,
+	attrOrder, nestedBlockOrder []string,
+) []byte {
+	attrRegions := ExtractAttrRegions(content, syntaxBody)
+	blockRegions := ExtractBlockRegions(content, syntaxBody)
+
+	if len(attrRegions) == 0 && len(blockRegions) == 0 {
+		return content
+	}
+
+	attrPrio := make(map[string]int, len(attrOrder))
+	for i, name := range attrOrder {
+		attrPrio[name] = i
+	}
+	blockPrio := make(map[string]int, len(nestedBlockOrder))
+	for i, t := range nestedBlockOrder {
+		blockPrio[t] = i
+	}
+
+	var orderedAttrs, leftoverAttrs []*AttrRegion
+	for _, name := range GetOrderedAttrNames(syntaxBody) {
+		region, ok := attrRegions[name]
+		if !ok || region == nil {
+			continue
+		}
+		if _, prioritized := attrPrio[name]; prioritized {
+			orderedAttrs = append(orderedAttrs, region)
+		} else {
+			leftoverAttrs = append(leftoverAttrs, region)
+		}
+	}
+	sort.SliceStable(orderedAttrs, func(i, j int) bool {
+		return attrPrio[orderedAttrs[i].Name] < attrPrio[orderedAttrs[j].Name]
+	})
+
+	var orderedBlocks, leftoverBlocks []*BlockRegion
+	for _, region := range blockRegions {
+		if _, prioritized := blockPrio[region.Type]; prioritized {
+			orderedBlocks = append(orderedBlocks, region)
+		} else {
+			leftoverBlocks = append(leftoverBlocks, region)
+		}
+	}
+	sort.SliceStable(orderedBlocks, func(i, j int) bool {
+		return blockPrio[orderedBlocks[i].Type] < blockPrio[orderedBlocks[j].Type]
+	})
+
+	lines := SplitLines(content)
+
+	consumed := make(map[int]bool)
+	markConsumedAttrLines(attrRegions, consumed)
+	markConsumedBlockLines(blockRegions, consumed)
+	orphans := collectOrphanLines(lines, blockStartLine, blockEndLine, consumed)
+
+	var newBlockContent []string
+	if blockStartLine-1 < len(lines) {
+		newBlockContent = append(newBlockContent, lines[blockStartLine-1])
+	}
+
+	appendRegion := func(comment string, regionLines []string) {
+		if comment != "" {
+			commentLines := strings.Split(strings.TrimSuffix(comment, "\n"), "\n")
+			newBlockContent = append(newBlockContent, commentLines...)
+		}
+		newBlockContent = append(newBlockContent, regionLines...)
+	}
+	for _, r := range orderedAttrs {
+		appendRegion(r.LeadingComment, r.Lines)
+	}
+	for _, r := range orderedBlocks {
+		appendRegion(r.LeadingComment, r.Lines)
+	}
+	for _, r := range leftoverAttrs {
+		appendRegion(r.LeadingComment, r.Lines)
+	}
+	for _, r := range leftoverBlocks {
+		appendRegion(r.LeadingComment, r.Lines)
+	}
+
+	newBlockContent = append(newBlockContent, orphans...)
+
+	if blockEndLine-1 < len(lines) {
+		newBlockContent = append(newBlockContent, lines[blockEndLine-1])
+	}
+
+	var result []string
+	for i := 0; i < blockStartLine-1 && i < len(lines); i++ {
+		result = append(result, lines[i])
+	}
+	result = append(result, newBlockContent...)
 	for i := blockEndLine; i < len(lines); i++ {
 		result = append(result, lines[i])
 	}
@@ -712,97 +960,159 @@ func ParseBothFormats(content []byte, filePath string) (*hclsyntax.Body, *hclwri
 	return syntaxBody, writeFile, nil
 }
 
-// ReorderTopLevelBlocks reorders top-level blocks in a file according to best practices:
-// 1. terraform blocks first
-// 2. provider blocks second
-// 3. variable blocks
-// 4. locals blocks
-// 5. data blocks
-// 6. resource blocks
-// 7. module blocks
-// 8. output blocks
-func ReorderTopLevelBlocks(writeFile *hclwrite.File) []byte {
-	blocks := writeFile.Body().Blocks()
-	if len(blocks) == 0 {
-		return writeFile.Bytes()
-	}
-
-	// Categorize blocks by type
-	var terraformBlocks []*hclwrite.Block
-	var providerBlocks []*hclwrite.Block
-	var variableBlocks []*hclwrite.Block
-	var localsBlocks []*hclwrite.Block
-	var dataBlocks []*hclwrite.Block
-	var resourceBlocks []*hclwrite.Block
-	var moduleBlocks []*hclwrite.Block
-	var outputBlocks []*hclwrite.Block
-	var otherBlocks []*hclwrite.Block
-
-	for _, block := range blocks {
-		switch block.Type() {
-		case "terraform":
-			terraformBlocks = append(terraformBlocks, block)
-		case "provider":
-			providerBlocks = append(providerBlocks, block)
-		case "variable":
-			variableBlocks = append(variableBlocks, block)
-		case "locals":
-			localsBlocks = append(localsBlocks, block)
-		case "data":
-			dataBlocks = append(dataBlocks, block)
-		case "resource":
-			resourceBlocks = append(resourceBlocks, block)
-		case "module":
-			moduleBlocks = append(moduleBlocks, block)
-		case "output":
-			outputBlocks = append(outputBlocks, block)
-		default:
-			otherBlocks = append(otherBlocks, block)
-		}
-	}
-
-	// Clear all blocks from the body
-	for _, block := range blocks {
-		writeFile.Body().RemoveBlock(block)
-	}
-
-	// Re-add blocks in the desired order
-	addBlocksWithSpacing(writeFile.Body(), terraformBlocks)
-	addBlocksWithSpacing(writeFile.Body(), providerBlocks)
-	addBlocksWithSpacing(writeFile.Body(), variableBlocks)
-	addBlocksWithSpacing(writeFile.Body(), localsBlocks)
-	addBlocksWithSpacing(writeFile.Body(), dataBlocks)
-	addBlocksWithSpacing(writeFile.Body(), resourceBlocks)
-	addBlocksWithSpacing(writeFile.Body(), moduleBlocks)
-	addBlocksWithSpacing(writeFile.Body(), outputBlocks)
-	addBlocksWithSpacing(writeFile.Body(), otherBlocks)
-
-	return FormatAndCleanBlankLines(writeFile.Bytes())
+// topLevelBlockPriority defines the canonical source order for top-level blocks.
+// Blocks of unknown type (e.g., user-defined extensions) sort to the bottom in source order.
+var topLevelBlockPriority = map[string]int{
+	"terraform": 1,
+	"provider":  2,
+	"variable":  3,
+	"locals":    4,
+	"data":      5,
+	"resource":  6,
+	"module":    7,
+	"output":    8,
 }
 
-// addBlocksWithSpacing adds blocks to a body, preserving their content including inline comments.
-func addBlocksWithSpacing(body *hclwrite.Body, blocks []*hclwrite.Block) {
-	for _, block := range blocks {
-		newBlock := body.AppendNewBlock(block.Type(), block.Labels())
-		// Copy attributes with inline comments preserved
-		for name, attr := range block.Body().Attributes() {
-			newBlock.Body().SetAttributeRaw(name, getExprTokensWithTrailingComment(attr))
+// topLevelOtherPriority is the sort key for top-level blocks of unknown type. The wide gap
+// from the highest known priority (8) leaves room to add new canonical types without
+// disturbing the relative ordering of pre-existing unknown blocks.
+const topLevelOtherPriority = 99
+
+// collectAdjacentLeadingComments walks backwards from startLine-1 (exclusive) down to
+// searchStart (inclusive), collecting `#` and `//` comment lines that are DIRECTLY
+// adjacent (no blank-line gap). Unlike collectLeadingComments, a blank line terminates
+// the scan. This stricter semantics matches the conventional reading at the top level:
+// file-header comments are separated from the first block by a blank line and should
+// stay with the file, not travel with the block.
+//
+// Returns the captured comment lines in source order. regionStart is the 1-indexed line
+// number of the first captured comment (or equal to startLine if no comments were captured).
+func collectAdjacentLeadingComments(lines []string, startLine, searchStart int) (comments []string, regionStart int) {
+	regionStart = startLine
+	for lineNum := startLine - 1; lineNum >= searchStart; lineNum-- {
+		if lineNum-1 < 0 || lineNum-1 >= len(lines) {
+			break
 		}
-		// Copy nested blocks
-		for _, nested := range block.Body().Blocks() {
-			copyNestedBlock(newBlock.Body(), nested)
+		line := lines[lineNum-1]
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			break
 		}
-		body.AppendNewline()
+		if !strings.HasPrefix(trimmed, "#") && !strings.HasPrefix(trimmed, "//") {
+			break
+		}
+		comments = append([]string{line}, comments...)
+		regionStart = lineNum
 	}
+	return comments, regionStart
 }
 
-// copyNestedBlock recursively copies a nested block to a new body, preserving inline comments.
-func copyNestedBlock(body *hclwrite.Body, block *hclwrite.Block) {
-	newBlock := body.AppendNewBlock(block.Type(), block.Labels())
-	for name, attr := range block.Body().Attributes() {
-		newBlock.Body().SetAttributeRaw(name, getExprTokensWithTrailingComment(attr))
+// ReorderTopLevelBlocksByLineRange reorders top-level blocks in a HCL file according to the
+// canonical priority defined by topLevelBlockPriority (terraform, provider, variable, locals,
+// data, resource, module, output, then anything else in source order).
+//
+// This is a line-based reorder: each block is emitted as its original source line range
+// plus any captured leading comments, so attribute order, inline comments, nested-block
+// layout, and heredoc bodies inside each block are byte-for-byte preserved.
+//
+// Stable within priority: blocks of the same type retain their original relative order.
+// File-header content (anything before the first block's adjacent leading comments) and
+// file-footer content (anything after the last block in source) is preserved verbatim.
+// Reordered blocks are joined with exactly one blank line between them.
+//
+// Top-level leading-comment capture is strict (collectAdjacentLeadingComments): only comments
+// directly above a block with no blank-line gap travel with it. This matches the convention
+// that file-level headers (copyright, license) are visually separated from the first block
+// by a blank line and should remain anchored to the file.
+func ReorderTopLevelBlocksByLineRange(content []byte) ([]byte, error) {
+	syntaxFile, diags := hclsyntax.ParseConfig(content, "", hcl.InitialPos)
+	if diags.HasErrors() {
+		return nil, diags
 	}
-	for _, nested := range block.Body().Blocks() {
-		copyNestedBlock(newBlock.Body(), nested)
+	body, ok := syntaxFile.Body.(*hclsyntax.Body)
+	if !ok || len(body.Blocks) == 0 {
+		return content, nil
 	}
+
+	lines := SplitLines(content)
+
+	sourceBlocks := make([]*hclsyntax.Block, len(body.Blocks))
+	copy(sourceBlocks, body.Blocks)
+	sort.Slice(sourceBlocks, func(i, j int) bool {
+		return sourceBlocks[i].Range().Start.Line < sourceBlocks[j].Range().Start.Line
+	})
+
+	type topRegion struct {
+		priority     int
+		sourceIdx    int
+		commentLines []string
+		regionStart  int // 1-indexed line where the comment+body region begins
+		bodyStart    int
+		bodyEnd      int
+	}
+
+	regions := make([]topRegion, 0, len(sourceBlocks))
+	for i, blk := range sourceBlocks {
+		searchStart := 1
+		if i > 0 {
+			searchStart = sourceBlocks[i-1].Range().End.Line + 1
+		}
+		commentLines, regionStart := collectAdjacentLeadingComments(lines, blk.Range().Start.Line, searchStart)
+
+		prio, known := topLevelBlockPriority[blk.Type]
+		if !known {
+			prio = topLevelOtherPriority
+		}
+		regions = append(regions, topRegion{
+			priority:     prio,
+			sourceIdx:    i,
+			commentLines: commentLines,
+			regionStart:  regionStart,
+			bodyStart:    blk.Range().Start.Line,
+			bodyEnd:      blk.Range().End.Line,
+		})
+	}
+
+	headerEnd := regions[0].regionStart
+	footerStart := sourceBlocks[len(sourceBlocks)-1].Range().End.Line
+
+	sort.SliceStable(regions, func(i, j int) bool {
+		if regions[i].priority != regions[j].priority {
+			return regions[i].priority < regions[j].priority
+		}
+		return regions[i].sourceIdx < regions[j].sourceIdx
+	})
+
+	var result []string
+
+	// File header: everything before the first source block's adjacent-comment region.
+	for i := 0; i < headerEnd-1 && i < len(lines); i++ {
+		result = append(result, lines[i])
+	}
+
+	for i, r := range regions {
+		if i > 0 {
+			result = append(result, "")
+		}
+		result = append(result, r.commentLines...)
+		for line := r.bodyStart; line <= r.bodyEnd && line-1 < len(lines); line++ {
+			result = append(result, lines[line-1])
+		}
+	}
+
+	// File footer: everything after the last source block, dropping a leading blank
+	// so the separator we emit before the footer isn't doubled.
+	var footer []string
+	for i := footerStart; i < len(lines); i++ {
+		footer = append(footer, lines[i])
+	}
+	for len(footer) > 0 && strings.TrimSpace(footer[0]) == "" {
+		footer = footer[1:]
+	}
+	if len(footer) > 0 {
+		result = append(result, "")
+		result = append(result, footer...)
+	}
+
+	return []byte(strings.Join(result, "\n") + "\n"), nil
 }

--- a/internal/engines/style/rules/helpers_test.go
+++ b/internal/engines/style/rules/helpers_test.go
@@ -1243,3 +1243,499 @@ func TestReorderBlockAttrs_EdgeCases(t *testing.T) {
 		assert.Greater(t, tagsIdx, nameIdx, "tags should appear after name")
 	})
 }
+
+func TestExtractBlockRegions(t *testing.T) {
+	tests := []struct {
+		name              string
+		content           string
+		expectTypes       []string
+		expectComments    map[int]string // block index -> expected comment substring
+		expectLineCounts  map[int]int    // block index -> expected number of lines
+		expectFirstLineAt map[int]int    // block index -> expected first line of region (1-indexed, comments-included)
+	}{
+		{
+			name: "single nested block without comment",
+			content: `variable "x" {
+  type = string
+  validation {
+    condition     = length(var.x) > 0
+    error_message = "required"
+  }
+}`,
+			expectTypes:      []string{"validation"},
+			expectLineCounts: map[int]int{0: 4},
+		},
+		{
+			name: "block with leading comment",
+			content: `variable "x" {
+  type = string
+  # validation comment
+  validation {
+    condition     = length(var.x) > 0
+    error_message = "required"
+  }
+}`,
+			expectTypes:    []string{"validation"},
+			expectComments: map[int]string{0: "# validation comment"},
+		},
+		{
+			name: "block sandwiched between attributes captures only its own comment",
+			//nolint:dupword // HCL content intentionally contains repeated identifiers
+			content: `variable "x" {
+  description = "x"
+  # only this comment belongs to validation
+  validation {
+    condition     = length(var.x) > 0
+    error_message = "required"
+  }
+  type = string
+}`,
+			expectTypes: []string{"validation"},
+			expectComments: map[int]string{
+				0: "# only this comment belongs to validation",
+			},
+		},
+		{
+			name: "multiple validation blocks preserved in source order",
+			content: `variable "x" {
+  type = string
+  validation {
+    condition     = length(var.x) > 0
+    error_message = "first"
+  }
+  validation {
+    condition     = length(var.x) < 64
+    error_message = "second"
+  }
+}`,
+			expectTypes: []string{"validation", "validation"},
+		},
+		{
+			name: "body with no nested blocks returns nil",
+			content: `variable "x" {
+  type = string
+}`,
+			expectTypes: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, diags := hclsyntax.ParseConfig([]byte(tt.content), "test.tf", hcl.InitialPos)
+			require.False(t, diags.HasErrors())
+
+			body := file.Body.(*hclsyntax.Body)
+			require.NotEmpty(t, body.Blocks, "test content should have at least one block")
+
+			regions := ExtractBlockRegions([]byte(tt.content), body.Blocks[0].Body)
+			require.Equal(t, len(tt.expectTypes), len(regions),
+				"expected %d regions, got %d", len(tt.expectTypes), len(regions))
+
+			for i, want := range tt.expectTypes {
+				assert.Equal(t, want, regions[i].Type, "region %d type", i)
+			}
+			for idx, want := range tt.expectComments {
+				assert.Contains(t, regions[idx].LeadingComment, want,
+					"region %d should have comment %q", idx, want)
+			}
+			for idx, want := range tt.expectLineCounts {
+				assert.Equal(t, want, len(regions[idx].Lines),
+					"region %d should span %d lines, got %d", idx, want, len(regions[idx].Lines))
+			}
+			for idx, want := range tt.expectFirstLineAt {
+				assert.Equal(t, want, regions[idx].StartLine, "region %d StartLine", idx)
+			}
+		})
+	}
+}
+
+func TestReorderBlockBodyPreservingAll(t *testing.T) {
+	t.Run("attrs and nested blocks reorder to canonical layout", func(t *testing.T) {
+		content := `variable "x" {
+  validation {
+    condition     = length(var.x) > 0
+    error_message = "required"
+  }
+  type        = string
+  description = "x"
+}
+`
+		file, diags := hclsyntax.ParseConfig([]byte(content), "test.tf", hcl.InitialPos)
+		require.False(t, diags.HasErrors())
+		body := file.Body.(*hclsyntax.Body)
+		require.NotEmpty(t, body.Blocks)
+		block := body.Blocks[0]
+
+		result := ReorderBlockBodyPreservingAll(
+			[]byte(content),
+			block.Body,
+			block.Range().Start.Line,
+			block.Range().End.Line,
+			[]string{"description", "type"},
+			[]string{"validation"},
+		)
+		out := string(result)
+
+		descIdx := strings.Index(out, `description = "x"`)
+		typeIdx := strings.Index(out, `type        = string`)
+		valIdx := strings.Index(out, `validation {`)
+		require.NotEqual(t, -1, descIdx)
+		require.NotEqual(t, -1, typeIdx)
+		require.NotEqual(t, -1, valIdx)
+		assert.Less(t, descIdx, typeIdx, "description before type")
+		assert.Less(t, typeIdx, valIdx, "type before validation")
+	})
+
+	t.Run("unknown attrs and blocks land after prioritized ones in source order", func(t *testing.T) {
+		content := `variable "x" {
+  custom_block {
+    field = 1
+  }
+  unknown_attr = "u"
+  validation {
+    condition     = length(var.x) > 0
+    error_message = "required"
+  }
+  type        = string
+  description = "x"
+}
+`
+		file, diags := hclsyntax.ParseConfig([]byte(content), "test.tf", hcl.InitialPos)
+		require.False(t, diags.HasErrors())
+		body := file.Body.(*hclsyntax.Body)
+		block := body.Blocks[0]
+
+		result := ReorderBlockBodyPreservingAll(
+			[]byte(content),
+			block.Body,
+			block.Range().Start.Line,
+			block.Range().End.Line,
+			[]string{"description", "type"},
+			[]string{"validation"},
+		)
+		out := string(result)
+
+		descIdx := strings.Index(out, `description = "x"`)
+		typeIdx := strings.Index(out, `type        = string`)
+		valIdx := strings.Index(out, `validation {`)
+		unknownIdx := strings.Index(out, `unknown_attr = "u"`)
+		customIdx := strings.Index(out, `custom_block {`)
+
+		assert.Less(t, descIdx, typeIdx, "description before type")
+		assert.Less(t, typeIdx, valIdx, "type before validation")
+		assert.Less(t, valIdx, unknownIdx, "validation before unknown_attr")
+		assert.Less(t, unknownIdx, customIdx, "unknown_attr before custom_block")
+	})
+
+	t.Run("empty body is left unchanged", func(t *testing.T) {
+		content := "variable \"x\" {}\n"
+		file, diags := hclsyntax.ParseConfig([]byte(content), "test.tf", hcl.InitialPos)
+		require.False(t, diags.HasErrors())
+		body := file.Body.(*hclsyntax.Body)
+		block := body.Blocks[0]
+
+		result := ReorderBlockBodyPreservingAll(
+			[]byte(content),
+			block.Body,
+			block.Range().Start.Line,
+			block.Range().End.Line,
+			[]string{"description"},
+			[]string{"validation"},
+		)
+		assert.Equal(t, content, string(result))
+	})
+
+	t.Run("trailing orphan comment is preserved before closing brace", func(t *testing.T) {
+		content := `variable "x" {
+  type        = string
+  description = "x"
+
+  # forgotten note pinned to the bottom
+}
+`
+		file, diags := hclsyntax.ParseConfig([]byte(content), "test.tf", hcl.InitialPos)
+		require.False(t, diags.HasErrors())
+		body := file.Body.(*hclsyntax.Body)
+		block := body.Blocks[0]
+
+		result := ReorderBlockBodyPreservingAll(
+			[]byte(content),
+			block.Body,
+			block.Range().Start.Line,
+			block.Range().End.Line,
+			[]string{"description", "type"},
+			nil,
+		)
+		out := string(result)
+
+		assert.Contains(t, out, `# forgotten note pinned to the bottom`,
+			"orphan comment with no following region must not be dropped")
+
+		// Orphan should appear after the last region and before the closing brace.
+		descIdx := strings.Index(out, `description = "x"`)
+		orphanIdx := strings.Index(out, `# forgotten note pinned to the bottom`)
+		closeIdx := strings.LastIndex(out, "}")
+		assert.Greater(t, orphanIdx, descIdx, "orphan should appear after all regions")
+		assert.Less(t, orphanIdx, closeIdx, "orphan should appear before closing brace")
+	})
+}
+
+func TestCollectOrphanLines(t *testing.T) {
+	tests := []struct {
+		name           string
+		content        string
+		blockStart     int
+		blockEnd       int
+		consumed       map[int]bool
+		expectedOrphan []string
+	}{
+		{
+			name: "trailing comment with no following region",
+			content: `block {
+  attr = "x"
+
+  # orphan
+}`,
+			blockStart:     1,
+			blockEnd:       5,
+			consumed:       map[int]bool{2: true},
+			expectedOrphan: []string{"  # orphan"},
+		},
+		{
+			name: "no orphans when everything is consumed",
+			content: `block {
+  a = 1
+  b = 2
+}`,
+			blockStart:     1,
+			blockEnd:       4,
+			consumed:       map[int]bool{2: true, 3: true},
+			expectedOrphan: nil,
+		},
+		{
+			name: "blank lines are dropped, not treated as orphans",
+			content: `block {
+  a = 1
+
+
+}`,
+			blockStart:     1,
+			blockEnd:       5,
+			consumed:       map[int]bool{2: true},
+			expectedOrphan: nil,
+		},
+		{
+			// Helper-level contract test. In real pipelines mid-block orphans do not
+			// arise because collectLeadingComments would claim line 3 as line 4's leading
+			// comment and the caller would mark line 3 consumed. We construct a `consumed`
+			// map that omits line 3 to verify the helper's contract: any non-consumed,
+			// non-blank line is returned regardless of position.
+			name: "non-consumed interior line is returned (helper contract)",
+			content: `block {
+  a = 1
+  # interior line
+  b = 2
+}`,
+			blockStart:     1,
+			blockEnd:       5,
+			consumed:       map[int]bool{2: true, 4: true},
+			expectedOrphan: []string{"  # interior line"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lines := SplitLines([]byte(tt.content))
+			got := collectOrphanLines(lines, tt.blockStart, tt.blockEnd, tt.consumed)
+			assert.Equal(t, tt.expectedOrphan, got)
+		})
+	}
+}
+
+func TestReorderTopLevelBlocksByLineRange(t *testing.T) {
+	t.Run("canonical priority order", func(t *testing.T) {
+		input := `output "x" { value = "x" }
+module "m" { source = "./m" }
+resource "r" "x" { x = 1 }
+data "d" "x" { x = 1 }
+locals { x = 1 }
+variable "v" { default = "x" }
+provider "p" { region = "x" }
+terraform { required_version = ">= 1.0" }
+`
+		out, err := ReorderTopLevelBlocksByLineRange([]byte(input))
+		require.NoError(t, err)
+
+		assertOrderedSubstrings(t, string(out), []string{
+			"terraform {",
+			"provider ",
+			"variable ",
+			"locals {",
+			"data ",
+			"resource ",
+			"module ",
+			"output ",
+		})
+	})
+
+	t.Run("preserves block-internal content byte-for-byte", func(t *testing.T) {
+		input := `resource "aws_instance" "x" {
+  # important comment
+  ami           = "ami-123"
+  instance_type = "t3.medium" # trailing
+  tags = {
+    Name = "test"
+  }
+}
+
+terraform {
+  required_version = ">= 1.0"
+}
+`
+		out, err := ReorderTopLevelBlocksByLineRange([]byte(input))
+		require.NoError(t, err)
+		outStr := string(out)
+
+		// Resource body must be byte-for-byte preserved; the buggy old helper would
+		// reshuffle attrs via map iteration.
+		expectedResourceBody := `resource "aws_instance" "x" {
+  # important comment
+  ami           = "ami-123"
+  instance_type = "t3.medium" # trailing
+  tags = {
+    Name = "test"
+  }
+}`
+		assert.Contains(t, outStr, expectedResourceBody)
+	})
+
+	t.Run("file header preserved before reordered blocks", func(t *testing.T) {
+		input := `# Copyright notice
+# License terms
+
+resource "x" "x" { x = 1 }
+
+terraform { required_version = ">= 1.0" }
+`
+		out, err := ReorderTopLevelBlocksByLineRange([]byte(input))
+		require.NoError(t, err)
+		outStr := string(out)
+
+		assertOrderedSubstrings(t, outStr, []string{
+			"# Copyright notice",
+			"# License terms",
+			"terraform {",
+			"resource ",
+		})
+	})
+
+	t.Run("file footer preserved after reordered blocks", func(t *testing.T) {
+		input := `resource "x" "x" { x = 1 }
+
+terraform { required_version = ">= 1.0" }
+
+# trailing footer note
+`
+		out, err := ReorderTopLevelBlocksByLineRange([]byte(input))
+		require.NoError(t, err)
+		outStr := string(out)
+
+		// Footer must appear after the last reordered block.
+		footerIdx := strings.Index(outStr, "# trailing footer note")
+		resourceIdx := strings.Index(outStr, "resource ")
+		require.NotEqual(t, -1, footerIdx, "footer comment must survive")
+		require.NotEqual(t, -1, resourceIdx)
+		assert.Greater(t, footerIdx, resourceIdx, "footer must appear after last block")
+	})
+
+	t.Run("unknown block types sort to bottom in source order", func(t *testing.T) {
+		input := `custom_block "x" { x = 1 }
+terraform { required_version = ">= 1.0" }
+another_custom "y" { y = 2 }
+resource "r" "x" { x = 1 }
+`
+		out, err := ReorderTopLevelBlocksByLineRange([]byte(input))
+		require.NoError(t, err)
+		assertOrderedSubstrings(t, string(out), []string{
+			"terraform {",
+			`resource `,
+			`custom_block `,
+			`another_custom `,
+		})
+	})
+
+	t.Run("empty file is returned unchanged", func(t *testing.T) {
+		input := []byte("")
+		out, err := ReorderTopLevelBlocksByLineRange(input)
+		require.NoError(t, err)
+		assert.Equal(t, input, out)
+	})
+
+	t.Run("comment directly above first block travels with that block", func(t *testing.T) {
+		// No blank line between the comment and the resource means the comment is the
+		// resource's adjacent leading comment, not file-level header content. After
+		// reorder, the comment must move with the resource.
+		input := `# directly attached comment
+resource "x" "x" { x = 1 }
+
+terraform { required_version = ">= 1.0" }
+`
+		out, err := ReorderTopLevelBlocksByLineRange([]byte(input))
+		require.NoError(t, err)
+		outStr := string(out)
+
+		// terraform is now first; the directly attached comment must precede resource
+		// (not appear at the top of the file as if it were a file header).
+		assertOrderedSubstrings(t, outStr, []string{
+			"terraform {",
+			"# directly attached comment",
+			"resource ",
+		})
+		// The directly attached comment must not appear before terraform.
+		tfIdx := strings.Index(outStr, "terraform {")
+		commentIdx := strings.Index(outStr, "# directly attached comment")
+		assert.Greater(t, commentIdx, tfIdx, "adjacent comment must travel with its block, not stay at file top")
+	})
+
+	t.Run("multi-blank-line gaps between blocks are normalised to single blank", func(t *testing.T) {
+		// Documents (does not enforce as new) behavior: the reorder emits exactly one
+		// blank line between reordered blocks. The old hclwrite-based reorder did the
+		// same through FormatAndCleanBlankLines. Extra blank lines between source blocks
+		// are collapsed; this is an intentional formatting normalization.
+		input := "terraform { required_version = \">= 1.0\" }\n\n\n\nresource \"x\" \"x\" { x = 1 }\n"
+		out, err := ReorderTopLevelBlocksByLineRange([]byte(input))
+		require.NoError(t, err)
+		outStr := string(out)
+
+		// Count blank-line runs between terraform and resource — there must be exactly one.
+		tfEnd := strings.Index(outStr, "}\n")
+		require.NotEqual(t, -1, tfEnd)
+		between := outStr[tfEnd+2:]
+		resIdx := strings.Index(between, "resource ")
+		require.NotEqual(t, -1, resIdx)
+		gap := between[:resIdx]
+		assert.Equal(t, "\n", gap, "expected exactly one blank line between blocks, got %q", gap)
+	})
+
+	t.Run("invalid HCL returns an error", func(t *testing.T) {
+		input := []byte("this is not valid hcl {{{\n")
+		_, err := ReorderTopLevelBlocksByLineRange(input)
+		assert.Error(t, err)
+	})
+
+	t.Run("stable order within same block type", func(t *testing.T) {
+		input := `variable "b" { default = "b" }
+variable "a" { default = "a" }
+terraform { required_version = ">= 1.0" }
+`
+		out, err := ReorderTopLevelBlocksByLineRange([]byte(input))
+		require.NoError(t, err)
+
+		// terraform must come first; variables preserve their source order (b then a).
+		assertOrderedSubstrings(t, string(out), []string{
+			"terraform {",
+			`variable "b"`,
+			`variable "a"`,
+		})
+	})
+}

--- a/internal/engines/style/rules/ordering.go
+++ b/internal/engines/style/rules/ordering.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
@@ -130,8 +131,25 @@ func (r *ForEachCountFirstRule) Fix(ctx *sdk.Context, file *hcl.File) ([]byte, e
 	return FormatAndCleanBlankLines(content), nil
 }
 
-// LifecycleAtEndRule ensures lifecycle block is at the end of resource blocks.
+// LifecycleAtEndRule ensures lifecycle block is at the end of resource, data,
+// module, and check blocks.
 type LifecycleAtEndRule struct{}
+
+// lifecycleHostBlockTypes lists the block types that may contain a `lifecycle`
+// nested block and that this rule polices. `check` is included for TF 1.5+
+// assertion blocks; while they rarely embed a lifecycle today, including the
+// type keeps the rule consistent and future-proof.
+var lifecycleHostBlockTypes = map[string]struct{}{
+	"resource": {},
+	"data":     {},
+	"module":   {},
+	"check":    {},
+}
+
+func isLifecycleHostBlock(blockType string) bool {
+	_, ok := lifecycleHostBlockTypes[blockType]
+	return ok
+}
 
 // Name returns the rule identifier.
 func (r *LifecycleAtEndRule) Name() string {
@@ -140,10 +158,10 @@ func (r *LifecycleAtEndRule) Name() string {
 
 // Description returns a human-readable description of the rule.
 func (r *LifecycleAtEndRule) Description() string {
-	return "Ensures lifecycle block is at the end of resource blocks"
+	return "Ensures lifecycle block is at the end of resource, data, module, and check blocks"
 }
 
-// Check examines resource blocks for lifecycle block positioning.
+// Check examines resource, data, module, and check blocks for lifecycle block positioning.
 func (r *LifecycleAtEndRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Finding, error) {
 	var findings []sdk.Finding
 
@@ -153,7 +171,7 @@ func (r *LifecycleAtEndRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Find
 	}
 
 	for _, block := range hclFile.Blocks {
-		if block.Type != "resource" {
+		if !isLifecycleHostBlock(block.Type) {
 			continue
 		}
 
@@ -182,7 +200,7 @@ func (r *LifecycleAtEndRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Find
 		if lifecycleBlock != nil && lifecycleBlock.Range().End.Line < lastLine {
 			findings = append(findings, sdk.Finding{
 				Rule:     r.Name(),
-				Message:  "lifecycle block should be at the end of the resource block",
+				Message:  "lifecycle block should be at the end of the " + block.Type + " block",
 				File:     ctx.File,
 				Location: sdk.LocationFromRange(lifecycleBlock.Range()),
 				Severity: sdk.SeverityWarning,
@@ -193,17 +211,18 @@ func (r *LifecycleAtEndRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Find
 	return findings, nil
 }
 
-// fixLifecyclePositionContent moves lifecycle block to the end of the resource.
-// Works entirely in memory - takes content as input.
-func (r *LifecycleAtEndRule) fixLifecyclePositionContent(content []byte, filePath string, blockLabels []string) ([]byte, error) {
+// fixLifecyclePositionContent moves the lifecycle block to the end of the
+// matching host block (resource, data, module, or check). Works entirely in
+// memory - takes content as input.
+func (r *LifecycleAtEndRule) fixLifecyclePositionContent(content []byte, filePath, blockType string, blockLabels []string) ([]byte, error) {
 	writeFile, diags := hclwrite.ParseConfig(content, filePath, hcl.InitialPos)
 	if diags.HasErrors() {
 		return nil, diags
 	}
 
-	// Find the resource block
+	// Find the host block
 	for _, block := range writeFile.Body().Blocks() {
-		if block.Type() != "resource" {
+		if block.Type() != blockType {
 			continue
 		}
 		if !MatchBlockLabels(block.Labels(), blockLabels) {
@@ -238,7 +257,7 @@ func (r *LifecycleAtEndRule) fixLifecyclePositionContent(content []byte, filePat
 	return FormatAndCleanBlankLines(writeFile.Bytes()), nil
 }
 
-// Fix moves lifecycle blocks to the end of resource blocks.
+// Fix moves lifecycle blocks to the end of resource, data, module, and check blocks.
 // Works entirely in memory - does NOT write to disk.
 func (r *LifecycleAtEndRule) Fix(ctx *sdk.Context, file *hcl.File) ([]byte, error) {
 	if ctx == nil || file == nil {
@@ -255,10 +274,14 @@ func (r *LifecycleAtEndRule) Fix(ctx *sdk.Context, file *hcl.File) ([]byte, erro
 		return nil, nil
 	}
 
-	// Collect block labels before modifying content
-	var blocksToFix [][]string
+	// Collect (block type, labels) pairs before modifying content
+	type blockRef struct {
+		blockType string
+		labels    []string
+	}
+	var blocksToFix []blockRef
 	for _, block := range hclFile.Blocks {
-		if block.Type != "resource" {
+		if !isLifecycleHostBlock(block.Type) {
 			continue
 		}
 
@@ -282,13 +305,13 @@ func (r *LifecycleAtEndRule) Fix(ctx *sdk.Context, file *hcl.File) ([]byte, erro
 		}
 
 		if lifecycleBlock != nil && lifecycleBlock.Range().End.Line < lastLine {
-			blocksToFix = append(blocksToFix, block.Labels)
+			blocksToFix = append(blocksToFix, blockRef{blockType: block.Type, labels: block.Labels})
 		}
 	}
 
 	// Process each block (re-parse after each modification)
-	for _, labels := range blocksToFix {
-		content, err = r.fixLifecyclePositionContent(content, ctx.File, labels)
+	for _, ref := range blocksToFix {
+		content, err = r.fixLifecyclePositionContent(content, ctx.File, ref.blockType, ref.labels)
 		if err != nil {
 			return nil, err
 		}
@@ -308,7 +331,7 @@ func (r *TagsAtEndRule) Name() string {
 
 // Description returns a human-readable description of the rule.
 func (r *TagsAtEndRule) Description() string {
-	return "Ensures tags/labels are near the end of resource blocks (before lifecycle)"
+	return "Ensures tags/labels appear just before lifecycle in resource/module blocks, after all other attributes and nested blocks"
 }
 
 // Check examines resource blocks for tags/labels positioning.
@@ -343,6 +366,11 @@ func (r *TagsAtEndRule) checkTagsBlock(ctx *sdk.Context, block *hclsyntax.Block)
 	lifecycleBlock := FindNestedBlock(body.Blocks, "lifecycle")
 	tagsLine := tagsAttr.Range().Start.Line
 
+	// Single-finding policy: the "before lifecycle" and "near the end" conditions both
+	// describe the same logical violation (tags is in the wrong spot). Emit the
+	// "before lifecycle" message when applicable since it is more specific; otherwise
+	// fall back to the more general "near the end" message. This avoids two findings
+	// pointing at the same line for a single misplacement.
 	if lifecycleBlock != nil && tagsLine > lifecycleBlock.Range().Start.Line {
 		findings = append(findings, sdk.Finding{
 			Rule:     r.Name(),
@@ -351,9 +379,11 @@ func (r *TagsAtEndRule) checkTagsBlock(ctx *sdk.Context, block *hclsyntax.Block)
 			Location: sdk.LocationFromRange(tagsAttr.Range()),
 			Severity: sdk.SeverityWarning,
 		})
-	}
-
-	if countAttrsAfterTags(body.Attributes, tagsLine) > 2 {
+	} else if countItemsAfterTags(body, tagsLine) > 0 {
+		// Flag any item (attr or non-lifecycle block) after tags. The earlier behavior
+		// (> 2 attrs) tolerated trailing attrs and ignored trailing nested blocks entirely,
+		// so a layout like `tags = {}; ingress {}; egress {}; lifecycle {}` went unflagged
+		// even though tags was nowhere near the end of the block.
 		findings = append(findings, sdk.Finding{
 			Rule:     r.Name(),
 			Message:  "tags should be near the end of the block",
@@ -366,69 +396,194 @@ func (r *TagsAtEndRule) checkTagsBlock(ctx *sdk.Context, block *hclsyntax.Block)
 	return findings
 }
 
+// findTagsAttribute returns the tags-family attribute the rule operates on, with a
+// deterministic priority. `tags` wins over `labels`, which wins over `tags_all`.
+// `tags_all` is provider-managed (derived from inherited tags) and is included only
+// as a fallback for resources that use it directly; otherwise the rule prefers the
+// author-controlled `tags`/`labels`.
 func findTagsAttribute(attrs hclsyntax.Attributes) *hclsyntax.Attribute {
-	for name, attr := range attrs {
-		if name == "tags" || name == "labels" || name == "tags_all" {
+	for _, name := range []string{"tags", "labels", "tags_all"} {
+		if attr, ok := attrs[name]; ok {
 			return attr
 		}
 	}
 	return nil
 }
 
-func countAttrsAfterTags(attrs hclsyntax.Attributes, tagsLine int) int {
+// countItemsAfterTags counts attributes and nested blocks that appear after the tags
+// attribute, excluding the items the rule deliberately treats as trailing:
+//   - `tags_all` (the derived attribute paired with `tags`)
+//   - `depends_on` (a meta-argument that conventionally goes last)
+//   - `lifecycle` (the trailing nested block)
+//
+// The new threshold of > 0 (down from > 2) means a single trailing item flags the
+// violation. The exclusions ensure the rule does not fire on canonical layouts where
+// tags is followed only by depends_on / lifecycle.
+func countItemsAfterTags(body *hclsyntax.Body, tagsLine int) int {
 	count := 0
-	for name, attr := range attrs {
-		if attr.Range().Start.Line > tagsLine && name != "tags_all" {
+	for name, attr := range body.Attributes {
+		if attr.Range().Start.Line > tagsLine && name != "tags_all" && name != "depends_on" {
+			count++
+		}
+	}
+	for _, b := range body.Blocks {
+		if b.Range().Start.Line > tagsLine && b.Type != "lifecycle" {
 			count++
 		}
 	}
 	return count
 }
 
-// Fix moves tags/labels to the end of blocks (before lifecycle if present).
-// Uses line-based reordering to preserve leading comments.
-func (r *TagsAtEndRule) Fix(ctx *sdk.Context, file *hcl.File) ([]byte, error) {
+// Fix moves tags/labels (and tags_all) to land just before any lifecycle block,
+// or at the end of the block body if no lifecycle is present. Other attributes and
+// nested blocks stay in their source positions; only the tags region (including its
+// leading comment) moves. Operates bottom-up so line ranges remain valid across rewrites.
+func (r *TagsAtEndRule) Fix(ctx *sdk.Context, _ *hcl.File) ([]byte, error) {
 	content, err := os.ReadFile(ctx.File)
 	if err != nil {
 		return nil, err
 	}
 
-	hclFile, ok := file.Body.(*hclsyntax.Body)
+	syntaxFile, diags := hclsyntax.ParseConfig(content, ctx.File, hcl.InitialPos)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+	hclFile, ok := syntaxFile.Body.(*hclsyntax.Body)
 	if !ok {
 		return nil, nil
 	}
 
-	// Process each block that has tags
+	var targets []*hclsyntax.Block
 	for _, block := range hclFile.Blocks {
 		if block.Type != "resource" && block.Type != "module" {
 			continue
 		}
-
-		// Check if block has tags
-		hasTags := FindAttribute(block.Body.Attributes, "tags") != nil ||
-			FindAttribute(block.Body.Attributes, "labels") != nil ||
-			FindAttribute(block.Body.Attributes, "tags_all") != nil
-		if !hasTags {
+		if findTagsAttribute(block.Body.Attributes) == nil {
 			continue
 		}
+		targets = append(targets, block)
+	}
+	sort.Slice(targets, func(i, j int) bool {
+		return targets[i].Range().Start.Line > targets[j].Range().Start.Line
+	})
 
-		orderedNames := GetOrderedAttrNames(block.Body)
-		// tags/labels should be at the end (before depends_on)
-		lastAttrs := []string{"tags", "labels", "tags_all", "depends_on"}
-
-		// Use line-based reordering to preserve leading comments
-		content = ReorderBlockAttrsPreservingComments(
-			content,
-			block.Body,
-			block.Range().Start.Line,
-			block.Range().End.Line,
-			orderedNames,
-			nil,
-			lastAttrs,
-		)
+	for _, block := range targets {
+		content = moveTagsBeforeLifecycle(content, block)
 	}
 
 	return FormatAndCleanBlankLines(content), nil
+}
+
+// moveAttrBeforeLifecycle relocates the given attribute (with its leading comment)
+// inside `block` to immediately before any lifecycle nested block, or to the end of
+// the block body when no lifecycle is present. All other body lines remain at their
+// source positions. The move is a no-op when the attribute is already adjacent to
+// the insertion point. Returns content unchanged when attr is nil.
+//
+// Shared by both `style.tags-at-end` (via moveTagsBeforeLifecycle wrapper) and
+// `style.depends-on-order` (via moveDependsOnBeforeLifecycle wrapper).
+func moveAttrBeforeLifecycle(content []byte, block *hclsyntax.Block, attr *hclsyntax.Attribute) []byte {
+	if attr == nil {
+		return content
+	}
+	attrStart := attr.Range().Start.Line
+	attrEnd := attr.Range().End.Line
+
+	var insertBefore int
+	if lifecycle := FindNestedBlock(block.Body.Blocks, "lifecycle"); lifecycle != nil {
+		insertBefore = lifecycle.Range().Start.Line
+	} else {
+		insertBefore = block.Range().End.Line
+	}
+
+	lines := SplitLines(content)
+
+	// No-op when attr is already effectively adjacent to the insertion point: nothing
+	// but blank lines sits between attrEnd+1 and insertBefore-1. A strict `attrEnd+1
+	// == insertBefore` check would miss the common case of one blank line separating
+	// the attribute from `lifecycle`, causing Fix to mutate files that Check considers
+	// clean (the splice runs, FormatAndCleanBlankLines normalises, idempotence holds
+	// but a spurious diff is produced on the first pass).
+	alreadyAdjacent := true
+	for line := attrEnd + 1; line < insertBefore; line++ {
+		if line-1 < 0 || line-1 >= len(lines) {
+			continue
+		}
+		if strings.TrimSpace(lines[line-1]) != "" {
+			alreadyAdjacent = false
+			break
+		}
+	}
+	if alreadyAdjacent {
+		return content
+	}
+
+	// Compute prior boundary for the leading-comment scan: the largest body-item end-line
+	// less than attrStart, falling back to the block's opening line.
+	priorEnd := block.Range().Start.Line
+	for _, a := range block.Body.Attributes {
+		if a.Range().End.Line < attrStart && a.Range().End.Line > priorEnd {
+			priorEnd = a.Range().End.Line
+		}
+	}
+	for _, b := range block.Body.Blocks {
+		if b.Range().End.Line < attrStart && b.Range().End.Line > priorEnd {
+			priorEnd = b.Range().End.Line
+		}
+	}
+
+	// Capture the leading-comment line numbers (not just strings) so we can both emit
+	// the moved region and skip those exact lines from their original position.
+	var commentLineNums []int
+	for lineNum := attrStart - 1; lineNum >= priorEnd+1; lineNum-- {
+		if lineNum-1 < 0 || lineNum-1 >= len(lines) {
+			continue
+		}
+		trimmed := strings.TrimSpace(lines[lineNum-1])
+		if trimmed == "" {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "//") {
+			commentLineNums = append([]int{lineNum}, commentLineNums...)
+			continue
+		}
+		break
+	}
+
+	moved := make([]string, 0, len(commentLineNums)+(attrEnd-attrStart+1))
+	for _, n := range commentLineNums {
+		moved = append(moved, lines[n-1])
+	}
+	for line := attrStart; line <= attrEnd && line-1 < len(lines); line++ {
+		moved = append(moved, lines[line-1])
+	}
+
+	skipped := make(map[int]bool, len(commentLineNums)+(attrEnd-attrStart+1))
+	for _, n := range commentLineNums {
+		skipped[n] = true
+	}
+	for line := attrStart; line <= attrEnd; line++ {
+		skipped[line] = true
+	}
+
+	result := make([]string, 0, len(lines)+len(moved))
+	for i, line := range lines {
+		lineNum := i + 1
+		if lineNum == insertBefore {
+			result = append(result, moved...)
+		}
+		if !skipped[lineNum] {
+			result = append(result, line)
+		}
+	}
+
+	return []byte(strings.Join(result, "\n") + "\n")
+}
+
+// moveTagsBeforeLifecycle is a thin wrapper around moveAttrBeforeLifecycle targeting
+// the tags-family attribute selected by findTagsAttribute (tags > labels > tags_all).
+func moveTagsBeforeLifecycle(content []byte, block *hclsyntax.Block) []byte {
+	return moveAttrBeforeLifecycle(content, block, findTagsAttribute(block.Body.Attributes))
 }
 
 // DependsOnOrderRule ensures depends_on is at the end of blocks.
@@ -441,7 +596,7 @@ func (r *DependsOnOrderRule) Name() string {
 
 // Description returns a human-readable description of the rule.
 func (r *DependsOnOrderRule) Description() string {
-	return "Ensures depends_on is at the end of resource/module blocks"
+	return "Ensures depends_on appears just before lifecycle in resource/module blocks, after all other attributes and non-lifecycle nested blocks"
 }
 
 // Check examines blocks for depends_on attribute positioning.
@@ -481,6 +636,9 @@ func (r *DependsOnOrderRule) checkDependsOnBlock(ctx *sdk.Context, block *hclsyn
 	lifecycleBlock := FindNestedBlock(body.Blocks, "lifecycle")
 	dependsOnLine := dependsOnAttr.Range().Start.Line
 
+	// Single-finding policy: the "before lifecycle" and "near the end" conditions both
+	// describe the same logical violation. Prefer the more specific "before lifecycle"
+	// message; otherwise fall back to "near the end".
 	if lifecycleBlock != nil && dependsOnLine > lifecycleBlock.Range().Start.Line {
 		findings = append(findings, sdk.Finding{
 			Rule:     r.Name(),
@@ -489,73 +647,86 @@ func (r *DependsOnOrderRule) checkDependsOnBlock(ctx *sdk.Context, block *hclsyn
 			Location: sdk.LocationFromRange(dependsOnAttr.Range()),
 			Severity: sdk.SeverityWarning,
 		})
-	}
-
-	if r.hasAttributesAfterDependsOn(body.Attributes, dependsOnLine) {
+	} else if countItemsAfterDependsOn(body, dependsOnLine) > 0 {
+		// Warning severity: a misplacement that --fix will actively rewrite deserves at
+		// least Warning. Info would hide the finding under default `severity_threshold:
+		// warning` configs, leaving users surprised when `--fix` mutates their file.
 		findings = append(findings, sdk.Finding{
 			Rule:     r.Name(),
-			Message:  "depends_on should be near the end of the block",
+			Message:  "depends_on should come after non-lifecycle nested blocks and before lifecycle (or at the end of the block)",
 			File:     ctx.File,
 			Location: sdk.LocationFromRange(dependsOnAttr.Range()),
-			Severity: sdk.SeverityInfo,
+			Severity: sdk.SeverityWarning,
 		})
 	}
 
 	return findings
 }
 
-func (r *DependsOnOrderRule) hasAttributesAfterDependsOn(attrs hclsyntax.Attributes, dependsOnLine int) bool {
-	endAttrs := map[string]bool{"depends_on": true, "tags": true, "tags_all": true, "labels": true}
-	for name, attr := range attrs {
-		if !endAttrs[name] && attr.Range().Start.Line > dependsOnLine {
-			return true
+// countItemsAfterDependsOn counts attributes and nested blocks that appear after the
+// depends_on attribute, excluding the items conventionally placed at the very tail:
+//   - `tags`, `tags_all`, `labels` (the tags family lives between depends_on and lifecycle)
+//   - `lifecycle` (the trailing nested block)
+//
+// `dependsOnLine` is the depends_on attribute's start line; the `>` comparison ensures
+// depends_on itself is never counted (its own start line is never strictly greater).
+// A single trailing item flags the violation.
+func countItemsAfterDependsOn(body *hclsyntax.Body, dependsOnLine int) int {
+	endAttrs := map[string]bool{"tags": true, "tags_all": true, "labels": true}
+	count := 0
+	for name, attr := range body.Attributes {
+		if attr.Range().Start.Line > dependsOnLine && !endAttrs[name] {
+			count++
 		}
 	}
-	return false
+	for _, b := range body.Blocks {
+		if b.Range().Start.Line > dependsOnLine && b.Type != "lifecycle" {
+			count++
+		}
+	}
+	return count
 }
 
-// Fix moves depends_on to be near the end of blocks.
-// Uses line-based reordering to preserve leading comments.
-func (r *DependsOnOrderRule) Fix(ctx *sdk.Context, file *hcl.File) ([]byte, error) {
-	if ctx == nil || file == nil {
+// Fix moves depends_on to land just before any lifecycle block, or at the end of
+// the block body when no lifecycle is present. Other attributes and nested blocks
+// (e.g. `ordered_placement_strategy` in `aws_ecs_service`) stay at their source
+// positions; only the depends_on region (including its leading comment) moves.
+func (r *DependsOnOrderRule) Fix(ctx *sdk.Context, _ *hcl.File) ([]byte, error) {
+	if ctx == nil {
 		return nil, nil
 	}
-
 	content, err := os.ReadFile(ctx.File)
 	if err != nil {
 		return nil, err
 	}
 
-	hclFile, ok := file.Body.(*hclsyntax.Body)
+	syntaxFile, diags := hclsyntax.ParseConfig(content, ctx.File, hcl.InitialPos)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+	hclFile, ok := syntaxFile.Body.(*hclsyntax.Body)
 	if !ok {
 		return nil, nil
 	}
 
-	// Process each block that has depends_on
+	var targets []*hclsyntax.Block
 	for _, block := range hclFile.Blocks {
 		if !IsDependsOnRelevantBlock(block.Type) {
 			continue
 		}
-
-		// Check if block has depends_on
 		if FindAttribute(block.Body.Attributes, "depends_on") == nil {
 			continue
 		}
+		targets = append(targets, block)
+	}
+	// Bottom-up so each rewrite cannot shift the line ranges of blocks above it.
+	sort.Slice(targets, func(i, j int) bool {
+		return targets[i].Range().Start.Line > targets[j].Range().Start.Line
+	})
 
-		orderedNames := GetOrderedAttrNames(block.Body)
-		// depends_on should be at the very end
-		lastAttrs := []string{"tags", "labels", "tags_all", "depends_on"}
-
-		// Use line-based reordering to preserve leading comments
-		content = ReorderBlockAttrsPreservingComments(
-			content,
-			block.Body,
-			block.Range().Start.Line,
-			block.Range().End.Line,
-			orderedNames,
-			nil,
-			lastAttrs,
-		)
+	for _, block := range targets {
+		dependsOn := FindAttribute(block.Body.Attributes, "depends_on")
+		content = moveAttrBeforeLifecycle(content, block, dependsOn)
 	}
 
 	return FormatAndCleanBlankLines(content), nil
@@ -834,46 +1005,47 @@ func (r *VariableOrderRule) checkAttrPair(ctx *sdk.Context, block *hclsyntax.Blo
 	return nil
 }
 
-// Fix reorders variable attributes to match the standard order.
-// Uses line-based reordering to preserve leading comments.
+// Fix reorders variable attributes and nested blocks to match the canonical order:
+// description, type, default, sensitive, nullable, validation blocks, then everything else.
+// Heredoc bodies live within an attribute's line range and are carried along intact.
 func (r *VariableOrderRule) Fix(ctx *sdk.Context, _ *hcl.File) ([]byte, error) {
 	content, err := os.ReadFile(ctx.File)
 	if err != nil {
 		return nil, err
 	}
 
-	// Parse with hclsyntax to get block positions
 	syntaxFile, diags := hclsyntax.ParseConfig(content, ctx.File, hcl.InitialPos)
 	if diags.HasErrors() {
 		return nil, diags
 	}
-
 	hclFile, ok := syntaxFile.Body.(*hclsyntax.Body)
 	if !ok {
 		return nil, nil
 	}
 
-	// Expected order for variable attributes
 	attrOrder := []string{"description", "type", "default", "sensitive", "nullable"}
+	nestedBlockOrder := []string{"validation"}
 
-	// Process each variable block
+	// Process variable blocks bottom-up: rewriting block N only mutates lines at or below
+	// blockStartLine of N, so blocks above N keep accurate line ranges from the single parse.
+	var variables []*hclsyntax.Block
 	for _, block := range hclFile.Blocks {
-		if block.Type != "variable" {
-			continue
+		if block.Type == "variable" {
+			variables = append(variables, block)
 		}
+	}
+	sort.Slice(variables, func(i, j int) bool {
+		return variables[i].Range().Start.Line > variables[j].Range().Start.Line
+	})
 
-		orderedNames := GetOrderedAttrNames(block.Body)
-
-		// Use line-based reordering to preserve leading comments
-		// For variables, the standard attrs come first in order, everything else after
-		content = ReorderBlockAttrsPreservingComments(
+	for _, block := range variables {
+		content = ReorderBlockBodyPreservingAll(
 			content,
 			block.Body,
 			block.Range().Start.Line,
 			block.Range().End.Line,
-			orderedNames,
 			attrOrder,
-			nil,
+			nestedBlockOrder,
 		)
 	}
 
@@ -987,46 +1159,51 @@ func (r *OutputOrderRule) checkOutputAttrPair(ctx *sdk.Context, block *hclsyntax
 	return nil
 }
 
-// Fix reorders output attributes to match the standard order.
-// Uses line-based reordering to preserve leading comments.
+// Fix reorders output attributes and preserves nested precondition blocks (TF 1.2+).
+//
+// Layout buckets, in order:
+//  1. Known attrs (description, value, sensitive, depends_on) in that order.
+//  2. precondition blocks (in source order if multiple).
+//  3. Any remaining attributes in source order.
+//  4. Any remaining nested blocks in source order.
 func (r *OutputOrderRule) Fix(ctx *sdk.Context, _ *hcl.File) ([]byte, error) {
 	content, err := os.ReadFile(ctx.File)
 	if err != nil {
 		return nil, err
 	}
 
-	// Parse with hclsyntax to get block positions
 	syntaxFile, diags := hclsyntax.ParseConfig(content, ctx.File, hcl.InitialPos)
 	if diags.HasErrors() {
 		return nil, diags
 	}
-
 	hclFile, ok := syntaxFile.Body.(*hclsyntax.Body)
 	if !ok {
 		return nil, nil
 	}
 
-	// Expected order for output attributes
 	attrOrder := []string{"description", "value", "sensitive", "depends_on"}
+	nestedBlockOrder := []string{"precondition"}
 
-	// Process each output block
+	// Process output blocks bottom-up: rewriting block N only mutates lines at or below
+	// blockStartLine of N, so blocks above N keep accurate line ranges from the single parse.
+	var outputs []*hclsyntax.Block
 	for _, block := range hclFile.Blocks {
-		if block.Type != "output" {
-			continue
+		if block.Type == "output" {
+			outputs = append(outputs, block)
 		}
+	}
+	sort.Slice(outputs, func(i, j int) bool {
+		return outputs[i].Range().Start.Line > outputs[j].Range().Start.Line
+	})
 
-		orderedNames := GetOrderedAttrNames(block.Body)
-
-		// Use line-based reordering to preserve leading comments
-		// For outputs, the standard attrs come first in order, everything else after
-		content = ReorderBlockAttrsPreservingComments(
+	for _, block := range outputs {
+		content = ReorderBlockBodyPreservingAll(
 			content,
 			block.Body,
 			block.Range().Start.Line,
 			block.Range().End.Line,
-			orderedNames,
 			attrOrder,
-			nil,
+			nestedBlockOrder,
 		)
 	}
 
@@ -1082,27 +1259,19 @@ func (r *TerraformBlockFirstRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk
 	return findings, nil
 }
 
-// fixFile moves the terraform block to the beginning of the file.
-func (r *TerraformBlockFirstRule) fixFile(filePath string) ([]byte, error) {
-	content, err := os.ReadFile(filePath)
-	if err != nil {
-		return nil, err
-	}
-
-	writeFile, diags := hclwrite.ParseConfig(content, filePath, hcl.InitialPos)
-	if diags.HasErrors() {
-		return nil, diags
-	}
-
-	return ReorderTopLevelBlocks(writeFile), nil
-}
-
-// Fix moves terraform block to the first position.
+// Fix moves the terraform block to the first position via line-range reorder.
+// Attribute order and comments inside every untouched block are byte-for-byte preserved.
+// Shares ReorderTopLevelBlocksByLineRange with ProviderBlockOrderRule.Fix intentionally —
+// both rules consume the same canonical priority order.
 func (r *TerraformBlockFirstRule) Fix(ctx *sdk.Context, _ *hcl.File) ([]byte, error) {
 	if ctx == nil {
 		return nil, nil
 	}
-	return r.fixFile(ctx.File)
+	content, err := os.ReadFile(ctx.File)
+	if err != nil {
+		return nil, err
+	}
+	return ReorderTopLevelBlocksByLineRange(content)
 }
 
 // ProviderBlockOrderRule ensures provider blocks come after terraform block.
@@ -1172,27 +1341,18 @@ func (r *ProviderBlockOrderRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.
 	return findings, nil
 }
 
-// fixFile reorders provider blocks to come after terraform and before resources.
-func (r *ProviderBlockOrderRule) fixFile(filePath string) ([]byte, error) {
-	content, err := os.ReadFile(filePath)
-	if err != nil {
-		return nil, err
-	}
-
-	writeFile, diags := hclwrite.ParseConfig(content, filePath, hcl.InitialPos)
-	if diags.HasErrors() {
-		return nil, diags
-	}
-
-	return ReorderTopLevelBlocks(writeFile), nil
-}
-
-// Fix reorders provider blocks to proper position.
+// Fix reorders provider blocks to the canonical position via line-range reorder.
+// Both rules share the same line-based helper because they consume the same canonical
+// priority order (terraform, provider, variable, locals, data, resource, module, output).
 func (r *ProviderBlockOrderRule) Fix(ctx *sdk.Context, _ *hcl.File) ([]byte, error) {
 	if ctx == nil {
 		return nil, nil
 	}
-	return r.fixFile(ctx.File)
+	content, err := os.ReadFile(ctx.File)
+	if err != nil {
+		return nil, err
+	}
+	return ReorderTopLevelBlocksByLineRange(content)
 }
 
 // AttributeGroupSpacingRule ensures blank lines between attribute groups in blocks.

--- a/internal/engines/style/rules/ordering_test.go
+++ b/internal/engines/style/rules/ordering_test.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
@@ -190,6 +191,7 @@ func TestLifecycleAtEndRule(t *testing.T) {
 		name         string
 		content      string
 		wantFindings int
+		wantMessage  string
 	}{
 		{
 			name: "lifecycle at end",
@@ -210,11 +212,78 @@ func TestLifecycleAtEndRule(t *testing.T) {
   ami = "ami-123"
 }`,
 			wantFindings: 1,
+			wantMessage:  "end of the resource block",
 		},
 		{
 			name: "no lifecycle",
 			content: `resource "aws_instance" "example" {
   ami = "ami-123"
+}`,
+			wantFindings: 0,
+		},
+		{
+			name: "data block lifecycle not at end",
+			content: `data "aws_ami" "example" {
+  lifecycle {
+    postcondition {
+      condition     = self.id != ""
+      error_message = "AMI not found"
+    }
+  }
+  most_recent = true
+  owners      = ["amazon"]
+}`,
+			wantFindings: 1,
+			wantMessage:  "end of the data block",
+		},
+		{
+			name: "data block lifecycle at end",
+			content: `data "aws_ami" "example" {
+  most_recent = true
+  owners      = ["amazon"]
+  lifecycle {
+    postcondition {
+      condition     = self.id != ""
+      error_message = "AMI not found"
+    }
+  }
+}`,
+			wantFindings: 0,
+		},
+		{
+			name: "module block lifecycle not at end",
+			content: `module "vpc" {
+  source = "./vpc"
+  lifecycle {
+    precondition {
+      condition     = var.region != ""
+      error_message = "region required"
+    }
+  }
+  cidr_block = "10.0.0.0/16"
+}`,
+			wantFindings: 1,
+			wantMessage:  "end of the module block",
+		},
+		{
+			name: "module block lifecycle at end",
+			content: `module "vpc" {
+  source     = "./vpc"
+  cidr_block = "10.0.0.0/16"
+  lifecycle {
+    precondition {
+      condition     = var.region != ""
+      error_message = "region required"
+    }
+  }
+}`,
+			wantFindings: 0,
+		},
+		{
+			name: "non-host block (variable) is ignored",
+			content: `variable "example" {
+  type    = string
+  default = "x"
 }`,
 			wantFindings: 0,
 		},
@@ -231,6 +300,9 @@ func TestLifecycleAtEndRule(t *testing.T) {
 			findings, err := rule.Check(ctx, hclFile)
 			require.NoError(t, err)
 			assert.Len(t, findings, tt.wantFindings)
+			if tt.wantMessage != "" && len(findings) > 0 {
+				assert.Contains(t, findings[0].Message, tt.wantMessage)
+			}
 		})
 	}
 
@@ -268,6 +340,117 @@ func TestLifecycleAtEndRule(t *testing.T) {
 		lifecycleIdx := indexOf(resultStr, "lifecycle")
 		amiIdx := indexOf(resultStr, "ami")
 		assert.Greater(t, lifecycleIdx, amiIdx, "lifecycle should be after ami")
+	})
+
+	t.Run("Fix moves lifecycle to end in data block", func(t *testing.T) {
+		content := `data "aws_ami" "example" {
+  lifecycle {
+    postcondition {
+      condition     = self.id != ""
+      error_message = "AMI not found"
+    }
+  }
+  most_recent = true
+  owners      = ["amazon"]
+}
+`
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "test.tf")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+
+		file, diags := hclsyntax.ParseConfig([]byte(content), tmpFile, hcl.InitialPos)
+		require.False(t, diags.HasErrors())
+
+		hclFile := &hcl.File{Body: file.Body}
+		ctx := &sdk.Context{File: tmpFile}
+
+		result, err := rule.Fix(ctx, hclFile)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		resultStr := string(result)
+		lifecycleIdx := indexOf(resultStr, "lifecycle")
+		ownersIdx := indexOf(resultStr, "owners")
+		assert.Greater(t, lifecycleIdx, ownersIdx, "lifecycle should be after owners in data block")
+	})
+
+	t.Run("Fix moves lifecycle to end in module block", func(t *testing.T) {
+		content := `module "vpc" {
+  source = "./vpc"
+  lifecycle {
+    precondition {
+      condition     = var.region != ""
+      error_message = "region required"
+    }
+  }
+  cidr_block = "10.0.0.0/16"
+}
+`
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "test.tf")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+
+		file, diags := hclsyntax.ParseConfig([]byte(content), tmpFile, hcl.InitialPos)
+		require.False(t, diags.HasErrors())
+
+		hclFile := &hcl.File{Body: file.Body}
+		ctx := &sdk.Context{File: tmpFile}
+
+		result, err := rule.Fix(ctx, hclFile)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		resultStr := string(result)
+		lifecycleIdx := indexOf(resultStr, "lifecycle")
+		cidrIdx := indexOf(resultStr, "cidr_block")
+		assert.Greater(t, lifecycleIdx, cidrIdx, "lifecycle should be after cidr_block in module block")
+	})
+
+	t.Run("Fix handles same labels across different block types", func(t *testing.T) {
+		// Regression: resource and data both labeled "example". Both have a
+		// lifecycle that needs moving. The fix must move both independently,
+		// matching by (block type, labels), not labels alone.
+		content := `resource "aws_instance" "example" {
+  lifecycle {
+    prevent_destroy = true
+  }
+  ami = "ami-123"
+}
+
+data "aws_ami" "example" {
+  lifecycle {
+    postcondition {
+      condition     = self.id != ""
+      error_message = "AMI not found"
+    }
+  }
+  most_recent = true
+}
+`
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "test.tf")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+
+		file, diags := hclsyntax.ParseConfig([]byte(content), tmpFile, hcl.InitialPos)
+		require.False(t, diags.HasErrors())
+
+		hclFile := &hcl.File{Body: file.Body}
+		ctx := &sdk.Context{File: tmpFile}
+
+		result, err := rule.Fix(ctx, hclFile)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		resultStr := string(result)
+		// Resource block: lifecycle should come after ami.
+		amiIdx := indexOf(resultStr, "ami =")
+		// First lifecycle occurrence is in the resource block.
+		firstLifecycleIdx := indexOf(resultStr, "lifecycle")
+		assert.Greater(t, firstLifecycleIdx, amiIdx, "resource lifecycle should be after ami")
+		// Data block: lifecycle should come after most_recent.
+		mostRecentIdx := indexOf(resultStr, "most_recent")
+		secondLifecycleIdx := strings.Index(resultStr[firstLifecycleIdx+len("lifecycle"):], "lifecycle") + firstLifecycleIdx + len("lifecycle")
+		assert.Greater(t, secondLifecycleIdx, mostRecentIdx, "data lifecycle should be after most_recent")
 	})
 }
 
@@ -407,6 +590,251 @@ func TestTagsAtEndRule(t *testing.T) {
 		amiIdx := indexOf(resultStr, "ami")
 		assert.Less(t, amiIdx, tagsIdx, "ami should be before tags")
 	})
+
+	t.Run("Check flags single attr after tags (new threshold > 0)", func(t *testing.T) {
+		// The team-tools fixture: only one attribute follows tags. With the old `> 2`
+		// threshold this slipped through; with `> 0` the Check fires.
+		content := `module "team-tools" {
+  source = "./team-tools"
+  tags   = { team = "platform" }
+  count  = 1
+}`
+		file, diags := hclsyntax.ParseConfig([]byte(content), "test.tf", hcl.InitialPos)
+		require.False(t, diags.HasErrors())
+		hclFile := &hcl.File{Body: file.Body}
+		ctx := &sdk.Context{File: "test.tf"}
+
+		findings, err := rule.Check(ctx, hclFile)
+		require.NoError(t, err)
+		// Expect the "near the end" finding; lifecycle is absent so no second finding.
+		assert.Len(t, findings, 1)
+		assert.Contains(t, findings[0].Message, "near the end")
+	})
+
+	t.Run("Check flags trailing nested blocks after tags", func(t *testing.T) {
+		// aws_security_group with tags in the middle, ingress/egress AFTER tags but BEFORE lifecycle.
+		// Previously countAttrsAfterTags returned 0 (no attrs trailing); now we count blocks too.
+		content := `resource "aws_security_group" "vpce" {
+  vpc_id      = "vpc-1"
+  name        = "x"
+  description = "y"
+  tags        = { Name = "test" }
+  ingress {
+    from_port = 80
+  }
+  egress {
+    to_port = 443
+  }
+  lifecycle {
+    prevent_destroy = true
+  }
+}`
+		file, diags := hclsyntax.ParseConfig([]byte(content), "test.tf", hcl.InitialPos)
+		require.False(t, diags.HasErrors())
+		hclFile := &hcl.File{Body: file.Body}
+		ctx := &sdk.Context{File: "test.tf"}
+
+		findings, err := rule.Check(ctx, hclFile)
+		require.NoError(t, err)
+		require.Len(t, findings, 1, "trailing non-lifecycle blocks should flag the rule")
+		assert.Contains(t, findings[0].Message, "near the end")
+	})
+
+	t.Run("Fix moves tags to just before lifecycle, other items stay put", func(t *testing.T) {
+		// Mirrors aws_security_group.vpce. Tags moves from position 4 to position 6
+		// (between egress and lifecycle). vpc_id, name, description, ingress, egress
+		// keep their source positions. Use alignment-agnostic anchors because hclwrite
+		// re-aligns `=` columns after the move.
+		content := `resource "aws_security_group" "vpce" {
+  vpc_id      = "vpc-1"
+  name        = "x"
+  description = "y"
+  tags        = { Name = "test" }
+  ingress {
+    from_port = 80
+  }
+  egress {
+    to_port = 443
+  }
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+`
+		out := runRuleFix(t, rule, content)
+		assertOrderedSubstrings(t, out, []string{
+			"\n  vpc_id",
+			"\n  name",
+			"\n  description",
+			"\n  ingress {",
+			"from_port = 80",
+			"\n  egress {",
+			"to_port = 443",
+			"\n  tags",
+			`Name = "test"`,
+			"\n  lifecycle {",
+			"prevent_destroy = true",
+		})
+	})
+
+	t.Run("Fix preserves leading comment on tags when moving", func(t *testing.T) {
+		// Mirrors a real ACM module fixture where tags carries a hint comment.
+		content := `resource "aws_acm_certificate" "x" {
+  domain_name       = "example.com"
+  # remove * from the beginning before importing into Vanta
+  tags              = { Name = "cert" }
+  validation_method = "DNS"
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+`
+		out := runRuleFix(t, rule, content)
+		assert.Contains(t, out, "# remove * from the beginning before importing into Vanta")
+		assertOrderedSubstrings(t, out, []string{
+			"\n  domain_name",
+			"\n  validation_method",
+			"\n  # remove * from the beginning before importing into Vanta",
+			"\n  tags",
+			"\n  lifecycle {",
+		})
+	})
+
+	t.Run("Fix moves tags to end when no lifecycle present", func(t *testing.T) {
+		content := `resource "aws_instance" "x" {
+  ami           = "ami-123"
+  tags          = { Name = "test" }
+  instance_type = "t3.medium"
+}
+`
+		out := runRuleFix(t, rule, content)
+		assertOrderedSubstrings(t, out, []string{
+			"\n  ami",
+			"\n  instance_type",
+			"\n  tags",
+		})
+	})
+
+	t.Run("Fix is idempotent", func(t *testing.T) {
+		content := `resource "aws_security_group" "x" {
+  vpc_id      = "vpc-1"
+  name        = "x"
+  description = "y"
+  tags        = { Name = "test" }
+  ingress {
+    from_port = 80
+  }
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+`
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "test.tf")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+
+		ctx := &sdk.Context{File: tmpFile}
+		first, err := rule.Fix(ctx, &hcl.File{Body: mustParseBody(t, content)})
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(tmpFile, first, 0o644))
+
+		second, err := rule.Fix(ctx, &hcl.File{Body: mustParseBody(t, string(first))})
+		require.NoError(t, err)
+		assert.Equal(t, string(first), string(second), "Fix(Fix(x)) must equal Fix(x)")
+	})
+
+	t.Run("Fix is idempotent after first-pass move with leading comment", func(t *testing.T) {
+		// Starts from a violating state (tags+comment in the middle) so the first Fix
+		// performs a real move. The second Fix must produce identical output.
+		content := `resource "aws_security_group" "x" {
+  vpc_id      = "vpc-1"
+  name        = "x"
+  # important: tag this carefully
+  tags        = { Name = "test" }
+  description = "y"
+  ingress {
+    from_port = 80
+  }
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+`
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "test.tf")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+
+		ctx := &sdk.Context{File: tmpFile}
+		first, err := rule.Fix(ctx, nil)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(tmpFile, first, 0o644))
+
+		second, err := rule.Fix(ctx, nil)
+		require.NoError(t, err)
+		assert.Equal(t, string(first), string(second), "Fix(Fix(x)) must equal Fix(x) after a real move")
+		// Comment must still be present after both passes.
+		assert.Contains(t, string(second), "# important: tag this carefully")
+	})
+
+	t.Run("findTagsAttribute prefers tags over tags_all", func(t *testing.T) {
+		// A resource where both tags and tags_all are present should have Fix() operate
+		// on `tags`, not `tags_all` (which is provider-managed). The reviewer flagged a
+		// non-deterministic map-iteration bug here; this test locks the priority order.
+		content := `resource "aws_instance" "x" {
+  ami            = "ami-123"
+  tags           = { Name = "user-tag" }
+  instance_type  = "t3.medium"
+  tags_all       = { Name = "user-tag", Inherited = "x" }
+}
+`
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "test.tf")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+
+		ctx := &sdk.Context{File: tmpFile}
+		result, err := rule.Fix(ctx, nil)
+		require.NoError(t, err)
+		out := string(result)
+
+		// `tags` moves to the end; `tags_all` stays in its original (after-`instance_type`)
+		// position since findTagsAttribute targets `tags` first.
+		assertOrderedSubstrings(t, out, []string{
+			"\n  ami",
+			"\n  instance_type",
+			"\n  tags_all",
+			"\n  tags ",
+		})
+	})
+
+	t.Run("Check emits a single finding when tags is after lifecycle (no double-fire)", func(t *testing.T) {
+		// Previously this case produced two findings on the same line ("before lifecycle"
+		// + "near the end"). The Check now picks the more specific message and skips the
+		// general one.
+		content := `resource "aws_instance" "x" {
+  ami = "ami-123"
+  lifecycle {
+    prevent_destroy = true
+  }
+  tags = { Name = "test" }
+}`
+		file, diags := hclsyntax.ParseConfig([]byte(content), "test.tf", hcl.InitialPos)
+		require.False(t, diags.HasErrors())
+		hclFile := &hcl.File{Body: file.Body}
+		ctx := &sdk.Context{File: "test.tf"}
+
+		findings, err := rule.Check(ctx, hclFile)
+		require.NoError(t, err)
+		require.Len(t, findings, 1, "should produce exactly one finding, not two, for a single misplacement")
+		assert.Contains(t, findings[0].Message, "before lifecycle")
+	})
+}
+
+// mustParseBody parses HCL content and returns its body, failing the test on error.
+func mustParseBody(t *testing.T, content string) hcl.Body {
+	t.Helper()
+	file, diags := hclsyntax.ParseConfig([]byte(content), "test.tf", hcl.InitialPos)
+	require.False(t, diags.HasErrors())
+	return file.Body
 }
 
 func TestDependsOnOrderRule(t *testing.T) {
@@ -528,6 +956,352 @@ func TestDependsOnOrderRule(t *testing.T) {
 		dependsOnIdx := indexOf(resultStr, "depends_on")
 		amiIdx := indexOf(resultStr, "ami")
 		assert.Greater(t, dependsOnIdx, amiIdx, "depends_on should be after ami")
+	})
+
+	t.Run("Check emits a single finding when depends_on is after lifecycle", func(t *testing.T) {
+		// Previously this case produced two findings; the single-finding policy now picks
+		// the more specific "before lifecycle" message and skips the general one.
+		content := `resource "aws_instance" "x" {
+  ami = "ami-123"
+  lifecycle {
+    prevent_destroy = true
+  }
+  depends_on = [aws_vpc.main]
+}`
+		file, diags := hclsyntax.ParseConfig([]byte(content), "test.tf", hcl.InitialPos)
+		require.False(t, diags.HasErrors())
+		hclFile := &hcl.File{Body: file.Body}
+		ctx := &sdk.Context{File: "test.tf"}
+
+		findings, err := rule.Check(ctx, hclFile)
+		require.NoError(t, err)
+		require.Len(t, findings, 1, "should produce exactly one finding, not two, for a single misplacement")
+		assert.Contains(t, findings[0].Message, "before lifecycle")
+	})
+
+	t.Run("Check flags trailing nested blocks after depends_on", func(t *testing.T) {
+		// New behavior: non-lifecycle nested blocks after depends_on count as "items
+		// after depends_on", so the rule flags them even though no attrs trail.
+		content := `resource "aws_ecs_service" "elixir" {
+  name        = "elixir"
+  cluster     = "main"
+  depends_on  = [aws_lb_listener.elixir]
+  ordered_placement_strategy {
+    type = "spread"
+  }
+  lifecycle {
+    create_before_destroy = true
+  }
+}`
+		file, diags := hclsyntax.ParseConfig([]byte(content), "test.tf", hcl.InitialPos)
+		require.False(t, diags.HasErrors())
+		hclFile := &hcl.File{Body: file.Body}
+		ctx := &sdk.Context{File: "test.tf"}
+
+		findings, err := rule.Check(ctx, hclFile)
+		require.NoError(t, err)
+		require.Len(t, findings, 1)
+		assert.Contains(t, findings[0].Message, "after non-lifecycle nested blocks")
+		assert.Equal(t, sdk.SeverityWarning, findings[0].Severity, "trailing-blocks finding should be Warning (Fix will rewrite the file)")
+	})
+
+	t.Run("Fix moves depends_on to before lifecycle, sub-blocks stay put", func(t *testing.T) {
+		// Mirrors aws_ecs_service.elixir. depends_on moves from position 3 to just
+		// before lifecycle. ordered_placement_strategy stays in its source position.
+		content := `resource "aws_ecs_service" "elixir" {
+  name       = "elixir"
+  cluster    = "main"
+  depends_on = [aws_lb_listener.elixir]
+  ordered_placement_strategy {
+    type  = "spread"
+    field = "instanceId"
+  }
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+`
+		out := runRuleFix(t, rule, content)
+		assertOrderedSubstrings(t, out, []string{
+			"\n  name",
+			"\n  cluster",
+			"\n  ordered_placement_strategy {",
+			`type  = "spread"`,
+			`field = "instanceId"`,
+			"\n  depends_on",
+			"\n  lifecycle {",
+		})
+	})
+
+	t.Run("Fix preserves leading comment on depends_on when moving", func(t *testing.T) {
+		content := `resource "aws_ecs_service" "x" {
+  name       = "x"
+  cluster    = "main"
+  # waits for the listener to be ready first
+  depends_on = [aws_lb_listener.x]
+  ordered_placement_strategy {
+    type = "spread"
+  }
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+`
+		out := runRuleFix(t, rule, content)
+		assert.Contains(t, out, "# waits for the listener to be ready first")
+		assertOrderedSubstrings(t, out, []string{
+			"\n  name",
+			"\n  cluster",
+			"\n  ordered_placement_strategy {",
+			"\n  # waits for the listener to be ready first",
+			"\n  depends_on",
+			"\n  lifecycle {",
+		})
+	})
+
+	t.Run("Fix moves depends_on to end when no lifecycle present", func(t *testing.T) {
+		content := `resource "aws_instance" "x" {
+  ami           = "ami-123"
+  depends_on    = [aws_vpc.main]
+  instance_type = "t3.medium"
+}
+`
+		out := runRuleFix(t, rule, content)
+		assertOrderedSubstrings(t, out, []string{
+			"\n  ami",
+			"\n  instance_type",
+			"\n  depends_on",
+		})
+	})
+
+	t.Run("Fix is idempotent after first-pass move with leading comment", func(t *testing.T) {
+		content := `resource "aws_instance" "x" {
+  ami = "ami-123"
+  # waits for vpc
+  depends_on = [aws_vpc.main]
+  instance_type = "t3.medium"
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+`
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "test.tf")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+
+		ctx := &sdk.Context{File: tmpFile}
+		first, err := rule.Fix(ctx, nil)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(tmpFile, first, 0o644))
+
+		second, err := rule.Fix(ctx, nil)
+		require.NoError(t, err)
+		assert.Equal(t, string(first), string(second), "Fix(Fix(x)) must equal Fix(x) after a real move")
+		assert.Contains(t, string(second), "# waits for vpc")
+	})
+
+	t.Run("Check accepts canonical depends_on then tags then lifecycle layout", func(t *testing.T) {
+		// Regression lock: countItemsAfterDependsOn must exclude the tags family because
+		// the canonical layout places tags between depends_on and lifecycle. Without this
+		// exclusion the rule would flag every well-formed resource that also has tags.
+		content := `resource "aws_instance" "x" {
+  ami        = "ami-123"
+  depends_on = [aws_vpc.main]
+  tags       = { Name = "x" }
+  lifecycle {
+    prevent_destroy = true
+  }
+}`
+		file, diags := hclsyntax.ParseConfig([]byte(content), "test.tf", hcl.InitialPos)
+		require.False(t, diags.HasErrors())
+		hclFile := &hcl.File{Body: file.Body}
+		ctx := &sdk.Context{File: "test.tf"}
+
+		findings, err := rule.Check(ctx, hclFile)
+		require.NoError(t, err)
+		assert.Empty(t, findings, "depends_on → tags → lifecycle is canonical and must not be flagged")
+	})
+
+	t.Run("Fix handles no-lifecycle resource with trailing nested blocks", func(t *testing.T) {
+		// depends_on followed by a nested block, no lifecycle present. The fix should
+		// move depends_on to right before the closing brace.
+		content := `resource "aws_ecs_service" "x" {
+  name       = "x"
+  cluster    = "main"
+  depends_on = [aws_lb_listener.x]
+  ordered_placement_strategy {
+    type = "spread"
+  }
+}
+`
+		out := runRuleFix(t, rule, content)
+		assertOrderedSubstrings(t, out, []string{
+			"\n  name",
+			"\n  cluster",
+			"\n  ordered_placement_strategy {",
+			"\n  depends_on",
+			"\n}",
+		})
+	})
+
+	t.Run("Fix handles two resources in one file, both needing the move", func(t *testing.T) {
+		// Validates the bottom-up sort: rewriting block N must not invalidate the
+		// line ranges of blocks above it. Without bottom-up, the second block's
+		// recorded range would be stale after the first rewrite.
+		content := `resource "aws_instance" "first" {
+  ami        = "ami-1"
+  depends_on = [aws_vpc.main]
+  instance_type = "t3.medium"
+}
+
+resource "aws_instance" "second" {
+  ami        = "ami-2"
+  depends_on = [aws_vpc.main]
+  instance_type = "t3.large"
+}
+`
+		out := runRuleFix(t, rule, content)
+		assertOrderedSubstrings(t, out, []string{
+			`"first"`,
+			"\n  ami",
+			"\n  instance_type",
+			"\n  depends_on",
+			`"second"`,
+			"\n  ami",
+			"\n  instance_type",
+			"\n  depends_on",
+		})
+	})
+
+	t.Run("Fix handles multi-line depends_on list intact", func(t *testing.T) {
+		// depends_on value spans multiple lines; the entire range must move together.
+		content := `resource "aws_instance" "x" {
+  ami = "ami-123"
+  depends_on = [
+    aws_vpc.main,
+    aws_subnet.public,
+    aws_security_group.app,
+  ]
+  instance_type = "t3.medium"
+}
+`
+		out := runRuleFix(t, rule, content)
+		// All three dependency lines must be present and contiguous after the move.
+		assert.Contains(t, out, "aws_vpc.main,")
+		assert.Contains(t, out, "aws_subnet.public,")
+		assert.Contains(t, out, "aws_security_group.app,")
+		assertOrderedSubstrings(t, out, []string{
+			"\n  ami",
+			"\n  instance_type",
+			"\n  depends_on = [",
+			"aws_vpc.main,",
+			"aws_subnet.public,",
+			"aws_security_group.app,",
+			"]",
+		})
+	})
+
+	t.Run("Check and Fix work on module blocks", func(t *testing.T) {
+		content := `module "team-tools" {
+  source     = "./team-tools"
+  depends_on = [aws_iam_role.team]
+  count      = 1
+}`
+		file, diags := hclsyntax.ParseConfig([]byte(content), "test.tf", hcl.InitialPos)
+		require.False(t, diags.HasErrors())
+		hclFile := &hcl.File{Body: file.Body}
+		ctx := &sdk.Context{File: "test.tf"}
+
+		findings, err := rule.Check(ctx, hclFile)
+		require.NoError(t, err)
+		assert.Len(t, findings, 1, "module with depends_on then count should flag")
+
+		out := runRuleFix(t, rule, content)
+		assertOrderedSubstrings(t, out, []string{
+			"\n  source",
+			"\n  count",
+			"\n  depends_on",
+		})
+	})
+
+	t.Run("Check and Fix work on data blocks", func(t *testing.T) {
+		content := `data "aws_ami" "x" {
+  most_recent = true
+  depends_on  = [aws_iam_role.x]
+  owners      = ["amazon"]
+}`
+		file, diags := hclsyntax.ParseConfig([]byte(content), "test.tf", hcl.InitialPos)
+		require.False(t, diags.HasErrors())
+		hclFile := &hcl.File{Body: file.Body}
+		ctx := &sdk.Context{File: "test.tf"}
+
+		findings, err := rule.Check(ctx, hclFile)
+		require.NoError(t, err)
+		assert.Len(t, findings, 1, "data with depends_on then owners should flag")
+
+		out := runRuleFix(t, rule, content)
+		assertOrderedSubstrings(t, out, []string{
+			"\n  most_recent",
+			"\n  owners",
+			"\n  depends_on",
+		})
+	})
+
+	t.Run("Fix is a no-op (no diff) when depends_on is already adjacent to lifecycle with a blank gap", func(t *testing.T) {
+		// Closes the Fix/Check semantic gap the reviewer flagged: previously Fix would
+		// run the splice on this layout (because attrEnd+1 != insertBefore), produce a
+		// visually-equivalent output, then FormatAndCleanBlankLines would collapse the
+		// blank — so the first pass produced a non-trivial diff. The tightened no-op
+		// guard now correctly recognizes this as already-canonical.
+		content := `resource "aws_instance" "x" {
+  ami        = "ami-123"
+  depends_on = [aws_vpc.main]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+`
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "test.tf")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+
+		ctx := &sdk.Context{File: tmpFile}
+		result, err := rule.Fix(ctx, nil)
+		require.NoError(t, err)
+		assert.Equal(t, content, string(result), "Fix should be a no-op when depends_on is already correctly placed (even with blank-line gap)")
+	})
+
+	t.Run("Fix is idempotent when depends_on is already adjacent to lifecycle with a blank line gap", func(t *testing.T) {
+		// Edge case the prior reviewer flagged: when there is a blank line between
+		// depends_on and lifecycle, the splice still runs but should produce visually
+		// identical output. Verifies that the no-op guard plus FormatAndCleanBlankLines
+		// converge after one pass.
+		content := `resource "aws_instance" "x" {
+  ami        = "ami-123"
+  depends_on = [aws_vpc.main]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+`
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "test.tf")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+
+		ctx := &sdk.Context{File: tmpFile}
+		first, err := rule.Fix(ctx, nil)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(tmpFile, first, 0o644))
+
+		second, err := rule.Fix(ctx, nil)
+		require.NoError(t, err)
+		assert.Equal(t, string(first), string(second), "blank line between depends_on and lifecycle must not break idempotence")
+		// depends_on still appears before lifecycle.
+		dependsIdx := strings.Index(string(second), "depends_on")
+		lifecycleIdx := strings.Index(string(second), "lifecycle {")
+		assert.Less(t, dependsIdx, lifecycleIdx)
 	})
 }
 
@@ -727,22 +1501,364 @@ func TestVariableOrderRule(t *testing.T) {
 		})
 	}
 
-	t.Run("Fix reorders attributes", func(t *testing.T) {
-		content := `variable "example" {
+	fixTests := []struct {
+		name      string
+		input     string
+		wantOrder []string // substrings that must appear in this top-down order in the output
+		wantKeep  []string // substrings that must remain present anywhere
+	}{
+		{
+			name: "type before description gets reordered",
+			input: `variable "example" {
   type        = string
   description = "Example variable"
   default     = "value"
 }
+`,
+			wantOrder: []string{`description = "Example variable"`, `type        = string`, `default     = "value"`},
+		},
+		{
+			name: "heredoc description survives reorder",
+			input: `variable "example" {
+  type        = string
+  description = <<-EOT
+    A multi-line
+    description with # hashes and // slashes
+  EOT
+  default     = "value"
+}
+`,
+			wantOrder: []string{
+				`description = <<-EOT`,
+				`A multi-line`,
+				`description with # hashes and // slashes`,
+				`EOT`,
+				`type        = string`,
+				`default     = "value"`,
+			},
+			wantKeep: []string{`# hashes and // slashes`},
+		},
+		{
+			name: "multi-line validation block keeps body and moves after attrs",
+			input: `variable "name" {
+  validation {
+    condition     = length(var.name) > 0
+    error_message = "must not be empty"
+  }
+  type        = string
+  description = "Name of the thing"
+}
+`,
+			wantOrder: []string{
+				`description = "Name of the thing"`,
+				`type        = string`,
+				`validation {`,
+				`condition     = length(var.name) > 0`,
+				`error_message = "must not be empty"`,
+			},
+		},
+		{
+			name: "validation-only variable preserves block",
+			input: `variable "name" {
+  type = string
+  validation {
+    condition     = length(var.name) > 0
+    error_message = "must not be empty"
+  }
+}
+`,
+			wantOrder: []string{`type = string`, `validation {`, `condition     = length(var.name) > 0`},
+		},
+		{
+			name: "description-only variable left unchanged",
+			input: `variable "name" {
+  description = "Name of the thing"
+}
+`,
+			wantOrder: []string{`description = "Name of the thing"`},
+		},
+		{
+			name:  "empty variable body left unchanged",
+			input: "variable \"name\" {}\n",
+			wantOrder: []string{
+				`variable "name" {`,
+			},
+		},
+		{
+			name: "interleaved validation moves to end after all known attrs",
+			input: `variable "name" {
+  description = "Name"
+  validation {
+    condition     = length(var.name) > 0
+    error_message = "must not be empty"
+  }
+  type    = string
+  default = "x"
+}
+`,
+			wantOrder: []string{
+				`description = "Name"`,
+				"\n  type",
+				"\n  default",
+				`validation {`,
+			},
+		},
+		{
+			name: "multiple validation blocks keep relative order",
+			input: `variable "name" {
+  validation {
+    condition     = length(var.name) > 0
+    error_message = "first"
+  }
+  type = string
+  validation {
+    condition     = length(var.name) < 64
+    error_message = "second"
+  }
+  description = "Name"
+}
+`,
+			wantOrder: []string{
+				`description = "Name"`,
+				"\n  type",
+				`error_message = "first"`,
+				`error_message = "second"`,
+			},
+		},
+		{
+			name: "all five known attributes reorder to canonical sequence",
+			input: `variable "name" {
+  nullable    = false
+  sensitive   = true
+  default     = "x"
+  type        = string
+  description = "Name"
+}
+`,
+			wantOrder: []string{
+				`description = "Name"`,
+				"\n  type",
+				"\n  default",
+				"\n  sensitive",
+				"\n  nullable",
+			},
+		},
+		{
+			name: "heredoc inside validation condition is preserved",
+			input: `variable "name" {
+  validation {
+    condition = (
+      length(var.name) > 0 &&
+      length(var.name) < 64
+    )
+    error_message = <<-EOT
+      name must be 1-63 characters.
+      See policy doc for # rationale.
+    EOT
+  }
+  type        = string
+  description = "Name"
+}
+`,
+			wantOrder: []string{
+				`description = "Name"`,
+				"\n  type",
+				`validation {`,
+				`length(var.name) > 0 &&`,
+				`length(var.name) < 64`,
+				`name must be 1-63 characters.`,
+				`See policy doc for # rationale.`,
+			},
+			wantKeep: []string{`See policy doc for # rationale.`},
+		},
+		{
+			name: "comment inside validation body survives reorder",
+			input: `variable "name" {
+  validation {
+    # check non-empty
+    condition     = length(var.name) > 0
+    error_message = "must not be empty"
+  }
+  type        = string
+  description = "Name"
+}
+`,
+			wantOrder: []string{
+				`description = "Name"`,
+				"\n  type",
+				`validation {`,
+				`# check non-empty`,
+				`condition     = length(var.name) > 0`,
+			},
+		},
+		{
+			name: "trailing comment on closing brace is preserved",
+			input: `variable "name" {
+  type        = string
+  description = "Name"
+} # end of name
+`,
+			wantOrder: []string{
+				`description = "Name"`,
+				"\n  type",
+				`} # end of name`,
+			},
+			wantKeep: []string{`# end of name`},
+		},
+		{
+			name: "orphan comment after last attr is preserved (no following region)",
+			input: `variable "name" {
+  type        = string
+  description = "Name"
+
+  # forgotten note pinned to the bottom
+}
+`,
+			wantOrder: []string{
+				`description = "Name"`,
+				"\n  type",
+				`# forgotten note pinned to the bottom`,
+			},
+			wantKeep: []string{`# forgotten note pinned to the bottom`},
+		},
+		{
+			name: "orphan comment between regions follows reordered next region",
+			input: `variable "name" {
+  type        = string
+
+  # comment naturally attached to default below
+  default     = "x"
+  description = "Name"
+}
+`,
+			wantOrder: []string{
+				`description = "Name"`,
+				"\n  type",
+				`# comment naturally attached to default below`,
+				"\n  default",
+			},
+		},
+		{
+			name: "leading comments on attrs and validation block are preserved",
+			input: `variable "name" {
+  # validation comment
+  validation {
+    condition     = length(var.name) > 0
+    error_message = "must not be empty"
+  }
+  # type comment
+  type = string
+  # description comment
+  description = "Name"
+}
+`,
+			wantOrder: []string{
+				`# description comment`,
+				`description = "Name"`,
+				`# type comment`,
+				`type = string`,
+				`# validation comment`,
+				`validation {`,
+			},
+			wantKeep: []string{
+				`# validation comment`,
+				`# type comment`,
+				`# description comment`,
+			},
+		},
+	}
+
+	for _, tt := range fixTests {
+		t.Run("Fix/"+tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			tmpFile := filepath.Join(tmpDir, "test.tf")
+			require.NoError(t, os.WriteFile(tmpFile, []byte(tt.input), 0o644))
+
+			ctx := &sdk.Context{File: tmpFile}
+			result, err := rule.Fix(ctx, nil)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			output := string(result)
+			assertOrderedSubstrings(t, output, tt.wantOrder)
+			for _, want := range tt.wantKeep {
+				assert.Contains(t, output, want, "should retain: %s", want)
+			}
+		})
+	}
+
+	t.Run("Fix is idempotent", func(t *testing.T) {
+		input := `variable "name" {
+  validation {
+    condition     = length(var.name) > 0
+    error_message = "must not be empty"
+  }
+  type        = string
+  description = <<-EOT
+    Multi-line
+    with # marker
+  EOT
+  default     = "x"
+}
 `
 		tmpDir := t.TempDir()
 		tmpFile := filepath.Join(tmpDir, "test.tf")
-		require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+		require.NoError(t, os.WriteFile(tmpFile, []byte(input), 0o644))
+
+		ctx := &sdk.Context{File: tmpFile}
+		first, err := rule.Fix(ctx, nil)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(tmpFile, first, 0o644))
+
+		second, err := rule.Fix(ctx, nil)
+		require.NoError(t, err)
+		assert.Equal(t, string(first), string(second), "Fix(Fix(content)) must equal Fix(content)")
+	})
+
+	t.Run("Fix handles multiple variables in one file", func(t *testing.T) {
+		input := `variable "first" {
+  type        = string
+  description = "First var"
+}
+
+variable "second" {
+  default     = "x"
+  type        = string
+  description = "Second var"
+}
+`
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "test.tf")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(input), 0o644))
 
 		ctx := &sdk.Context{File: tmpFile}
 		result, err := rule.Fix(ctx, nil)
 		require.NoError(t, err)
-		assert.NotNil(t, result)
+		output := string(result)
+		assertOrderedSubstrings(t, output, []string{
+			`description = "First var"`,
+			`type        = string`,
+			`description = "Second var"`,
+			`type        = string`,
+			`default     = "x"`,
+		})
 	})
+}
+
+// assertOrderedSubstrings asserts that each substring appears in the given top-down order.
+func assertOrderedSubstrings(t *testing.T, haystack string, needles []string) {
+	t.Helper()
+	prev := 0
+	prevNeedle := ""
+	for _, needle := range needles {
+		if prev > len(haystack) {
+			t.Fatalf("expected %q to appear after %q but reached end of input:\n%s", needle, prevNeedle, haystack)
+		}
+		idx := strings.Index(haystack[prev:], needle)
+		require.NotEqual(t, -1, idx, "expected %q to appear after %q in:\n%s", needle, prevNeedle, haystack)
+		prev += idx + len(needle)
+		prevNeedle = needle
+	}
 }
 
 func TestOutputOrderRule(t *testing.T) {
@@ -793,20 +1909,181 @@ func TestOutputOrderRule(t *testing.T) {
 		})
 	}
 
-	t.Run("Fix reorders attributes", func(t *testing.T) {
-		content := `output "example" {
+	outputFixTests := []struct {
+		name      string
+		input     string
+		wantOrder []string
+		wantKeep  []string
+	}{
+		{
+			name: "value before description gets reordered",
+			input: `output "example" {
+  value       = "test"
+  description = "Example output"
+}
+`,
+			wantOrder: []string{`description = "Example output"`, `value       = "test"`},
+		},
+		{
+			name: "all four known attrs reorder to canonical sequence",
+			input: `output "example" {
+  depends_on  = [aws_s3_bucket.x]
+  sensitive   = true
+  value       = "test"
+  description = "Example output"
+}
+`,
+			wantOrder: []string{
+				`description = "Example output"`,
+				"\n  value",
+				"\n  sensitive",
+				"\n  depends_on",
+			},
+		},
+		{
+			name: "precondition block moves after attrs",
+			input: `output "example" {
+  precondition {
+    condition     = var.x != ""
+    error_message = "x must be set"
+  }
+  value       = "test"
+  description = "Example output"
+}
+`,
+			wantOrder: []string{
+				`description = "Example output"`,
+				"\n  value",
+				`precondition {`,
+				`condition     = var.x != ""`,
+			},
+		},
+		{
+			name: "heredoc inside value attribute is preserved",
+			input: `output "example" {
+  value       = <<-EOT
+    A multi-line value
+    with # markers
+  EOT
+  description = "Example output"
+}
+`,
+			wantOrder: []string{
+				`description = "Example output"`,
+				`value       = <<-EOT`,
+				`A multi-line value`,
+				`with # markers`,
+				`EOT`,
+			},
+			wantKeep: []string{`with # markers`},
+		},
+		{
+			name: "leading comments on attrs and precondition are preserved",
+			input: `output "example" {
+  # precondition comment
+  precondition {
+    condition     = var.x != ""
+    error_message = "x must be set"
+  }
+  # value comment
+  value = "test"
+  # description comment
+  description = "Example output"
+}
+`,
+			wantOrder: []string{
+				`# description comment`,
+				`description = "Example output"`,
+				`# value comment`,
+				`value = "test"`,
+				`# precondition comment`,
+				`precondition {`,
+			},
+		},
+		{
+			name: "orphan trailing comment is preserved",
+			input: `output "example" {
+  value       = "test"
+  description = "Example output"
+
+  # forgotten trailing note
+}
+`,
+			wantKeep: []string{`# forgotten trailing note`},
+		},
+	}
+
+	for _, tt := range outputFixTests {
+		t.Run("Fix/"+tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			tmpFile := filepath.Join(tmpDir, "test.tf")
+			require.NoError(t, os.WriteFile(tmpFile, []byte(tt.input), 0o644))
+
+			ctx := &sdk.Context{File: tmpFile}
+			result, err := rule.Fix(ctx, nil)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			output := string(result)
+			assertOrderedSubstrings(t, output, tt.wantOrder)
+			for _, want := range tt.wantKeep {
+				assert.Contains(t, output, want, "should retain: %s", want)
+			}
+		})
+	}
+
+	t.Run("Fix is idempotent", func(t *testing.T) {
+		input := `output "example" {
+  precondition {
+    condition     = var.x != ""
+    error_message = "x must be set"
+  }
+  depends_on  = [aws_s3_bucket.x]
+  sensitive   = true
   value       = "test"
   description = "Example output"
 }
 `
 		tmpDir := t.TempDir()
 		tmpFile := filepath.Join(tmpDir, "test.tf")
-		require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+		require.NoError(t, os.WriteFile(tmpFile, []byte(input), 0o644))
+
+		ctx := &sdk.Context{File: tmpFile}
+		first, err := rule.Fix(ctx, nil)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(tmpFile, first, 0o644))
+
+		second, err := rule.Fix(ctx, nil)
+		require.NoError(t, err)
+		assert.Equal(t, string(first), string(second), "Fix(Fix(content)) must equal Fix(content)")
+	})
+
+	t.Run("Fix handles multiple outputs in one file", func(t *testing.T) {
+		input := `output "first" {
+  value       = "1"
+  description = "First"
+}
+
+output "second" {
+  sensitive   = true
+  value       = "2"
+  description = "Second"
+}
+`
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "test.tf")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(input), 0o644))
 
 		ctx := &sdk.Context{File: tmpFile}
 		result, err := rule.Fix(ctx, nil)
 		require.NoError(t, err)
-		assert.NotNil(t, result)
+		assertOrderedSubstrings(t, string(result), []string{
+			`description = "First"`,
+			`value       = "1"`,
+			`description = "Second"`,
+			`value       = "2"`,
+			`sensitive   = true`,
+		})
 	})
 }
 
@@ -871,10 +2148,110 @@ terraform {
 		})
 	}
 
-	t.Run("Fix returns nil", func(t *testing.T) {
+	t.Run("Fix returns nil when ctx is nil", func(t *testing.T) {
 		result, err := rule.Fix(nil, nil)
 		assert.NoError(t, err)
 		assert.Nil(t, result)
+	})
+
+	t.Run("Fix moves terraform block to first position", func(t *testing.T) {
+		input := `resource "aws_instance" "x" {
+  ami = "ami-123"
+}
+
+terraform {
+  required_version = ">= 1.0"
+}
+`
+		out := runRuleFix(t, rule, input)
+		tfIdx := strings.Index(out, "terraform {")
+		rIdx := strings.Index(out, "resource ")
+		require.NotEqual(t, -1, tfIdx)
+		require.NotEqual(t, -1, rIdx)
+		assert.Less(t, tfIdx, rIdx, "terraform must precede resource after fix")
+	})
+
+	t.Run("Fix preserves comments inside resource bodies", func(t *testing.T) {
+		input := `resource "aws_instance" "x" {
+  # important: choose AMI carefully
+  ami           = "ami-123"
+  instance_type = "t3.medium" # production size
+}
+
+terraform {
+  required_version = ">= 1.0"
+}
+`
+		out := runRuleFix(t, rule, input)
+		assert.Contains(t, out, "# important: choose AMI carefully")
+		assert.Contains(t, out, "# production size")
+		// The buggy old helper would reshuffle attrs via map iteration; line-range never touches block bodies.
+		amiIdx := strings.Index(out, "ami           = ")
+		instIdx := strings.Index(out, "instance_type = ")
+		require.NotEqual(t, -1, amiIdx)
+		require.NotEqual(t, -1, instIdx)
+		assert.Less(t, amiIdx, instIdx, "resource body attribute order must be untouched")
+	})
+
+	t.Run("Fix preserves standalone comments above blocks", func(t *testing.T) {
+		// Mirrors a real-world backup-style file: standalone section header comments
+		// and an external link comment must remain anchored to their blocks after reorder.
+		//nolint:dupword // HCL content intentionally contains repeated identifiers
+		input := `# https://docs.example.com/backup-policy
+
+# Section: SNS Notifications
+resource "aws_sns_topic" "backup" {
+  name = "backup"
+}
+
+# A note about the module
+module "backup_vault" {
+  source = "./vault"
+  name   = "default"
+}
+
+terraform {
+  required_version = ">= 1.0"
+}
+`
+		out := runRuleFix(t, rule, input)
+		// The Slab-style URL comment lives in the file header.
+		assert.Contains(t, out, "# https://docs.example.com/backup-policy")
+		// Section header travels with its sns_topic resource.
+		assert.Contains(t, out, "# Section: SNS Notifications")
+		// Module-attached comment stays with the module.
+		assert.Contains(t, out, "# A note about the module")
+		// Resulting order: terraform, resource, module
+		assertOrderedSubstrings(t, out, []string{
+			"terraform {",
+			"# Section: SNS Notifications",
+			`resource "aws_sns_topic"`,
+			"# A note about the module",
+			`module "backup_vault"`,
+		})
+	})
+
+	t.Run("Fix is idempotent", func(t *testing.T) {
+		input := `resource "aws_instance" "x" {
+  ami = "ami-123"
+}
+
+terraform {
+  required_version = ">= 1.0"
+}
+`
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "test.tf")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(input), 0o644))
+
+		ctx := &sdk.Context{File: tmpFile}
+		first, err := rule.Fix(ctx, nil)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(tmpFile, first, 0o644))
+
+		second, err := rule.Fix(ctx, nil)
+		require.NoError(t, err)
+		assert.Equal(t, string(first), string(second), "Fix(Fix(content)) must equal Fix(content)")
 	})
 }
 
@@ -947,11 +2324,141 @@ provider "aws" {
 		})
 	}
 
-	t.Run("Fix returns nil", func(t *testing.T) {
+	t.Run("Fix returns nil when ctx is nil", func(t *testing.T) {
 		result, err := rule.Fix(nil, nil)
 		assert.NoError(t, err)
 		assert.Nil(t, result)
 	})
+
+	t.Run("Fix reorders terraform, resource, provider to terraform, provider, resource", func(t *testing.T) {
+		input := `terraform {
+  required_version = ">= 1.0"
+}
+
+resource "aws_instance" "x" {
+  ami = "ami-123"
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+`
+		out := runRuleFix(t, rule, input)
+		assertOrderedSubstrings(t, out, []string{
+			"terraform {",
+			`provider "aws"`,
+			`resource "aws_instance"`,
+		})
+	})
+
+	t.Run("Fix preserves all comments through reorder", func(t *testing.T) {
+		//nolint:dupword // HCL content intentionally contains repeated block-type identifiers
+		input := `# File-level note at top.
+
+# About the resource
+resource "aws_instance" "x" {
+  ami = "ami-123"
+}
+
+# About the provider
+provider "aws" {
+  region = "us-east-1"
+}
+
+# About terraform
+terraform {
+  required_version = ">= 1.0"
+}
+`
+		out := runRuleFix(t, rule, input)
+		assert.Contains(t, out, "# File-level note at top.")
+		assert.Contains(t, out, "# About the resource")
+		assert.Contains(t, out, "# About the provider")
+		assert.Contains(t, out, "# About terraform")
+		assertOrderedSubstrings(t, out, []string{
+			"# File-level note at top.",
+			"# About terraform",
+			"terraform {",
+			"# About the provider",
+			`provider "aws"`,
+			"# About the resource",
+			`resource "aws_instance"`,
+		})
+	})
+
+	t.Run("Fix does not touch attributes inside untouched blocks", func(t *testing.T) {
+		input := `resource "aws_instance" "x" {
+  ami           = "ami-123"
+  instance_type = "t3.medium"
+  tags = {
+    Name = "test"
+    Env  = "prod"
+  }
+}
+
+terraform {
+  required_version = ">= 1.0"
+}
+`
+		out := runRuleFix(t, rule, input)
+		// Resource body order untouched.
+		amiIdx := strings.Index(out, "ami           = ")
+		instIdx := strings.Index(out, "instance_type = ")
+		tagsIdx := strings.Index(out, "tags = {")
+		require.NotEqual(t, -1, amiIdx)
+		require.NotEqual(t, -1, instIdx)
+		require.NotEqual(t, -1, tagsIdx)
+		assert.Less(t, amiIdx, instIdx)
+		assert.Less(t, instIdx, tagsIdx)
+		// Nested map order preserved
+		nameIdx := strings.Index(out, `Name = "test"`)
+		envIdx := strings.Index(out, `Env  = "prod"`)
+		assert.Less(t, nameIdx, envIdx)
+	})
+
+	t.Run("Fix is idempotent", func(t *testing.T) {
+		input := `provider "aws" {
+  region = "us-east-1"
+}
+
+terraform {
+  required_version = ">= 1.0"
+}
+
+resource "aws_instance" "x" {
+  ami = "ami-123"
+}
+`
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "test.tf")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(input), 0o644))
+
+		ctx := &sdk.Context{File: tmpFile}
+		first, err := rule.Fix(ctx, nil)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(tmpFile, first, 0o644))
+
+		second, err := rule.Fix(ctx, nil)
+		require.NoError(t, err)
+		assert.Equal(t, string(first), string(second), "Fix(Fix(content)) must equal Fix(content)")
+	})
+}
+
+// runRuleFix writes content to a tmp file, runs rule.Fix, and returns the output as a string.
+func runRuleFix(t *testing.T, rule sdk.Rule, content string) string {
+	t.Helper()
+	fixer, ok := rule.(sdk.Fixer)
+	require.True(t, ok, "rule must implement sdk.Fixer")
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "test.tf")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+
+	ctx := &sdk.Context{File: tmpFile}
+	result, err := fixer.Fix(ctx, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	return string(result)
 }
 
 func TestIsDependsOnRelevantBlock(t *testing.T) {

--- a/internal/engines/style/rules/organization.go
+++ b/internal/engines/style/rules/organization.go
@@ -30,9 +30,9 @@ func (r *VariablesInFileRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Fin
 		return findings, nil
 	}
 
-	// Skip if this is variables.tf
+	// Skip if this is variables.tf or its singular alias
 	basename := filepath.Base(ctx.File)
-	if basename == "variables.tf" {
+	if basename == "variables.tf" || basename == "variable.tf" {
 		return findings, nil
 	}
 
@@ -78,9 +78,9 @@ func (r *OutputsInFileRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Findi
 		return findings, nil
 	}
 
-	// Skip if this is outputs.tf
+	// Skip if this is outputs.tf or its singular alias
 	basename := filepath.Base(ctx.File)
-	if basename == "outputs.tf" {
+	if basename == "outputs.tf" || basename == "output.tf" {
 		return findings, nil
 	}
 
@@ -126,9 +126,9 @@ func (r *ProvidersInFileRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Fin
 		return findings, nil
 	}
 
-	// Skip if this is providers.tf or versions.tf
+	// Skip if this is providers.tf, its singular alias, or versions.tf
 	basename := filepath.Base(ctx.File)
-	if basename == "providers.tf" || basename == "versions.tf" {
+	if basename == "providers.tf" || basename == "provider.tf" || basename == "versions.tf" {
 		return findings, nil
 	}
 

--- a/internal/engines/style/rules/organization_test.go
+++ b/internal/engines/style/rules/organization_test.go
@@ -38,6 +38,14 @@ func TestVariablesInFileRule(t *testing.T) {
 			wantFindings: 0,
 		},
 		{
+			name:     "variable in singular variable.tf is valid",
+			filename: "variable.tf",
+			content: `variable "example" {
+  type = string
+}`,
+			wantFindings: 0,
+		},
+		{
 			name:     "variable in main.tf reports finding",
 			filename: "main.tf",
 			content: `variable "example" {
@@ -112,6 +120,14 @@ func TestOutputsInFileRule(t *testing.T) {
 			wantFindings: 0,
 		},
 		{
+			name:     "output in singular output.tf is valid",
+			filename: "output.tf",
+			content: `output "example" {
+  value = "test"
+}`,
+			wantFindings: 0,
+		},
+		{
 			name:     "output in main.tf reports finding",
 			filename: "main.tf",
 			content: `output "example" {
@@ -180,6 +196,22 @@ func TestProvidersInFileRule(t *testing.T) {
   region = "us-east-1"
 }`,
 			wantFindings: 0,
+		},
+		{
+			name:     "provider in singular provider.tf is valid",
+			filename: "provider.tf",
+			content: `provider "aws" {
+  region = "us-east-1"
+}`,
+			wantFindings: 0,
+		},
+		{
+			name:     "provider in singular version.tf reports finding (not aliased)",
+			filename: "version.tf",
+			content: `provider "aws" {
+  region = "us-east-1"
+}`,
+			wantFindings: 1,
 		},
 		{
 			name:     "provider in main.tf reports finding",

--- a/internal/output/junit.go
+++ b/internal/output/junit.go
@@ -148,7 +148,8 @@ func (f *JUnitFormatter) buildTestSuite(file string, findings []sdk.Finding, tim
 		}
 
 		// Build detailed message with location
-		detail := fmt.Sprintf("File: %s\nLine: %d, Column: %d\n\n%s",
+		detail := fmt.Sprintf(
+			"File: %s\nLine: %d, Column: %d\n\n%s",
 			displayFile,
 			findings[i].Location.StartLine,
 			findings[i].Location.StartColumn,

--- a/internal/output/markdown.go
+++ b/internal/output/markdown.go
@@ -94,7 +94,8 @@ func (f *MarkdownFormatter) writeFileFindingsAsTable(w io.Writer, file string, f
 
 	for _, finding := range findings {
 		icon := f.severityIcon(finding.Severity)
-		_, _ = fmt.Fprintf(w, "\n| %s %s | %d | `%s` | %s |",
+		_, _ = fmt.Fprintf(
+			w, "\n| %s %s | %d | `%s` | %s |",
 			icon,
 			finding.Severity,
 			finding.Location.StartLine,

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -116,7 +116,8 @@ func (f *TextFormatter) Format(findings []sdk.Finding, w io.Writer) error {
 		hasLocation := finding.Location.StartLine > 0
 		if f.Color {
 			if hasLocation {
-				_, _ = fmt.Fprintf(w, "%s%s%s %s:%d:%d: %s %s(%s)%s\n",
+				_, _ = fmt.Fprintf(
+					w, "%s%s%s %s:%d:%d: %s %s(%s)%s\n",
 					iconColor, icon, colorReset,
 					displayFile,
 					finding.Location.StartLine,
@@ -125,7 +126,8 @@ func (f *TextFormatter) Format(findings []sdk.Finding, w io.Writer) error {
 					colorGray, finding.Rule, colorReset,
 				)
 			} else {
-				_, _ = fmt.Fprintf(w, "%s%s%s %s: %s %s(%s)%s\n",
+				_, _ = fmt.Fprintf(
+					w, "%s%s%s %s: %s %s(%s)%s\n",
 					iconColor, icon, colorReset,
 					displayFile,
 					finding.Message,
@@ -134,7 +136,8 @@ func (f *TextFormatter) Format(findings []sdk.Finding, w io.Writer) error {
 			}
 		} else {
 			if hasLocation {
-				_, _ = fmt.Fprintf(w, "%s %s:%d:%d: %s (%s)\n",
+				_, _ = fmt.Fprintf(
+					w, "%s %s:%d:%d: %s (%s)\n",
 					icon,
 					displayFile,
 					finding.Location.StartLine,
@@ -143,7 +146,8 @@ func (f *TextFormatter) Format(findings []sdk.Finding, w io.Writer) error {
 					finding.Rule,
 				)
 			} else {
-				_, _ = fmt.Fprintf(w, "%s %s: %s (%s)\n",
+				_, _ = fmt.Fprintf(
+					w, "%s %s: %s (%s)\n",
 					icon,
 					displayFile,
 					finding.Message,
@@ -376,7 +380,8 @@ func (f *TableFormatter) printFinding(w io.Writer, finding sdk.Finding) {
 	}
 
 	if f.Color {
-		_, _ = fmt.Fprintf(w, "%s%-10s%s %-50s %s\n",
+		_, _ = fmt.Fprintf(
+			w, "%s%-10s%s %-50s %s\n",
 			severityColor, severity, colorReset,
 			location,
 			message,
@@ -497,7 +502,8 @@ func (f *HTMLFormatter) generateHTML(
 	errors, warnings, info int,
 ) string {
 	total := len(findings)
-	return fmt.Sprintf(`<!DOCTYPE html>
+	return fmt.Sprintf(
+		`<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
@@ -712,7 +718,8 @@ func (f *HTMLFormatter) generateFindingHTML(finding sdk.Finding) string {
 		fixableBadge = `<span class="badge badge-fixable">Fixable</span>`
 	}
 
-	return fmt.Sprintf(`
+	return fmt.Sprintf(
+		`
             <div class="finding">
                 <div class="finding-icon %s">%s</div>
                 <div class="finding-content">


### PR DESCRIPTION
## What and why

Accuracy and correctness pass on the `internal/engines/style/rules/` package. Four atomic commits:

- **`fix(style): preserve comments and nested blocks during reorder`** — overhauls the line-range reorder pipeline. New helpers (`collectLeadingComments`, `BlockRegion` + `ExtractBlockRegions`, `ReorderBlockBodyPreservingAll`, `ReorderTopLevelBlocksByLineRange`, `collectOrphanLines`) make every reorder byte-faithful. The previous AST-copy `ReorderTopLevelBlocks` dropped inline comments and could damage nested block contents; the new line-range path emits unclaimed non-blank lines before the closing brace so reorder is never lossy. `LifecycleAtEndRule` now covers `data`, `module`, `check` (not just `resource`). `TagsAtEndRule` / `DependsOnOrderRule` adopt a single-finding policy ("before lifecycle" wins over "near the end"), count trailing nested blocks (not only attributes), share `moveAttrBeforeLifecycle`, and rewrite bottom-up. `DependsOnOrderRule` severity bumped from info to warning so the finding surfaces under default thresholds before `--fix` mutates the file. `VariableOrderRule` / `OutputOrderRule` now also order `validation` / `precondition` nested blocks.
- **`fix(style): scope CommentSyntaxRule to full-line // comments`** — only flags lines whose first non-whitespace characters are `//`. Inline trailing `// note` after a value and `#` comments containing `//` (e.g. URLs like `# https://example.com/path`) no longer false-positive. Replaces the hand-rolled per-character string-aware scanner with a trim-and-prefix check.
- **`feat(style): accept singular file aliases for variable/output/provider`** — `variable.tf`, `output.tf`, `provider.tf` are now valid containers alongside the canonical plural names. Affects `VariablesInFileRule`, `OutputsInFileRule`, `ProvidersInFileRule`, and `TerraformFilesStructureRule`. Suggestion messages still point to the canonical plural names.
- **`style: split first arg onto its own line in multi-line calls`** — whitespace-only normalization across CLI, lint engine, and output formatters.

**Why:** several style rules were producing false positives or silently dropping content during `--fix`. The reorder paths were the worst offenders — the AST-copy approach for top-level blocks lost inline comments and could corrupt nested-block bodies, and the line-range path for nested reordering had no orphan-line fallback. `CommentSyntaxRule` flagged URLs inside `#` comments. `LifecycleAtEndRule` only knew about `resource`. The singular file aliases are a common Terraform convention that users were getting nagged about. Fixing these together kept the helper changes coherent.

## How to test

```bash
mise run check    # fmt + vet + lint + test (clean locally, 96% coverage on pkg/sdk)
```

Specific behaviors worth eyeballing manually:

- `terratidy check --fix` on a resource with `tags = {}; ingress {}; lifecycle {}` — tags should land just before lifecycle, ingress should stay put.
- A file with `# https://example.com/path` should no longer be flagged by `style.comment-syntax`.
- A `variable.tf` containing a `variable` block should pass `style.variables-in-file`.
- `terratidy check --fix` on a file with a section-header comment above a block should keep the comment attached to the block after reorder.

## Notes for reviewers

- Commit 4 is the bulk of the diff (~2.8k insertions in `helpers.go` / `ordering.go` plus their tests). Helpers grow but each new symbol has a doc comment that explains the semantics (blank-line passthrough, orphan-line position, top-level vs nested comment-capture rules).
- `DependsOnOrderRule` severity bump (info -> warning) is intentional: leaving it at info hid the finding under the default `severity_threshold: warning` config, so `--fix` would rewrite a file the user never saw flagged.
- Singular file aliases (`variable.tf` etc.) are accepted as valid but suggestion messages still recommend the canonical plural form — kept guidance consistent rather than encouraging both conventions in parallel.
- No public-API changes in `pkg/sdk/`.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
