### PR TITLE
fix(style): relocate tags above lifecycle when authored below

### DIFF
--- a/internal/engines/style/rules/ordering.go
+++ b/internal/engines/style/rules/ordering.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/santosr2/TerraTidy/internal/cst"
 	"github.com/santosr2/TerraTidy/pkg/sdk"
 )
 
@@ -439,44 +440,69 @@ func countItemsAfterTags(body *hclsyntax.Body, tagsLine int) int {
 }
 
 // Fix moves tags/labels (and tags_all) to land just before any lifecycle block,
-// or at the end of the block body if no lifecycle is present. Other attributes and
-// nested blocks stay in their source positions; only the tags region (including its
-// leading comment) moves. Operates bottom-up so line ranges remain valid across rewrites.
+// or at the last position in the block body when no lifecycle is present. Other
+// attributes and nested blocks stay in their source positions; only the tags
+// region (including its leading comment) moves. Direction-agnostic: tags below
+// lifecycle is relocated above lifecycle in the same call.
 func (r *TagsAtEndRule) Fix(ctx *sdk.Context, _ *hcl.File) (*sdk.FixResult, error) {
 	originalContent, err := os.ReadFile(ctx.File)
 	if err != nil {
 		return nil, err
 	}
 
-	syntaxFile, diags := hclsyntax.ParseConfig(originalContent, ctx.File, hcl.InitialPos)
-	if diags.HasErrors() {
-		return nil, diags
-	}
-	hclFile, ok := syntaxFile.Body.(*hclsyntax.Body)
-	if !ok {
-		return nil, nil
+	file, parseErr := cst.Build(originalContent, ctx.File, cst.DefaultTopLevelPolicy())
+	if parseErr != nil {
+		// No-op on parse error: do not mutate a partial tree, and do not
+		// surface the diagnostic as a Fix error (Check already produced it).
+		return nil, nil //nolint:nilerr // parse error already surfaced by Check; Fix preserves no-op contract on partial trees
 	}
 
-	var targets []*hclsyntax.Block
-	for _, block := range hclFile.Blocks {
+	for _, item := range file.Body.Items {
+		block, ok := item.(*cst.Block)
+		if !ok {
+			continue
+		}
 		if block.Type != "resource" && block.Type != "module" {
 			continue
 		}
-		if findTagsAttribute(block.Body.Attributes) == nil {
-			continue
+		moveTagsAttrToEnd(block.Body)
+	}
+
+	return WholeFileEdit(originalContent, file.Bytes()), nil
+}
+
+// moveTagsAttrToEnd relocates the tags-family attribute in body (priority:
+// tags > labels > tags_all) to immediately before any lifecycle nested block,
+// or to the last position in the body when no lifecycle is present. A no-op
+// when no tags-family attribute exists, when the attribute is already in the
+// canonical position, or when body is nil.
+func moveTagsAttrToEnd(body *cst.Body) {
+	if body == nil {
+		return
+	}
+	tagsAttr := findTagsCSTAttribute(body)
+	if tagsAttr == nil {
+		return
+	}
+	if lifecycle := body.FindBlock("lifecycle"); lifecycle != nil {
+		body.MoveBefore(tagsAttr, lifecycle)
+		return
+	}
+	body.Move(tagsAttr, len(body.Items)-1)
+}
+
+// findTagsCSTAttribute returns the tags-family attribute in body with a
+// deterministic priority. `tags` wins over `labels`, which wins over
+// `tags_all`. `tags_all` is provider-managed (derived from inherited tags)
+// and is included only as a fallback for resources that use it directly;
+// otherwise the rule prefers the author-controlled `tags`/`labels`.
+func findTagsCSTAttribute(body *cst.Body) *cst.Attribute {
+	for _, name := range []string{"tags", "labels", "tags_all"} {
+		if attr := body.FindAttribute(name); attr != nil {
+			return attr
 		}
-		targets = append(targets, block)
 	}
-	sort.Slice(targets, func(i, j int) bool {
-		return targets[i].Range().Start.Line > targets[j].Range().Start.Line
-	})
-
-	content := originalContent
-	for _, block := range targets {
-		content = moveTagsBeforeLifecycle(content, block)
-	}
-
-	return WholeFileEdit(originalContent, FormatAndCleanBlankLines(content)), nil
+	return nil
 }
 
 // moveAttrBeforeLifecycle relocates the given attribute (with its leading comment)
@@ -485,8 +511,7 @@ func (r *TagsAtEndRule) Fix(ctx *sdk.Context, _ *hcl.File) (*sdk.FixResult, erro
 // source positions. The move is a no-op when the attribute is already adjacent to
 // the insertion point. Returns content unchanged when attr is nil.
 //
-// Shared by both `style.tags-at-end` (via moveTagsBeforeLifecycle wrapper) and
-// `style.depends-on-order` (via moveDependsOnBeforeLifecycle wrapper).
+// Used directly by `style.depends-on-order`.
 func moveAttrBeforeLifecycle(content []byte, block *hclsyntax.Block, attr *hclsyntax.Attribute) []byte {
 	if attr == nil {
 		return content
@@ -583,12 +608,6 @@ func moveAttrBeforeLifecycle(content []byte, block *hclsyntax.Block, attr *hclsy
 	}
 
 	return []byte(strings.Join(result, "\n") + "\n")
-}
-
-// moveTagsBeforeLifecycle is a thin wrapper around moveAttrBeforeLifecycle targeting
-// the tags-family attribute selected by findTagsAttribute (tags > labels > tags_all).
-func moveTagsBeforeLifecycle(content []byte, block *hclsyntax.Block) []byte {
-	return moveAttrBeforeLifecycle(content, block, findTagsAttribute(block.Body.Attributes))
 }
 
 // DependsOnOrderRule ensures depends_on is at the end of blocks.

--- a/internal/engines/style/rules/ordering_test.go
+++ b/internal/engines/style/rules/ordering_test.go
@@ -909,6 +909,83 @@ func TestTagsAtEnd_BelowLifecycle_WithLeadingComment_RelocatesAbove(t *testing.T
 	assert.Contains(t, out, "# remove * from the beginning before importing into Vanta")
 }
 
+// TestTagsAtEnd_Labels_BelowLifecycle_RelocatesAbove covers the `labels` arm
+// of findTagsCSTAttribute's priority list. The pre-existing tags-vs-tags_all
+// priority test stops at the first iteration; a labels-only fixture is the
+// only way the second iteration's return path is reached.
+func TestTagsAtEnd_Labels_BelowLifecycle_RelocatesAbove(t *testing.T) {
+	rule := &TagsAtEndRule{}
+	content := `module "cluster" {
+  source = "./cluster"
+  lifecycle {
+    create_before_destroy = true
+  }
+  labels = { env = "prod" }
+}
+`
+	out := runRuleFix(t, rule, content)
+
+	assertOrderedSubstrings(t, out, []string{
+		"\n  source",
+		"\n  labels",
+		"\n  lifecycle {",
+		"create_before_destroy = true",
+	})
+}
+
+// TestTagsAtEnd_Fix_SkipsBlocksWithoutTags pins the no-op path in
+// moveTagsAttrToEnd / findTagsCSTAttribute for resource and module blocks
+// that have no tags-family attribute. Fix iterates every resource/module
+// block (Check's filter is not reused), so this path is real, not defensive.
+// The second resource carries tags below lifecycle so Fix produces a real
+// edit; the first must round-trip byte-for-byte through the no-op path.
+func TestTagsAtEnd_Fix_SkipsBlocksWithoutTags(t *testing.T) {
+	rule := &TagsAtEndRule{}
+	content := `resource "aws_vpc" "no_tags" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_acm_certificate" "with_tags" {
+  domain_name = "example.com"
+  lifecycle {
+    create_before_destroy = true
+  }
+  tags = { Name = "cert" }
+}
+`
+	out := runRuleFix(t, rule, content)
+
+	// The first block is untouched: no tags to move, no shape change.
+	assert.Contains(t, out, `resource "aws_vpc" "no_tags" {
+  cidr_block = "10.0.0.0/16"
+}`)
+
+	// The second block has tags relocated above lifecycle.
+	assertOrderedSubstrings(t, out, []string{
+		"aws_acm_certificate",
+		"\n  domain_name",
+		"\n  tags",
+		"\n  lifecycle {",
+	})
+}
+
+// TestTagsAtEnd_Fix_ParseErrorReturnsNoOp pins the contract documented on
+// Fix: when cst.Build fails to parse, Fix returns (nil, nil) rather than
+// surfacing the diagnostic. Check has already reported the parse error, and
+// mutating a partial tree would be unsafe.
+func TestTagsAtEnd_Fix_ParseErrorReturnsNoOp(t *testing.T) {
+	rule := &TagsAtEndRule{}
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "broken.tf")
+	// Unclosed block: hclsyntax cannot produce a usable tree.
+	require.NoError(t, os.WriteFile(tmpFile, []byte(`resource "aws_x" "y" {
+`), 0o644))
+
+	result, err := rule.Fix(&sdk.Context{File: tmpFile}, nil)
+	require.NoError(t, err)
+	assert.Nil(t, result)
+}
+
 func TestDependsOnOrderRule(t *testing.T) {
 	rule := &DependsOnOrderRule{}
 

--- a/internal/engines/style/rules/ordering_test.go
+++ b/internal/engines/style/rules/ordering_test.go
@@ -742,11 +742,11 @@ func TestTagsAtEndRule(t *testing.T) {
 		require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
 
 		ctx := &sdk.Context{File: tmpFile}
-		first, err := rule.Fix(ctx, &hcl.File{Body: mustParseBody(t, content)})
+		first, err := rule.Fix(ctx, nil)
 		require.NoError(t, err)
 		require.NoError(t, os.WriteFile(tmpFile, first.Edits[0].Replacement, 0o644))
 
-		second, err := rule.Fix(ctx, &hcl.File{Body: mustParseBody(t, string(first.Edits[0].Replacement))})
+		second, err := rule.Fix(ctx, nil)
 		require.NoError(t, err)
 		assert.Nil(t, second, "Fix(Fix(x)) must equal Fix(x)")
 	})
@@ -830,12 +830,83 @@ func TestTagsAtEndRule(t *testing.T) {
 	})
 }
 
-// mustParseBody parses HCL content and returns its body, failing the test on error.
-func mustParseBody(t *testing.T, content string) hcl.Body {
-	t.Helper()
-	file, diags := hclsyntax.ParseConfig([]byte(content), "test.tf", hcl.InitialPos)
-	require.False(t, diags.HasErrors())
-	return file.Body
+// TestTagsAtEnd_BelowLifecycle_RelocatesAbove pins the 2026-05-20 bug fix.
+//
+// Pre-CST, the line-based Fix short-circuited as "already adjacent" when tags
+// was authored below lifecycle because its line-counting check only handled
+// one direction (attrEnd >= insertBefore). The CST Move is direction-agnostic,
+// so the same call that handles "tags above misplaced" also handles "tags
+// below misplaced". The fixture mirrors a terraform/modules/acm/main.tf shape
+// that triggered the original no-op.
+func TestTagsAtEnd_BelowLifecycle_RelocatesAbove(t *testing.T) {
+	rule := &TagsAtEndRule{}
+	content := `resource "aws_acm_certificate" "x" {
+  domain_name       = "example.com"
+  validation_method = "DNS"
+  lifecycle {
+    create_before_destroy = true
+  }
+  tags = { Name = "cert" }
+}
+`
+	out := runRuleFix(t, rule, content)
+
+	// tags now sits immediately above lifecycle.
+	assertOrderedSubstrings(t, out, []string{
+		"\n  domain_name",
+		"\n  validation_method",
+		"\n  tags",
+		"\n  lifecycle {",
+		"create_before_destroy = true",
+	})
+
+	// Exact-alignment assertions are deliberate: unchanged items must
+	// round-trip byte-for-byte through the CST, never re-aligned. Do not
+	// relax these to alignment-agnostic anchors — that would weaken
+	// coverage of the CST's unchanged-region preservation invariant.
+	assert.Contains(t, out, `domain_name       = "example.com"`)
+	assert.Contains(t, out, `validation_method = "DNS"`)
+	assert.Contains(t, out, `tags = { Name = "cert" }`)
+	assert.Contains(t, out, "create_before_destroy = true")
+
+	// No comment loss: the input has none, and none must appear.
+	assert.NotContains(t, out, "#")
+	assert.NotContains(t, out, "//")
+}
+
+// TestTagsAtEnd_BelowLifecycle_WithLeadingComment_RelocatesAbove verifies
+// that a leading comment on tags travels with the attribute when the
+// direction-agnostic Move relocates tags from below lifecycle to above it.
+// The pre-CST line-based path would have re-discovered the comment via line
+// scanning; the CST path carries it as part of the attribute's raw bytes.
+// The "free carriage" claim of the migration needs explicit coverage for
+// the upward-move direction.
+func TestTagsAtEnd_BelowLifecycle_WithLeadingComment_RelocatesAbove(t *testing.T) {
+	rule := &TagsAtEndRule{}
+	content := `resource "aws_acm_certificate" "x" {
+  domain_name       = "example.com"
+  validation_method = "DNS"
+  lifecycle {
+    create_before_destroy = true
+  }
+  # remove * from the beginning before importing into Vanta
+  tags = { Name = "cert" }
+}
+`
+	out := runRuleFix(t, rule, content)
+
+	// Both the comment and tags now sit immediately above lifecycle, in
+	// their original relative order.
+	assertOrderedSubstrings(t, out, []string{
+		"\n  domain_name",
+		"\n  validation_method",
+		"\n  # remove * from the beginning before importing into Vanta",
+		"\n  tags",
+		"\n  lifecycle {",
+	})
+
+	// Comment content preserved verbatim.
+	assert.Contains(t, out, "# remove * from the beginning before importing into Vanta")
 }
 
 func TestDependsOnOrderRule(t *testing.T) {


### PR DESCRIPTION
## What and why

Relocate the `tags` attribute (and `labels` / `tags_all`) to land above `lifecycle` when authored below it. Previously this case was a silent no-op.

**Why:** The pre-CST `style.tags-at-end` Fix used a line-based "already adjacent" check that only ran in one direction (`attrEnd >= insertBefore`), so tags authored below `lifecycle` short-circuited and never moved. Migrating to `cst.Body.MoveBefore` makes the fix direction-agnostic in a single call, and the CST carries leading comments as part of the attribute's raw bytes so the bespoke comment-scanning logic falls away.

## How to test

```bash
mise run test ./internal/engines/style/rules/...
```

Or reproduce the original bug on a fixture:

```hcl
resource "aws_acm_certificate" "x" {
  domain_name       = "example.com"
  validation_method = "DNS"
  lifecycle {
    create_before_destroy = true
  }
  tags = { Name = "cert" }
}
```

Running `terratidy style --fix` now moves `tags` above `lifecycle`; on `main` it silently leaves the block alone.

## Notes for reviewers

- `moveTagsBeforeLifecycle` and its line-based body-rewriting helper are gone from the `tags-at-end` path; `depends-on-order` still uses `moveAttrBeforeLifecycle` and is unchanged.
- Two new tests pin the regression: one for bare `tags` below `lifecycle`, one for a leading comment travelling with the attribute. They assert exact alignment of unchanged lines to keep coverage on the CST's byte-for-byte preservation invariant.
- On HCL parse error, `Fix` now returns `(nil, nil)` instead of surfacing the diagnostic — `Check` has already reported it, and mutating a partial tree would be unsafe.
- No doc update needed: `docs/site/docs/rules/style-rules.md` already describes the bidirectional behavior (*"Both paths share the same fix — moving `tags` to land just before `lifecycle`"*). The docs were aspirationally correct; this PR makes the implementation match.
- A follow-up commit adds three tests covering the no-op paths (`tagsAttr == nil`, `labels`-priority iteration, parse-error contract) to satisfy the codecov patch target.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
