### PR TITLE
ci(vscode): check out branch head for dependabot lockfile commit

### DIFF
--- a/.github/workflows/vscode.yml
+++ b/.github/workflows/vscode.yml
@@ -40,6 +40,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          # For Dependabot PRs, check out the branch head instead of the PR merge ref
+          # so the regenerated bun.lock commits onto the branch tip and pushes back as a
+          # fast-forward. Empty string falls back to the default (merge ref) for everyone else.
+          ref: ${{ github.actor == 'dependabot[bot]' && github.head_ref || '' }}
           # Persist credentials for Dependabot lockfile commits
           persist-credentials: ${{ github.actor == 'dependabot[bot]' }}
 
@@ -86,7 +90,7 @@ jobs:
             git config user.email "49699333+dependabot[bot]@users.noreply.github.com"
             git add bun.lock
             git commit -m "chore(vscode): update bun.lock for Dependabot PR"
-            # actions/checkout leaves a detached HEAD, so push explicitly to the PR branch
+            # Push explicitly to the PR head ref (checkout above put us on the branch tip)
             git push origin "HEAD:${HEAD_REF}"
           fi
 


### PR DESCRIPTION
## What and why

PR #181 fixed the bare `git push` in the dependabot lockfile-commit step, but it surfaced the next layer of the bug: the push is now rejected as a **non-fast-forward** (`! [rejected] ... (fetch first)`).

On `pull_request` events, `actions/checkout` checks out the *PR merge ref* (`refs/pull/N/merge`, a detached merge of the branch into `main`), not the branch tip. Committing the regenerated `bun.lock` on top of that and pushing it to the real branch isn't a fast-forward, so GitHub rejects it.

This checks out the **branch head** (`github.head_ref`) for dependabot PRs, so the lockfile commit lands directly on the branch tip and pushes cleanly. The empty-string fallback keeps the default merge-ref checkout for all other actors/events.

**Why:** Without this, dependabot VSCode dependency PRs still can't go green — the lockfile push fails before lint/compile/test run.

## How to test

- actionlint and zizmor pass locally on the modified workflow.
- End-to-end: after merging to `main`, re-run a dependabot VSCode PR (e.g. `@dependabot rebase` on #178). The lockfile-commit step should now push successfully, and CI should advance to the compile step. (For #178 specifically, compile then fails on a separate `vscode-languageclient` v10 type change — that is a distinct issue, not this workflow fix.)

## Notes for reviewers

- Minimal change: one `ref:` line on the checkout plus a comment refresh on the push step.
- `ref: ${{ github.actor == 'dependabot[bot]' && github.head_ref || '' }}` — empty string means "use the default ref", so non-dependabot runs are unchanged and still test the merge result.
- Builds on #181; only the dependabot path is affected.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works <!-- N/A: CI workflow change; validated with actionlint + zizmor -->
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test) <!-- workflow-only change; actionlint + zizmor clean -->
- [ ] I have updated documentation as needed <!-- N/A: no user-facing behavior change -->
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
