### PR TITLE
feat(fmt): structured output mode + diff-color polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ benchmarks/*
 .plans
 .issues
 .history
+.pre-specs
 
 # temp
 temp/

--- a/cmd/terratidy/fmt.go
+++ b/cmd/terratidy/fmt.go
@@ -63,16 +63,22 @@ Use --all to also apply style fixes (equivalent to running fmt + style --fix).`,
 		fmtCfg := buildFmtConfig(cmd, cfg)
 		engine := fmtengine.New(fmtCfg)
 
-		modeMsg := ""
-		if changed {
-			modeMsg = " (changed files only)"
-		}
-		if fmtAll && fmtCfg.Check {
-			fmt.Printf("Checking formatting and style on %s%s...\n\n", formatFileCount(len(files)), modeMsg)
-		} else if fmtAll {
-			fmt.Printf("Formatting and applying style fixes to %s%s...\n\n", formatFileCount(len(files)), modeMsg)
-		} else {
-			fmt.Printf("Formatting %s%s...\n\n", formatFileCount(len(files)), modeMsg)
+		// Structured output formats (json, sarif, etc.) suppress all human-readable
+		// progress text; findings are emitted through the shared formatter at the end.
+		useStructuredOutput := format != "" && format != "text"
+
+		if !useStructuredOutput {
+			modeMsg := ""
+			if changed {
+				modeMsg = " (changed files only)"
+			}
+			if fmtAll && fmtCfg.Check {
+				fmt.Printf("Checking formatting and style on %s%s...\n\n", formatFileCount(len(files)), modeMsg)
+			} else if fmtAll {
+				fmt.Printf("Formatting and applying style fixes to %s%s...\n\n", formatFileCount(len(files)), modeMsg)
+			} else {
+				fmt.Printf("Formatting %s%s...\n\n", formatFileCount(len(files)), modeMsg)
+			}
 		}
 
 		// Run formatter
@@ -85,44 +91,60 @@ Use --all to also apply style fixes (equivalent to running fmt + style --fix).`,
 		// (fmt.formatted has SeverityInfo which would be filtered out)
 		needsFormatting := 0
 		formatted := 0
-		useAbsolutePaths := getEffectiveAbsolutePaths(cfg)
-		for _, finding := range findings {
-			displayFile := output.DisplayPath(finding.File, useAbsolutePaths)
-			switch finding.Rule {
-			case "fmt.needs-formatting":
-				fmt.Printf("  [!] %s: needs formatting\n", displayFile)
-				needsFormatting++
-			case "fmt.formatted":
-				fmt.Printf("  [+] %s: formatted\n", displayFile)
-				formatted++
+		if !useStructuredOutput {
+			useAbsolutePaths := getEffectiveAbsolutePaths(cfg)
+			for _, finding := range findings {
+				displayFile := output.DisplayPath(finding.File, useAbsolutePaths)
+				switch finding.Rule {
+				case "fmt.needs-formatting":
+					fmt.Printf("  [!] %s: needs formatting\n", displayFile)
+					needsFormatting++
+				case "fmt.formatted":
+					fmt.Printf("  [+] %s: formatted\n", displayFile)
+					formatted++
+				}
+				// Print diff if diff mode is enabled (via CLI or config) and the finding carries one
+				if fmtCfg.Diff && finding.IsDiff {
+					fmt.Println()
+					fmt.Print(output.FormatDiff(finding.Message, color))
+				}
 			}
-			// Print diff if diff mode is enabled (via CLI or config) and the finding carries one
-			if fmtCfg.Diff && finding.IsDiff {
+
+			// Summary for formatting
+			if len(findings) == 0 {
+				fmt.Println("All files are properly formatted")
+			} else if formatted > 0 {
 				fmt.Println()
-				fmt.Print(output.FormatDiff(finding.Message, color))
+				fmt.Println("---")
+				fmt.Printf("Formatted %s\n", formatFileCount(formatted))
+			}
+		} else {
+			// Structured output: count needs-formatting for exit code only.
+			for _, finding := range findings {
+				if finding.Rule == "fmt.needs-formatting" {
+					needsFormatting++
+				}
 			}
 		}
 
-		// Summary for formatting
-		if len(findings) == 0 {
-			fmt.Println("All files are properly formatted")
-		} else if formatted > 0 {
-			fmt.Println()
-			fmt.Printf("Formatted %s\n", formatFileCount(formatted))
-		}
+		// Collect findings to emit via the formatter in structured output mode.
+		var allFindings []sdk.Finding
+		allFindings = append(allFindings, findings...)
 
 		// Track total issues for check mode exit code
 		totalIssues := needsFormatting
 
 		// Run style engine if --all flag is set (in both check and fix modes)
 		if fmtAll {
-			fmt.Println()
-			if fmtCfg.Check {
-				fmt.Println("Checking style...")
-			} else {
-				fmt.Println("Applying style fixes...")
+			if !useStructuredOutput {
+				fmt.Println()
+				if fmtCfg.Check {
+					fmt.Println("Checking style...")
+				} else {
+					fmt.Println("Applying style fixes...")
+				}
+				fmt.Println()
 			}
-			fmt.Println()
 
 			// Load plugin rules if plugins are enabled
 			pluginRules, err := loadPluginRules(cfg)
@@ -144,10 +166,10 @@ Use --all to also apply style fixes (equivalent to running fmt + style --fix).`,
 			styleIssues := 0
 			styleFixed := 0
 			for _, finding := range styleFindings {
-				// Skip diff-only findings (style.diff rule)
+				// Skip diff-only findings (style.diff rule) for issue counting
 				if finding.Rule == "style.diff" {
-					// Print diff if present
-					if fmtCfg.Diff && finding.IsDiff {
+					// Print diff if present (text mode only; structured mode emits via formatter)
+					if !useStructuredOutput && fmtCfg.Diff && finding.IsDiff {
 						fmt.Println()
 						fmt.Print(output.FormatDiff(finding.Message, color))
 					}
@@ -162,38 +184,61 @@ Use --all to also apply style fixes (equivalent to running fmt + style --fix).`,
 				}
 			}
 
+			allFindings = append(allFindings, styleFindings...)
+
 			if fmtCfg.Check {
-				// Check mode: report issues found
 				if styleIssues > 0 {
-					fmt.Printf("Found %d style issue(s) that can be fixed with fmt --all\n", styleIssues)
+					if !useStructuredOutput {
+						fmt.Println("---")
+						fmt.Printf("Found %d style issue(s) that can be fixed with fmt --all\n", styleIssues)
+					}
 					totalIssues += styleIssues
-				} else {
+				} else if !useStructuredOutput {
 					fmt.Println("No style issues found")
 				}
 			} else {
 				// Fix mode: report fixes applied
 				if styleFixed > 0 {
-					fmt.Printf("Fixed %d style issue(s)\n", styleFixed)
+					if !useStructuredOutput {
+						fmt.Println("---")
+						fmt.Printf("Fixed %d style issue(s)\n", styleFixed)
 
-					// Re-run formatter after style fixes to restore proper HCL formatting
-					// (style fixes may disrupt equal sign alignment)
-					fmt.Println()
-					fmt.Println("Re-formatting files...")
+						// Re-run formatter after style fixes to restore proper HCL formatting
+						// (style fixes may disrupt equal sign alignment)
+						fmt.Println()
+						fmt.Println("Re-aligning attributes after style fixes...")
+					}
 					rerunEngine := fmtengine.New(&fmtengine.Config{
 						Check: false,
 						Diff:  false,
 					})
 					if _, err := rerunEngine.Run(context.Background(), files); err != nil {
-						return sdk.NewInternalError(fmt.Errorf("re-formatting files: %w", err))
+						return sdk.NewInternalError(fmt.Errorf("re-aligning attributes: %w", err))
 					}
-					fmt.Println("Done")
-				} else {
+					if !useStructuredOutput {
+						fmt.Println("Done")
+					}
+				} else if !useStructuredOutput {
 					fmt.Println("No style issues to fix")
 				}
 			}
 		}
 
-		// In check mode, return findings error if any issues found
+		// Structured output: emit all findings through the shared formatter.
+		// outputResults handles the exit code for SeverityError findings, so we
+		// only need to add the fmt-specific check-mode short-circuit for the rare
+		// case where check mode produced only info-severity findings.
+		if useStructuredOutput {
+			if err := outputResults(allFindings, "Format summary", cfg); err != nil {
+				return err
+			}
+			if fmtCfg.Check && totalIssues > 0 {
+				return sdk.NewFindingsError()
+			}
+			return nil
+		}
+
+		// In check mode (text), return findings error if any issues found
 		if fmtCfg.Check && totalIssues > 0 {
 			return sdk.NewFindingsError()
 		}

--- a/cmd/terratidy/fmt_test.go
+++ b/cmd/terratidy/fmt_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -668,5 +670,313 @@ func TestFmtAllCheckMode(t *testing.T) {
 
 		// Should succeed with no issues
 		assert.NoError(t, err, "fmt --all --check should succeed when no issues exist")
+	})
+}
+
+// TestFmtTextSummarySeparator verifies that `---` appears before fmt and style
+// summary totals in text mode (matching lint/style/policy cadence), and does
+// NOT appear when there are no findings to summarize.
+func TestFmtTextSummarySeparator(t *testing.T) {
+	oldFmtCheck := fmtCheck
+	oldFmtDiff := fmtDiff
+	oldFmtAll := fmtAll
+	oldChanged := changed
+	oldFormat := format
+	oldColor := color
+
+	resetFmtFlags := func() {
+		for _, name := range []string{"check", "diff", "all"} {
+			if f := fmtCmd.Flags().Lookup(name); f != nil {
+				f.Changed = false
+			}
+		}
+	}
+
+	t.Cleanup(func() {
+		fmtCheck = oldFmtCheck
+		fmtDiff = oldFmtDiff
+		fmtAll = oldFmtAll
+		changed = oldChanged
+		format = oldFormat
+		color = oldColor
+		rootCmd.SetArgs(nil)
+		resetFmtFlags()
+	})
+
+	captureStdout := func(t *testing.T, run func()) string {
+		t.Helper()
+		oldStdout := os.Stdout
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		os.Stdout = w
+		run()
+		_ = w.Close()
+		os.Stdout = oldStdout
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+		return buf.String()
+	}
+
+	t.Run("fmt with formatted files prints --- before Formatted totals", func(t *testing.T) {
+		resetFmtFlags()
+		dir := t.TempDir()
+		unformatted := `resource "aws_instance" "bad"   {
+ami="ami-123"
+}`
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "bad.tf"), []byte(unformatted), 0o644))
+
+		fmtCheck = false
+		fmtDiff = false
+		fmtAll = false
+		changed = false
+		format = "text"
+		color = false
+
+		out := captureStdout(t, func() {
+			rootCmd.SetArgs([]string{"fmt", dir})
+			_ = rootCmd.Execute()
+		})
+
+		assert.Contains(t, out, "---\nFormatted ", "expected --- separator before Formatted totals")
+	})
+
+	t.Run("fmt with all-formatted files does NOT print --- separator", func(t *testing.T) {
+		resetFmtFlags()
+		dir := t.TempDir()
+		formatted := `resource "aws_instance" "good" {
+  ami = "ami-123"
+}
+`
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "good.tf"), []byte(formatted), 0o644))
+
+		fmtCheck = false
+		fmtDiff = false
+		fmtAll = false
+		changed = false
+		format = "text"
+		color = false
+
+		out := captureStdout(t, func() {
+			rootCmd.SetArgs([]string{"fmt", dir})
+			_ = rootCmd.Execute()
+		})
+
+		assert.NotContains(t, out, "---", "no --- separator when there are no totals to print")
+		assert.Contains(t, out, "All files are properly formatted")
+	})
+
+	t.Run("fmt --all --check with style issues prints --- before Found totals", func(t *testing.T) {
+		resetFmtFlags()
+		dir := t.TempDir()
+		// Style issue: tags should be at end of resource block.
+		content := `resource "aws_instance" "test" {
+  tags = {
+    Name = "test"
+  }
+
+  ami = "ami-123"
+}
+`
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"), []byte(content), 0o644))
+
+		fmtCheck = false
+		fmtDiff = false
+		fmtAll = false
+		changed = false
+		format = "text"
+		color = false
+
+		out := captureStdout(t, func() {
+			rootCmd.SetArgs([]string{"fmt", "--all", "--check", dir})
+			_ = rootCmd.Execute()
+		})
+
+		assert.Contains(t, out, "---\nFound ", "expected --- separator before Found style totals")
+	})
+}
+
+// TestFmtStructuredOutput verifies that `fmt --format json` (and other
+// structured formats) emit valid JSON, suppress banners/per-file lines, and
+// surface exit codes through the shared findings-error path.
+func TestFmtStructuredOutput(t *testing.T) {
+	// Save and restore globals to avoid test pollution
+	oldFmtCheck := fmtCheck
+	oldFmtDiff := fmtDiff
+	oldFmtAll := fmtAll
+	oldChanged := changed
+	oldFormat := format
+	oldColor := color
+
+	resetFmtFlags := func() {
+		for _, name := range []string{"check", "diff", "all"} {
+			if f := fmtCmd.Flags().Lookup(name); f != nil {
+				f.Changed = false
+			}
+		}
+	}
+
+	t.Cleanup(func() {
+		fmtCheck = oldFmtCheck
+		fmtDiff = oldFmtDiff
+		fmtAll = oldFmtAll
+		changed = oldChanged
+		format = oldFormat
+		color = oldColor
+		rootCmd.SetArgs(nil)
+		resetFmtFlags()
+	})
+
+	t.Run("check mode with unformatted file produces valid JSON and no banner", func(t *testing.T) {
+		resetFmtFlags()
+
+		dir := t.TempDir()
+		unformattedContent := `resource "aws_instance" "bad"   {
+ami="ami-123"
+}`
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "bad.tf"), []byte(unformattedContent), 0o644))
+
+		// Reset flags
+		fmtCheck = false
+		fmtDiff = false
+		fmtAll = false
+		changed = false
+		format = "json"
+		color = false
+
+		// Capture stdout
+		oldStdout := os.Stdout
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		os.Stdout = w
+
+		rootCmd.SetArgs([]string{"fmt", "--check", "--format", "json", dir})
+		runErr := rootCmd.Execute()
+
+		_ = w.Close()
+		os.Stdout = oldStdout
+
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+		out := buf.String()
+
+		// fmt --check on an unformatted file must surface a findings exit error.
+		require.Error(t, runErr, "fmt --check on unformatted file should return ExitError")
+		var exitErr *sdk.ExitError
+		require.True(t, errors.As(runErr, &exitErr), "expected ExitError, got: %v", runErr)
+		assert.Equal(t, sdk.ExitFindings, exitErr.Code)
+
+		// Output must be valid JSON.
+		var payload map[string]any
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &payload), "output should be valid JSON, got: %s", out)
+
+		// Banner text and per-file markers must not appear on stdout in structured mode.
+		assert.NotContains(t, out, "Formatting ")
+		assert.NotContains(t, out, "[!] ")
+		assert.NotContains(t, out, "[+] ")
+		assert.NotContains(t, out, "Re-aligning")
+		assert.NotContains(t, out, "All files are properly formatted")
+
+		// JSON payload should include the fmt finding.
+		assert.Contains(t, out, "fmt.needs-formatting")
+	})
+
+	t.Run("all and check with style issue emits valid JSON with no banner", func(t *testing.T) {
+		resetFmtFlags()
+
+		dir := t.TempDir()
+		// Style issue (tags should be at end of resource block).
+		contentWithStyleIssue := `resource "aws_instance" "test" {
+  tags = {
+    Name = "test"
+  }
+
+  ami           = "ami-123"
+  instance_type = "t2.micro"
+}
+`
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"), []byte(contentWithStyleIssue), 0o644))
+
+		fmtCheck = false
+		fmtDiff = false
+		fmtAll = false
+		changed = false
+		format = "json"
+		color = false
+
+		oldStdout := os.Stdout
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		os.Stdout = w
+
+		rootCmd.SetArgs([]string{"fmt", "--all", "--check", "--format", "json", dir})
+		runErr := rootCmd.Execute()
+
+		_ = w.Close()
+		os.Stdout = oldStdout
+
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+		out := buf.String()
+
+		// --all --check on a file with a style issue must return ExitFindings.
+		require.Error(t, runErr, "fmt --all --check should error on style issue")
+		var exitErr *sdk.ExitError
+		require.True(t, errors.As(runErr, &exitErr), "expected ExitError, got: %v", runErr)
+		assert.Equal(t, sdk.ExitFindings, exitErr.Code)
+
+		// Output must be valid JSON.
+		var payload map[string]any
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &payload), "output should be valid JSON, got: %s", out)
+
+		// No human-readable banners or sub-banners on stdout.
+		assert.NotContains(t, out, "Checking formatting and style")
+		assert.NotContains(t, out, "Checking style...")
+		assert.NotContains(t, out, "Applying style fixes...")
+		assert.NotContains(t, out, "Re-aligning")
+		assert.NotContains(t, out, "Found ")
+	})
+
+	t.Run("formatted file in check mode emits valid JSON with no findings and no banner", func(t *testing.T) {
+		resetFmtFlags()
+
+		dir := t.TempDir()
+		formattedContent := `resource "aws_instance" "good" {
+  ami           = "ami-123"
+  instance_type = "t2.micro"
+}
+`
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "good.tf"), []byte(formattedContent), 0o644))
+
+		fmtCheck = false
+		fmtDiff = false
+		fmtAll = false
+		changed = false
+		format = "json"
+		color = false
+
+		oldStdout := os.Stdout
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		os.Stdout = w
+
+		rootCmd.SetArgs([]string{"fmt", "--check", "--format", "json", dir})
+		runErr := rootCmd.Execute()
+
+		_ = w.Close()
+		os.Stdout = oldStdout
+
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+		out := buf.String()
+
+		assert.NoError(t, runErr, "fmt --check should succeed on formatted files")
+
+		// Output must be valid JSON even when there are no findings.
+		var payload map[string]any
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &payload), "output should be valid JSON, got: %s", out)
+
+		assert.NotContains(t, out, "Formatting ")
+		assert.NotContains(t, out, "All files are properly formatted")
+		assert.NotContains(t, out, "---")
 	})
 }

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -33,7 +33,7 @@ func DisplayPath(path string, absolutePaths bool) string {
 }
 
 // FormatDiff colorizes unified diff output for terminal display.
-// Headers (--- and +++), hunk markers (@@), removed lines (-), and added lines (+) get colored.
+// Matches git's diff styling: --- red, +++ green, @@ cyan, - red, + green.
 // If color is false, returns the input unchanged.
 func FormatDiff(diff string, color bool) string {
 	if !color || diff == "" {
@@ -46,8 +46,10 @@ func FormatDiff(diff string, color bool) string {
 			result.WriteString("\n")
 		}
 		switch {
-		case strings.HasPrefix(line, "---") || strings.HasPrefix(line, "+++"):
-			result.WriteString(colorCyan + line + colorReset)
+		case strings.HasPrefix(line, "---"):
+			result.WriteString(colorRed + line + colorReset)
+		case strings.HasPrefix(line, "+++"):
+			result.WriteString(colorGreen + line + colorReset)
 		case strings.HasPrefix(line, "@@"):
 			result.WriteString(colorCyan + line + colorReset)
 		case strings.HasPrefix(line, "-"):

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -1245,14 +1245,13 @@ func TestFormatDiff(t *testing.T) {
 		diff := "--- a/file.tf\n+++ b/file.tf\n@@ -1,3 +1,3 @@\n-old line\n+new line\n context line"
 		result := FormatDiff(diff, true)
 
-		assert.Contains(t, result, "\033[36m--- a/file.tf\033[0m")
-		assert.Contains(t, result, "\033[36m+++ b/file.tf\033[0m")
-		assert.Contains(t, result, "\033[36m@@ -1,3 +1,3 @@\033[0m")
-		assert.Contains(t, result, "\033[31m-old line\033[0m")
-		assert.Contains(t, result, "\033[32m+new line\033[0m")
-		assert.Contains(t, result, "context line")
-		assert.NotContains(t, result, "\033[31mcontext")
-		assert.NotContains(t, result, "\033[32mcontext")
+		want := "\033[31m--- a/file.tf\033[0m\n" +
+			"\033[32m+++ b/file.tf\033[0m\n" +
+			"\033[36m@@ -1,3 +1,3 @@\033[0m\n" +
+			"\033[31m-old line\033[0m\n" +
+			"\033[32m+new line\033[0m\n" +
+			" context line"
+		assert.Equal(t, want, result)
 	})
 
 	t.Run("non-diff text unchanged", func(t *testing.T) {


### PR DESCRIPTION
## What and why

Make `terratidy fmt` behave correctly in structured output modes (`--format json|sarif|...`) and tighten the text-mode summary so it matches the cadence used by `lint`, `style`, and `policy`. Also aligns the unified-diff color palette with `git`'s defaults.

Three commits:

- **`chore: ignore .pre-specs/ working directory`** — Add `.pre-specs/` to `.gitignore` alongside `.plans/`, `.issues/`, `.history/`.
- **`feat(output): match git's diff palette in FormatDiff`** — `---` renders red, `+++` green (was both cyan). `@@` stays cyan, `-`/`+` line bodies unchanged. `FormatDiff` test tightened from per-line `Contains` to a single `Equal` against the full expected output (line-order corruption would otherwise slip through).
- **`feat(fmt): route structured output through formatter, polish text summaries`** — All human-readable prints (entry banner, `[+]`/`[!]` per-file lines, style sub-banners, totals, "Re-aligning..." line) gated behind `format == "" || format == "text"`; in structured modes findings flow through the shared `outputResults` helper. Exit code preserved via `NewFindingsError`. `---` separator added before fmt and style totals in text mode to match `lint`/`style`/`policy` cadence (omitted when there is no totals line to introduce). Post-style-fix re-run line renamed `"Re-formatting files..."` → `"Re-aligning attributes after style fixes..."` (and the wrapped error to match).

**Why:** `fmt --format json` previously emitted a mix of banner text and JSON to stdout, which is unparseable downstream and breaks CI consumers. Text mode also lacked the `---` summary separator the other engines use, making `fmt` output feel inconsistent. Git-default diff colors are what users already expect from `diff --color=always` in their terminals.

## How to test

```bash
mise run check                       # fmt, vet, lint, test all pass

# Structured mode produces valid JSON, no banner / per-file lines:
./bin/terratidy fmt --check --format json some-unformatted-dir | jq .

# Text mode: --- separator before totals, no separator when nothing to summarize:
./bin/terratidy fmt --all --check some-dir-with-style-issues
./bin/terratidy fmt some-already-formatted-dir

# Diff colors match git's palette:
./bin/terratidy fmt --check --diff --color=true some-unformatted-dir
```

New tests:

- `TestFmtStructuredOutput` (3 subtests): JSON output is valid; banners suppressed; `--all` + style issue surfaces `ExitFindings`; no-finding case is clean.
- `TestFmtTextSummarySeparator` (3 subtests): `---` present before `Formatted` and `Found` totals; absent when no totals exist.
- `TestFormatDiff/colorizes_diff_lines_correctly`: tightened to assert full expected output via `Equal`.

## Notes for reviewers

- No breaking changes to user-facing CLI flags or config. The renamed line `"Re-formatting files..."` → `"Re-aligning attributes after style fixes..."` is the only visible text change in text mode; structured mode never showed it.
- `cmd/terratidy/style.go`, `cmd/terratidy/lint.go`, and `cmd/terratidy/policy.go` already gated their banners on `useStructuredOutput` — verified, no change needed there.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test)
- [x] I have updated documentation as needed (none required — no flag/config/behavior changes user-visible beyond the renamed text line)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
