### PR TITLE
fix(style): preserve leading comment on lifecycle reorder

### DIFF
--- a/internal/engines/style/rules/ordering.go
+++ b/internal/engines/style/rules/ordering.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
-	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/santosr2/TerraTidy/internal/cst"
 	"github.com/santosr2/TerraTidy/pkg/sdk"
 )
@@ -214,116 +213,50 @@ func (r *LifecycleAtEndRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Find
 	return findings, nil
 }
 
-// fixLifecyclePositionContent moves the lifecycle block to the end of the
-// matching host block (resource, data, module, or check). Works entirely in
-// memory - takes content as input.
-func (r *LifecycleAtEndRule) fixLifecyclePositionContent(content []byte, filePath, blockType string, blockLabels []string) ([]byte, error) {
-	writeFile, diags := hclwrite.ParseConfig(content, filePath, hcl.InitialPos)
-	if diags.HasErrors() {
-		return nil, diags
-	}
-
-	// Find the host block
-	for _, block := range writeFile.Body().Blocks() {
-		if block.Type() != blockType {
-			continue
-		}
-		if !MatchBlockLabels(block.Labels(), blockLabels) {
-			continue
-		}
-
-		// Find and remove lifecycle block
-		var lifecycleBlock *hclwrite.Block
-		for _, nested := range block.Body().Blocks() {
-			if nested.Type() == "lifecycle" {
-				lifecycleBlock = nested
-				break
-			}
-		}
-
-		if lifecycleBlock == nil {
-			continue
-		}
-
-		// Get lifecycle block tokens (preserving content)
-		lifecycleTokens := lifecycleBlock.BuildTokens(nil)
-
-		// Remove lifecycle block
-		block.Body().RemoveBlock(lifecycleBlock)
-
-		// Re-add lifecycle block at the end
-		block.Body().AppendUnstructuredTokens(lifecycleTokens)
-
-		break
-	}
-
-	return FormatAndCleanBlankLines(writeFile.Bytes()), nil
-}
-
-// Fix moves lifecycle blocks to the end of resource, data, module, and check blocks.
-// Works entirely in memory - does NOT write to disk.
-func (r *LifecycleAtEndRule) Fix(ctx *sdk.Context, file *hcl.File) (*sdk.FixResult, error) {
-	if ctx == nil || file == nil {
-		return nil, nil
-	}
-
+// Fix moves the lifecycle nested block to the last position inside each
+// host block (resource/data/module/check) that contains one. Other body
+// items stay at their source positions; only the lifecycle region moves.
+// No-op when no host block contains a lifecycle or when lifecycle is
+// already in the canonical position.
+func (r *LifecycleAtEndRule) Fix(ctx *sdk.Context, _ *hcl.File) (*sdk.FixResult, error) {
 	originalContent, err := os.ReadFile(ctx.File)
 	if err != nil {
 		return nil, err
 	}
 
-	hclFile, ok := file.Body.(*hclsyntax.Body)
-	if !ok {
-		return nil, nil
+	file, parseErr := cst.Build(originalContent, ctx.File, cst.DefaultTopLevelPolicy())
+	if parseErr != nil {
+		// No-op on parse error: do not mutate a partial tree, and do not
+		// surface the diagnostic as a Fix error (Check already produced it).
+		return nil, nil //nolint:nilerr // parse error already surfaced by Check; Fix preserves no-op contract on partial trees
 	}
 
-	// Collect (block type, labels) pairs before modifying content
-	type blockRef struct {
-		blockType string
-		labels    []string
-	}
-	var blocksToFix []blockRef
-	for _, block := range hclFile.Blocks {
+	for _, item := range file.Body.Items {
+		block, ok := item.(*cst.Block)
+		if !ok {
+			continue
+		}
 		if !isLifecycleHostBlock(block.Type) {
 			continue
 		}
-
-		// Check if this block has a lifecycle that needs moving
-		var lifecycleBlock *hclsyntax.Block
-		var lastLine int
-
-		for _, nested := range block.Body.Blocks {
-			if nested.Range().End.Line > lastLine {
-				lastLine = nested.Range().End.Line
-			}
-			if nested.Type == "lifecycle" {
-				lifecycleBlock = nested
-			}
-		}
-
-		for _, attr := range block.Body.Attributes {
-			if attr.Range().End.Line > lastLine {
-				lastLine = attr.Range().End.Line
-			}
-		}
-
-		if lifecycleBlock != nil && lifecycleBlock.Range().End.Line < lastLine {
-			blocksToFix = append(blocksToFix, blockRef{blockType: block.Type, labels: block.Labels})
-		}
+		moveLifecycleToEnd(block.Body)
 	}
 
-	content := originalContent
+	return WholeFileEdit(originalContent, file.Bytes()), nil
+}
 
-	// Process each block (re-parse after each modification)
-	for _, ref := range blocksToFix {
-		content, err = r.fixLifecyclePositionContent(content, ctx.File, ref.blockType, ref.labels)
-		if err != nil {
-			return nil, err
-		}
-		// Do NOT write to disk - work entirely in memory
+// moveLifecycleToEnd relocates the lifecycle nested block in body to the
+// last position in body.Items. A no-op when body is nil, no lifecycle
+// block exists, or lifecycle is already at the last index.
+func moveLifecycleToEnd(body *cst.Body) {
+	if body == nil {
+		return
 	}
-
-	return WholeFileEdit(originalContent, content), nil
+	lifecycle := body.FindBlock("lifecycle")
+	if lifecycle == nil {
+		return
+	}
+	body.Move(lifecycle, len(body.Items)-1)
 }
 
 // TagsAtEndRule ensures tags/labels are at the end of resource blocks (before lifecycle).

--- a/internal/engines/style/rules/ordering_test.go
+++ b/internal/engines/style/rules/ordering_test.go
@@ -533,6 +533,65 @@ func TestLifecycleAtEnd_AlreadyAtEnd_FixIsNoOp(t *testing.T) {
 	assert.Nil(t, result, "Fix should return nil when lifecycle is already at end")
 }
 
+// TestLifecycleAtEnd_HostBlockWithoutLifecycle_FixIsNoOp covers the branch
+// where the walker visits a lifecycle-host block (resource/data/module/check)
+// that doesn't contain a lifecycle nested block. moveLifecycleToEnd must
+// early-return on the lifecycle == nil path and Fix must surface a nil
+// FixResult (no bytes changed) via WholeFileEdit's nil-on-no-change contract.
+func TestLifecycleAtEnd_HostBlockWithoutLifecycle_FixIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	rule := &LifecycleAtEndRule{}
+	content := `resource "aws_instance" "example" {
+  ami           = "ami-123"
+  instance_type = "t2.micro"
+}
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "test.tf")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+
+	file, diags := hclsyntax.ParseConfig([]byte(content), tmpFile, hcl.InitialPos)
+	require.False(t, diags.HasErrors())
+
+	ctx := &sdk.Context{File: tmpFile}
+	result, err := rule.Fix(ctx, &hcl.File{Body: file.Body})
+	require.NoError(t, err)
+	assert.Nil(t, result, "Fix should return nil when no host block contains lifecycle")
+}
+
+// TestLifecycleAtEnd_ParseError_FixIsNoOp covers the cst.Build parse-error
+// branch. On a partial tree, Fix must return (nil, nil) — Check already
+// surfaces the diagnostic and Fix preserves its no-op contract.
+func TestLifecycleAtEnd_ParseError_FixIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	rule := &LifecycleAtEndRule{}
+	// Unterminated block: cst.Build returns a parse error.
+	content := "resource \"aws_instance\" \"x\" {\n  ami = \"ami-123\"\n"
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "broken.tf")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+
+	ctx := &sdk.Context{File: tmpFile}
+	result, err := rule.Fix(ctx, nil)
+	require.NoError(t, err, "Fix must swallow parse errors; Check surfaces them")
+	assert.Nil(t, result)
+}
+
+// TestLifecycleAtEnd_ReadError_FixSurfacesError covers the os.ReadFile error
+// branch — Fix must propagate I/O errors to the caller rather than returning
+// a partial result.
+func TestLifecycleAtEnd_ReadError_FixSurfacesError(t *testing.T) {
+	t.Parallel()
+
+	rule := &LifecycleAtEndRule{}
+	ctx := &sdk.Context{File: filepath.Join(t.TempDir(), "does-not-exist.tf")}
+	result, err := rule.Fix(ctx, nil)
+	require.Error(t, err)
+	assert.Nil(t, result)
+}
+
 func TestTagsAtEndRule(t *testing.T) {
 	rule := &TagsAtEndRule{}
 

--- a/internal/engines/style/rules/ordering_test.go
+++ b/internal/engines/style/rules/ordering_test.go
@@ -308,12 +308,6 @@ func TestLifecycleAtEndRule(t *testing.T) {
 		})
 	}
 
-	t.Run("Fix returns nil for nil inputs", func(t *testing.T) {
-		result, err := rule.Fix(nil, nil)
-		assert.NoError(t, err)
-		assert.Nil(t, result)
-	})
-
 	t.Run("Fix moves lifecycle to end", func(t *testing.T) {
 		content := `resource "aws_instance" "example" {
   lifecycle {
@@ -458,6 +452,85 @@ data "aws_ami" "example" {
 		secondLifecycleIdx := strings.Index(resultStr[firstLifecycleIdx+len("lifecycle"):], "lifecycle") + firstLifecycleIdx + len("lifecycle")
 		assert.Greater(t, secondLifecycleIdx, mostRecentIdx, "data lifecycle should be after most_recent")
 	})
+}
+
+// TestLifecycleAtEnd_WithLeadingComment_TravelsWithBlock pins the carriage
+// invariant that motivated the CST migration: a leading comment above a
+// lifecycle block must travel with the block when Move relocates it to the
+// end. The mechanism (Block.headerRaw encodes leading-comment bytes; Move
+// preserves item raw) is shared with TagsAtEndRule and TerraformBlockFirstRule
+// — each has a sibling test pinning the same invariant.
+func TestLifecycleAtEnd_WithLeadingComment_TravelsWithBlock(t *testing.T) {
+	t.Parallel()
+
+	rule := &LifecycleAtEndRule{}
+	content := `resource "aws_instance" "example" {
+  # Prevent accidental destruction
+  lifecycle {
+    prevent_destroy = true
+  }
+  ami           = "ami-123"
+  instance_type = "t2.micro"
+}
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "test.tf")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+
+	file, diags := hclsyntax.ParseConfig([]byte(content), tmpFile, hcl.InitialPos)
+	require.False(t, diags.HasErrors())
+
+	ctx := &sdk.Context{File: tmpFile}
+	result, err := rule.Fix(ctx, &hcl.File{Body: file.Body})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Edits, 1)
+
+	out := string(result.Edits[0].Replacement)
+
+	// Ordering: ami < instance_type < comment < lifecycle.
+	amiIdx := indexOf(out, "ami")
+	instanceTypeIdx := indexOf(out, "instance_type")
+	commentIdx := indexOf(out, "# Prevent accidental destruction")
+	lifecycleIdx := indexOf(out, "lifecycle")
+
+	assert.Greater(t, instanceTypeIdx, amiIdx, "attributes preserve source order")
+	assert.Greater(t, commentIdx, instanceTypeIdx, "leading comment moves with the block")
+	assert.Greater(t, lifecycleIdx, commentIdx, "lifecycle remains immediately after its leading comment")
+
+	// Comment must NOT also appear in its original position (no duplication).
+	assert.Equal(t, 1, strings.Count(out, "# Prevent accidental destruction"),
+		"comment should appear exactly once after the move")
+}
+
+// TestLifecycleAtEnd_AlreadyAtEnd_FixIsNoOp pins the WholeFileEdit nil-on-
+// no-change contract for the canonical input — sibling to the idempotence
+// tests on TagsAtEndRule (lines 720, 748) and TerraformBlockFirstRule (line
+// 2350). Guards against a future caller assuming Fix always returns a non-nil
+// FixResult on success.
+func TestLifecycleAtEnd_AlreadyAtEnd_FixIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	rule := &LifecycleAtEndRule{}
+	content := `resource "aws_instance" "example" {
+  ami           = "ami-123"
+  instance_type = "t2.micro"
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "test.tf")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+
+	file, diags := hclsyntax.ParseConfig([]byte(content), tmpFile, hcl.InitialPos)
+	require.False(t, diags.HasErrors())
+
+	ctx := &sdk.Context{File: tmpFile}
+	result, err := rule.Fix(ctx, &hcl.File{Body: file.Body})
+	require.NoError(t, err)
+	assert.Nil(t, result, "Fix should return nil when lifecycle is already at end")
 }
 
 func TestTagsAtEndRule(t *testing.T) {


### PR DESCRIPTION
## What and why

Migrate `LifecycleAtEndRule.Fix` from the `hclwrite` parse-mutate-reparse loop to the project's CST via `cst.Build` + `Body.Move`. The `hclwrite` path dropped a comment authored immediately above the `lifecycle` block when relocating the block to the end of its host (resource/data/module/check), because `RemoveBlock` + `AppendUnstructuredTokens` didn't carry the leading-comment tokens. Under CST, leading-comment bytes are encoded in `Block.headerRaw` and `Body.Move` preserves item raw, so the comment travels with the block.

**Why:** Completes the comment-carriage parity across the ordering rules — the same invariant was already pinned for tags (#185) and the terraform block (#186). The `hclwrite` re-parse loop also did N parses for N host blocks; the CST path does one parse per file.

## How to test

```bash
mise run check
```

Or just the focused tests:

```bash
go test ./internal/engines/style/rules/ -run 'TestLifecycleAtEnd'
```

Two new pinning tests cover the invariants:

- `TestLifecycleAtEnd_WithLeadingComment_TravelsWithBlock` — leading comment moves with the block, appears exactly once after the move.
- `TestLifecycleAtEnd_AlreadyAtEnd_FixIsNoOp` — `Fix` returns `nil` when lifecycle is already in canonical position (`WholeFileEdit` nil-on-no-change contract).

## Notes for reviewers

- Dropped the stale "Fix returns nil for nil inputs" test: `Fix` no longer accepts a nil `ctx` (it dereferences `ctx.File` directly to read content), matching the CST signature used by sibling rules.
- `Fix` now ignores the `*hcl.File` parameter (renamed to `_`) because the CST path re-parses from disk via `cst.Build`. The signature is preserved to satisfy `sdk.Fixer`.
- Parse errors in `cst.Build` are intentionally swallowed (`return nil, nil`): `Check` already surfaces the diagnostic, and `Fix` preserves the no-op contract on partial trees. The `//nolint:nilerr` is annotated with the reason.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
