### PR TITLE
fix(cli): print error and exit 3 on missing target file

### DIFF
--- a/cmd/terratidy/check_test.go
+++ b/cmd/terratidy/check_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"errors"
+	"path/filepath"
 	"testing"
 
 	"github.com/santosr2/TerraTidy/pkg/sdk"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCheckCmd(t *testing.T) {
@@ -50,6 +53,32 @@ func TestCheckCmd(t *testing.T) {
 		assert.NotNil(t, flag)
 		assert.Equal(t, "false", flag.DefValue)
 	})
+}
+
+// TestCheckCmd_MissingTargetFile verifies that passing a non-existent target path
+// returns an ExitError with code 3 and a "file not found" message. Previously the
+// CLI exited silently with code 3 and no message.
+func TestCheckCmd_MissingTargetFile(t *testing.T) {
+	resetCheckGlobals(t)
+
+	// Construct a path inside a real temp dir that is guaranteed not to exist —
+	// avoids races with anything that might write to /tmp.
+	missing := filepath.Join(t.TempDir(), "does-not-exist.tf")
+
+	format = "text"
+	cfgFile = ""
+	changed = false
+
+	rootCmd.SetArgs([]string{"check", missing})
+	err := rootCmd.Execute()
+
+	require.Error(t, err, "check command should fail for missing target file")
+
+	var exitErr *sdk.ExitError
+	require.True(t, errors.As(err, &exitErr), "expected ExitError, got: %v", err)
+	assert.Equal(t, sdk.ExitInternal, exitErr.Code, "exit code should be 3 for missing target file")
+	assert.Contains(t, err.Error(), "file not found", "error message should say 'file not found'")
+	assert.Contains(t, err.Error(), missing, "error message should include the missing path")
 }
 
 func TestCountBySeverity(t *testing.T) {

--- a/cmd/terratidy/helpers.go
+++ b/cmd/terratidy/helpers.go
@@ -2,7 +2,9 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -333,6 +335,9 @@ func newFileCollector(recursive bool) *fileCollector {
 func (c *fileCollector) collectPath(path string) error {
 	info, err := os.Stat(path)
 	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("file not found: %s", path)
+		}
 		return fmt.Errorf("stat %s: %w", path, err)
 	}
 

--- a/cmd/terratidy/main.go
+++ b/cmd/terratidy/main.go
@@ -21,6 +21,11 @@ func main() {
 	if err := Execute(); err != nil {
 		var exitErr *sdk.ExitError
 		if errors.As(err, &exitErr) {
+			// NewFindingsError sets Err=nil (output is the formatter's job); only
+			// config/internal exits carry a non-nil Err that the user needs to see.
+			if exitErr.Err != nil {
+				_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", exitErr.Err)
+			}
 			os.Exit(exitErr.Code)
 		}
 		_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)


### PR DESCRIPTION
## What and why

Passing a non-existent path to any TerraTidy command (`check`, `fmt`, `fix`, `style`, `lint`, `policy`) used to exit silently with code 3 and zero stderr output, leaving the user to guess what went wrong.

```
$ terratidy check /tmp/typo.tf
$ echo $?
3
```

Now:

```
$ terratidy check /tmp/typo.tf
Error: finding files: file not found: /tmp/typo.tf
$ echo $?
3
```

**Why:** Two stacked causes hid the message. `main.go` unwrapped `*sdk.ExitError` and called `os.Exit(exitErr.Code)` without ever printing the wrapped `Err`; combined with `SilenceErrors: true` on the root cobra command, nothing reached stderr. And the underlying `os.Stat` error read "no such file or directory" rather than the user-friendly "file not found" — so even when we did print it, the wording was system jargon.

## How to test

```bash
mise run build

# Bug reproduction (before this PR exited silently):
./bin/terratidy check /tmp/does-not-exist.tf
# → stderr: Error: finding files: file not found: /tmp/does-not-exist.tf
# → exit: 3

# Same behavior across all commands:
./bin/terratidy fmt /tmp/does-not-exist.tf
./bin/terratidy lint /tmp/does-not-exist.tf
./bin/terratidy fix /tmp/does-not-exist.tf

# Happy path unchanged:
./bin/terratidy check .
# → normal output, exit 0 or 1 by findings

# Automated coverage:
mise run check  # full gate
go test ./cmd/terratidy/ -run TestCheckCmd_MissingTargetFile -v
```

## Notes for reviewers

- **Two-file fix.** `main.go` prints to stderr when `exitErr.Err != nil`. `helpers.go` (`(*fileCollector).collectPath`) detects `errors.Is(err, fs.ErrNotExist)` and returns a clean "file not found" message. Other stat errors (permission denied, etc.) keep the existing `stat %s: %w` wrapping so callers can still `errors.Is(err, fs.ErrPermission)` against them.
- **Why no `Code != ExitFindings` guard in main.go?** `NewFindingsError()` constructs the ExitError with `Err: nil`, so the nil check alone is sufficient — findings keep flowing through their formatter and never double-print. A reviewer flagged this during local validation and the guard was removed.
- **Why not refactor `main()` to accept an `io.Writer` for testing?** The test (`TestCheckCmd_MissingTargetFile`) verifies the cobra-level error chain via `rootCmd.Execute()` — that's the contract surface. The stderr print itself is a one-line `Fprintf` whose only logic is "if non-nil, print". Refactoring `main()` to take an `io.Writer` for testing that single print felt like disproportionate scope.
- **Why does the message still contain `finding files:`?** The wrap site `fmt.Errorf("finding files: %w", err)` exists in all six commands. One reviewer argued the prefix usefully distinguishes file-discovery failures from engine failures; another argued it reads as internal plumbing. Conflict deferred — the literal task ("print 'file not found' and exit 3") is satisfied either way. Logged as a follow-up in the local tech-debt log.
- **Tested commands:** all six commands that share `getTargetFilesWithExcludes` (`check`, `fmt`, `fix`, `style`, `lint`, `policy`) inherit the fix. Manually smoke-tested `check`, `fmt`, and `lint`.
- **No docs changes.** This restores documented behavior (errors should be visible); no documented contract changes.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
