### PR TITLE
ci: float Go version to 1.26.x with check-latest

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -34,7 +34,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.x'
+          check-latest: true
 
       - name: Run fuzz tests
         id: fuzz

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -57,7 +57,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.x'
+          check-latest: true
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.x'
+          check-latest: true
           cache: false  # Disable cache to prevent cache poisoning on tag-triggered releases
 
       - name: Install cosign

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -83,6 +83,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.x'
+          check-latest: true
 
       - name: Install go-licenses
         run: go install github.com/google/go-licenses/v2@v2.0.1
@@ -120,6 +121,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.x'
+          check-latest: true
           cache: false
 
       - name: Install osv-scanner
@@ -160,6 +162,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.x'
+          check-latest: true
 
       - name: Install gorelease
         if: steps.filter.outputs.sdk == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,7 +77,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.x'
+          check-latest: true
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
@@ -96,7 +97,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.x'
+          check-latest: true
 
       - name: Build
         run: go build -v ./...


### PR DESCRIPTION
## What and why

Replace the pinned `go-version: '1.26.3'` in `fuzz`, `quality`, `release`, and `test` workflows with the floating `1.26.x`, and add `check-latest: true` to those plus the three `security.yml` setup-go steps that already used `1.26.x`.

**Why:** Workflows were locked to 1.26.3, so picking up Go patch releases required a manual bump in every file. Floating to `1.26.x` with `check-latest: true` lets setup-go pull the newest 1.26 patch automatically and keeps the version policy consistent across all workflows.

## How to test

- CI runs on this PR (test, quality, security, fuzz, release dry-run) should all resolve to the latest 1.26.x.
- Workflow lint and zizmor passed locally via pre-commit hooks.

## Notes for reviewers

- `test.yml`'s matrix (`['1.25.x', '1.26.x']`) was already floating and is unchanged.
- `vscode.yml` uses `go-version: "1.26.x"` without `check-latest` and is left as-is to keep this PR scoped to the workflows that were actually pinned to a patch.
- No code or docs change; no version bump.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works <!-- N/A: CI config only -->
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test) <!-- pre-commit (yamllint, actionlint, zizmor) green; no Go changes -->
- [ ] I have updated documentation as needed <!-- N/A: no user-facing change -->
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
