### PR TITLE
feat(fmt): indent --check --diff output and add unformatted-file summary

### DIFF
--- a/cmd/terratidy/fmt.go
+++ b/cmd/terratidy/fmt.go
@@ -117,6 +117,14 @@ Use --all to also apply style fixes (equivalent to running fmt + style --fix).`,
 				fmt.Println()
 				fmt.Println("---")
 				fmt.Printf("Formatted %s\n", formatFileCount(formatted))
+			} else if fmtCfg.Check && fmtCfg.Diff && needsFormatting > 0 {
+				// In --check --diff mode the per-file `[!]` lines are interleaved
+				// with diff output, so a closing total makes the result scannable.
+				// Bare --check (no diff) keeps the per-file lines as the sole signal
+				// by design — adding a total there is a separate UX decision.
+				fmt.Println()
+				fmt.Println("---")
+				fmt.Printf("Found %d file(s) that can be formatted with 'terratidy fmt'\n", needsFormatting)
 			}
 		} else {
 			// Structured output: count needs-formatting for exit code only.

--- a/cmd/terratidy/fmt.go
+++ b/cmd/terratidy/fmt.go
@@ -106,7 +106,7 @@ Use --all to also apply style fixes (equivalent to running fmt + style --fix).`,
 				// Print diff if diff mode is enabled (via CLI or config) and the finding carries one
 				if fmtCfg.Diff && finding.IsDiff {
 					fmt.Println()
-					fmt.Print(output.FormatDiff(finding.Message, color))
+					fmt.Print(output.FormatDiffIndented(finding.Message, color, "  "))
 				}
 			}
 
@@ -168,7 +168,9 @@ Use --all to also apply style fixes (equivalent to running fmt + style --fix).`,
 			for _, finding := range styleFindings {
 				// Skip diff-only findings (style.diff rule) for issue counting
 				if finding.Rule == "style.diff" {
-					// Print diff if present (text mode only; structured mode emits via formatter)
+					// Print diff if present (text mode only; structured mode emits via formatter).
+					// Flush-left (not indented) because there is no per-file status line under
+					// fmt --all for style findings to anchor under.
 					if !useStructuredOutput && fmtCfg.Diff && finding.IsDiff {
 						fmt.Println()
 						fmt.Print(output.FormatDiff(finding.Message, color))

--- a/cmd/terratidy/fmt_test.go
+++ b/cmd/terratidy/fmt_test.go
@@ -765,6 +765,79 @@ ami="ami-123"
 		assert.Contains(t, out, "All files are properly formatted")
 	})
 
+	t.Run("fmt --check --diff with unformatted files prints Found summary", func(t *testing.T) {
+		resetFmtFlags()
+		dir := t.TempDir()
+		unformatted := `resource "aws_instance" "bad"   {
+ami="ami-123"
+}`
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "bad.tf"), []byte(unformatted), 0o644))
+
+		fmtCheck = false
+		fmtDiff = false
+		fmtAll = false
+		changed = false
+		format = "text"
+		color = false
+
+		out := captureStdout(t, func() {
+			rootCmd.SetArgs([]string{"fmt", "--check", "--diff", dir})
+			_ = rootCmd.Execute()
+		})
+
+		assert.Contains(t, out, "---\nFound 1 file(s) that can be formatted with 'terratidy fmt'\n",
+			"expected --- separator and singular file summary in check+diff mode")
+	})
+
+	t.Run("fmt --check (no diff) does NOT print Found summary", func(t *testing.T) {
+		resetFmtFlags()
+		dir := t.TempDir()
+		unformatted := `resource "aws_instance" "bad"   {
+ami="ami-123"
+}`
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "bad.tf"), []byte(unformatted), 0o644))
+
+		fmtCheck = false
+		fmtDiff = false
+		fmtAll = false
+		changed = false
+		format = "text"
+		color = false
+
+		out := captureStdout(t, func() {
+			rootCmd.SetArgs([]string{"fmt", "--check", dir})
+			_ = rootCmd.Execute()
+		})
+
+		assert.NotContains(t, out, "Found ",
+			"Found summary is scoped to --check --diff; bare --check keeps the per-file lines as the sole signal")
+	})
+
+	t.Run("fmt --check --diff with multiple files uses plural file(s) marker", func(t *testing.T) {
+		resetFmtFlags()
+		dir := t.TempDir()
+		unformatted := `resource "aws_instance" "bad"   {
+ami="ami-123"
+}`
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "a.tf"), []byte(unformatted), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "b.tf"), []byte(unformatted), 0o644))
+
+		fmtCheck = false
+		fmtDiff = false
+		fmtAll = false
+		changed = false
+		format = "text"
+		color = false
+
+		out := captureStdout(t, func() {
+			rootCmd.SetArgs([]string{"fmt", "--check", "--diff", dir})
+			_ = rootCmd.Execute()
+		})
+
+		assert.Contains(t, out, "Found 2 file(s) that can be formatted with 'terratidy fmt'\n",
+			"expected aggregate count for both unformatted files")
+	})
+
 	t.Run("fmt --all --check with style issues prints --- before Found totals", func(t *testing.T) {
 		resetFmtFlags()
 		dir := t.TempDir()

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -34,10 +34,42 @@ func DisplayPath(path string, absolutePaths bool) string {
 
 // FormatDiff colorizes unified diff output for terminal display.
 // Matches git's diff styling: --- red, +++ green, @@ cyan, - red, + green.
-// If color is false, returns the input unchanged.
+// Always returns the diff with exactly one trailing newline (or "" for empty input)
+// so callers can `fmt.Print` it without padding or stripping blank lines.
+// If color is false, the diff content is unchanged apart from the trailing-newline guard.
 func FormatDiff(diff string, color bool) string {
-	if !color || diff == "" {
+	if diff == "" {
 		return diff
+	}
+	if !color {
+		return ensureTrailingNewline(diff)
+	}
+	// strings.Split on "a\nb\n" yields ["a","b",""], so the loop naturally emits
+	// one extra "\n" at the tail. ensureTrailingNewline collapses it — do not
+	// remove that call without also restructuring this loop.
+	var result strings.Builder
+	lines := strings.Split(diff, "\n")
+	for i, line := range lines {
+		if i > 0 {
+			result.WriteString("\n")
+		}
+		result.WriteString(colorizeDiffLine(line, color))
+	}
+	return ensureTrailingNewline(result.String())
+}
+
+// FormatDiffIndented colorizes a unified diff and prefixes every non-empty
+// line with indent. Use it when the diff is printed under a status line that
+// already carries leading indent (e.g., fmt's "  [+] file.tf: formatted").
+// Empty lines are left flush-left so the output has no trailing whitespace.
+// Pass indent="" to fall back to FormatDiff's flush-left behavior.
+// Always returns exactly one trailing newline (or "" for empty input).
+func FormatDiffIndented(diff string, color bool, indent string) string {
+	if diff == "" {
+		return diff
+	}
+	if indent == "" {
+		return FormatDiff(diff, color)
 	}
 	var result strings.Builder
 	lines := strings.Split(diff, "\n")
@@ -45,22 +77,42 @@ func FormatDiff(diff string, color bool) string {
 		if i > 0 {
 			result.WriteString("\n")
 		}
-		switch {
-		case strings.HasPrefix(line, "---"):
-			result.WriteString(colorRed + line + colorReset)
-		case strings.HasPrefix(line, "+++"):
-			result.WriteString(colorGreen + line + colorReset)
-		case strings.HasPrefix(line, "@@"):
-			result.WriteString(colorCyan + line + colorReset)
-		case strings.HasPrefix(line, "-"):
-			result.WriteString(colorRed + line + colorReset)
-		case strings.HasPrefix(line, "+"):
-			result.WriteString(colorGreen + line + colorReset)
-		default:
-			result.WriteString(line)
+		if line != "" {
+			result.WriteString(indent)
 		}
+		result.WriteString(colorizeDiffLine(line, color))
 	}
-	return result.String()
+	return ensureTrailingNewline(result.String())
+}
+
+// ensureTrailingNewline guarantees the string ends with exactly one "\n".
+// Trims any trailing newlines (collapsing blank lines after the final hunk)
+// then appends a single "\n". Must not be called on an empty string (would
+// return "\n" instead of ""); callers must guard with the `== ""` fast-path.
+func ensureTrailingNewline(s string) string {
+	return strings.TrimRight(s, "\n") + "\n"
+}
+
+// colorizeDiffLine applies git-style ANSI coloring to a single unified diff
+// line. Returns the line unchanged when color is false.
+func colorizeDiffLine(line string, color bool) string {
+	if !color {
+		return line
+	}
+	switch {
+	case strings.HasPrefix(line, "---"):
+		return colorRed + line + colorReset
+	case strings.HasPrefix(line, "+++"):
+		return colorGreen + line + colorReset
+	case strings.HasPrefix(line, "@@"):
+		return colorCyan + line + colorReset
+	case strings.HasPrefix(line, "-"):
+		return colorRed + line + colorReset
+	case strings.HasPrefix(line, "+"):
+		return colorGreen + line + colorReset
+	default:
+		return line
+	}
 }
 
 // ANSI color codes

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -1235,10 +1235,10 @@ func TestFormatDiff(t *testing.T) {
 		assert.Equal(t, "", result)
 	})
 
-	t.Run("color false returns unchanged", func(t *testing.T) {
+	t.Run("color false preserves content and ensures single trailing newline", func(t *testing.T) {
 		diff := "--- a/file.tf\n+++ b/file.tf\n@@ -1,3 +1,3 @@\n-old\n+new\n context"
 		result := FormatDiff(diff, false)
-		assert.Equal(t, diff, result)
+		assert.Equal(t, diff+"\n", result)
 	})
 
 	t.Run("colorizes diff lines correctly", func(t *testing.T) {
@@ -1250,13 +1250,99 @@ func TestFormatDiff(t *testing.T) {
 			"\033[36m@@ -1,3 +1,3 @@\033[0m\n" +
 			"\033[31m-old line\033[0m\n" +
 			"\033[32m+new line\033[0m\n" +
-			" context line"
+			" context line\n"
 		assert.Equal(t, want, result)
 	})
 
-	t.Run("non-diff text unchanged", func(t *testing.T) {
+	t.Run("non-diff text unchanged apart from trailing newline", func(t *testing.T) {
 		text := "just some text\nwith multiple lines"
 		result := FormatDiff(text, true)
-		assert.Equal(t, text, result)
+		assert.Equal(t, text+"\n", result)
+	})
+
+	t.Run("trailing newline guard normalizes input variants", func(t *testing.T) {
+		// difflib normally emits one trailing "\n"; verify we keep it.
+		withNewline := "--- a\n+++ b\n@@\n-x\n+y\n"
+		assert.Equal(t, withNewline, FormatDiff(withNewline, false))
+
+		// Multiple trailing newlines (extra blank line after final hunk) collapse to one.
+		withExtraBlank := "--- a\n+++ b\n@@\n-x\n+y\n\n"
+		assert.Equal(t, "--- a\n+++ b\n@@\n-x\n+y\n", FormatDiff(withExtraBlank, false))
+
+		// Missing trailing newline gets one appended.
+		noNewline := "--- a\n+++ b\n@@\n-x\n+y"
+		assert.Equal(t, noNewline+"\n", FormatDiff(noNewline, false))
+
+		// Color path applies the same guarantee.
+		colored := FormatDiff(withExtraBlank, true)
+		assert.True(t, strings.HasSuffix(colored, "\033[0m\n"))
+		assert.False(t, strings.HasSuffix(colored, "\n\n"))
+	})
+}
+
+func TestFormatDiffIndented(t *testing.T) {
+	t.Run("empty diff returns empty", func(t *testing.T) {
+		result := FormatDiffIndented("", true, "  ")
+		assert.Equal(t, "", result)
+	})
+
+	t.Run("empty indent leaves output flush-left", func(t *testing.T) {
+		diff := "--- a/file.tf\n+++ b/file.tf\n@@ -1 +1 @@\n-old\n+new"
+
+		// No color: each line passes through unchanged; trailing newline appended by guard.
+		assert.Equal(t, diff+"\n", FormatDiffIndented(diff, false, ""))
+
+		// With color: each line is colorized but unindented (no two-space prefix).
+		want := "\033[31m--- a/file.tf\033[0m\n" +
+			"\033[32m+++ b/file.tf\033[0m\n" +
+			"\033[36m@@ -1 +1 @@\033[0m\n" +
+			"\033[31m-old\033[0m\n" +
+			"\033[32m+new\033[0m\n"
+		assert.Equal(t, want, FormatDiffIndented(diff, true, ""))
+	})
+
+	t.Run("prefixes every non-empty line with indent (no color)", func(t *testing.T) {
+		diff := "--- a/file.tf\n+++ b/file.tf\n@@ -1,3 +1,3 @@\n-old line\n+new line\n context line"
+		result := FormatDiffIndented(diff, false, "  ")
+
+		want := "  --- a/file.tf\n" +
+			"  +++ b/file.tf\n" +
+			"  @@ -1,3 +1,3 @@\n" +
+			"  -old line\n" +
+			"  +new line\n" +
+			"   context line\n"
+		assert.Equal(t, want, result)
+	})
+
+	t.Run("indent precedes color codes", func(t *testing.T) {
+		diff := "--- a/file.tf\n+new"
+		result := FormatDiffIndented(diff, true, "  ")
+
+		want := "  \033[31m--- a/file.tf\033[0m\n" +
+			"  \033[32m+new\033[0m\n"
+		assert.Equal(t, want, result)
+	})
+
+	t.Run("empty lines are not indented (no trailing whitespace)", func(t *testing.T) {
+		diff := "--- a/file.tf\n\n+++ b/file.tf"
+		result := FormatDiffIndented(diff, false, "  ")
+
+		want := "  --- a/file.tf\n\n  +++ b/file.tf\n"
+		assert.Equal(t, want, result)
+	})
+
+	t.Run("trailing newline guard collapses blank lines after final hunk", func(t *testing.T) {
+		// Extra blank line at end (e.g., a producer that double-terminates) collapses.
+		withExtraBlank := "--- a\n+++ b\n@@\n-x\n+y\n\n"
+		want := "  --- a\n  +++ b\n  @@\n  -x\n  +y\n"
+		assert.Equal(t, want, FormatDiffIndented(withExtraBlank, false, "  "))
+
+		// Already correctly terminated input is unchanged content-wise.
+		clean := "--- a\n+++ b\n@@\n-x\n+y\n"
+		assert.Equal(t, want, FormatDiffIndented(clean, false, "  "))
+
+		// Missing trailing newline gets one appended.
+		noNewline := "--- a\n+++ b\n@@\n-x\n+y"
+		assert.Equal(t, want, FormatDiffIndented(noNewline, false, "  "))
 	})
 }


### PR DESCRIPTION
## What and why

Two CLI polish items for `fmt` output, both visible only in text mode.

**1. `FormatDiffIndented` + trailing-newline guarantee** ([4306acc](../../commit/4306acc))

New helper renders a unified diff with each non-empty line prefixed by a caller-supplied indent — used to align diff bodies under the per-file `[!]` status line emitted by `fmt --check --diff`. Both `FormatDiff` and `FormatDiffIndented` now route through `ensureTrailingNewline`, so call sites can `fmt.Print` the result without padding or stripping blank lines. Empty diff lines stay flush-left (no trailing whitespace). `fmt --all`'s style-diff site stays flush-left because there is no per-file anchor; the asymmetry is commented inline.

**2. `Found N file(s) ...` summary in `--check --diff`** ([1bc04dc](../../commit/1bc04dc))

`fmt --check --diff` previously ended with no totals line — per-file `[!]` markers were interleaved with diff hunks, making the result hard to count by eye. New summary mirrors the existing `Found N style issue(s) that can be fixed with fmt --all` cadence (action hint included). Bare `--check` keeps the per-file lines as the sole signal by design; the gating is locked by a test and commented in the code.

**Why:** field testing on a large real-world HCL codebase showed `fmt --check --diff` producing a dense scroll of diffs with no anchor under each status line and no closing count. The indent + summary together make the output scannable.

## How to test

```bash
mise run check   # fmt + vet + lint + tests (all green locally)

# Visual smoke (no color):
mkdir -p /tmp/fmt-demo && cd /tmp/fmt-demo
cat > a.tf <<'EOF'
resource "aws_instance" "bad"   {
ami="ami-123"
}
EOF
cp a.tf b.tf

terratidy fmt --check --diff --color=false /tmp/fmt-demo
# Expect: two indented diff blocks under `[!]` lines, then:
#
# ---
# Found 2 file(s) that can be formatted with 'terratidy fmt'

terratidy fmt --check --color=false /tmp/fmt-demo
# Expect: same per-file `[!]` lines, NO `Found ...` total (bare --check gating).
```

## Notes for reviewers

- The summary wording mirrors the existing `Found N style issue(s) that can be fixed with fmt --all` action-hint cadence rather than a bare "N files need formatting" phrase — UX consistency between the two summaries.
- `ensureTrailingNewline` must not be called on `""` (would return `"\n"`). Both public `FormatDiff*` functions guard with a `== ""` fast-path; the contract is documented in the helper's comment.
- A pre-existing visual collision between the `---` summary separator and unified-diff `---` headers was raised during review and logged as tech debt rather than fixed in this PR — it spans 8 call sites across `cmd/terratidy/` and warrants a separate sweep.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
