### PR TITLE
ci(vscode): push dependabot lockfile update to PR branch

### DIFF
--- a/.github/workflows/vscode.yml
+++ b/.github/workflows/vscode.yml
@@ -76,6 +76,8 @@ jobs:
       - name: Commit updated lockfile (Dependabot only)
         if: github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]' && matrix.os == 'ubuntu-latest'
         working-directory: vscode
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           if git diff --quiet bun.lock; then
             echo "No lockfile changes to commit"
@@ -84,7 +86,8 @@ jobs:
             git config user.email "49699333+dependabot[bot]@users.noreply.github.com"
             git add bun.lock
             git commit -m "chore(vscode): update bun.lock for Dependabot PR"
-            git push
+            # actions/checkout leaves a detached HEAD, so push explicitly to the PR branch
+            git push origin "HEAD:${HEAD_REF}"
           fi
 
       - name: Lint


### PR DESCRIPTION
## What and why

The VSCode extension's `build-and-test` job has a "Commit updated lockfile (Dependabot only)" step that regenerates `bun.lock` and pushes it back to the PR branch. It ran a bare `git push`, but `actions/checkout` leaves the workspace in a detached HEAD, so the push failed with `fatal: You are not currently on a branch` (exit 128). Because this step runs before lint/compile/test, the whole job aborted, leaving every dependabot PR touching `vscode/` red without ever validating the bump.

This pushes explicitly to the PR head ref (`git push origin "HEAD:${HEAD_REF}"`), passing `github.head_ref` through an env var to avoid run-step expression injection.

**Why:** Dependabot can't update the binary `bun.lock`, so CI regenerates and commits it. With the push broken, no dependabot VSCode dependency PR could ever go green (e.g. #178, the vscode-languageclient bump).

## How to test

- actionlint and zizmor pass locally on the modified workflow.
- End-to-end validation: once merged to `main`, rebase a dependabot VSCode PR (e.g. `@dependabot rebase` on #178). The lockfile-commit step should now push successfully instead of failing at `git push`, allowing lint/compile/test to run.

## Notes for reviewers

- Minimal, surgical change: only the push target and an env var. Step ordering is unchanged.
- `HEAD_REF` is passed via `env:` rather than inlined into the script to satisfy zizmor's template-injection checks.
- The job already grants `contents: write` and persists credentials for dependabot, so the push is authorized.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works <!-- N/A: CI workflow change; validated with actionlint + zizmor -->
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test) <!-- workflow-only change; actionlint + zizmor clean -->
- [ ] I have updated documentation as needed <!-- N/A: no user-facing behavior change -->
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
