### PR TITLE
refactor(style): rewrite provider-block-order Fix on top of CST

### DIFF
--- a/internal/engines/style/rules/ordering.go
+++ b/internal/engines/style/rules/ordering.go
@@ -1330,23 +1330,99 @@ func (r *ProviderBlockOrderRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.
 	return findings, nil
 }
 
-// Fix reorders provider blocks to the canonical position via line-range reorder.
-// The canonical priority order is (terraform, provider, variable, locals, data,
-// resource, module, output); the helper materializes that order across all
-// top-level blocks in the file, not just the provider blocks this rule flags.
+// Fix reorders top-level blocks into the canonical priority order
+// (terraform, provider, variable, locals, data, resource, module, output)
+// via cst.Body.Move / MoveAfter. Blocks of unknown type stay in source
+// order after the canonical prefix. The canonical prefix anchors at the
+// first existing Block in body.Items, so file-header StandaloneComments
+// (separated from the first block by a blank line) stay in their slot.
+//
+// Under DefaultTopLevelPolicy (StrictAdjacency=true), comments with a blank
+// line above them are StandaloneComments and do NOT travel with the block
+// they were adjacent to in source — unlike the line-based predecessor's
+// collectAdjacentLeadingComments, which carried them. This is the same
+// mechanism that fixes the floating section-header bug in
+// style.terraform-block-first.
 func (r *ProviderBlockOrderRule) Fix(ctx *sdk.Context, _ *hcl.File) (*sdk.FixResult, error) {
-	if ctx == nil {
+	originalContent, err := os.ReadFile(ctx.File)
+	if err != nil {
+		return nil, err
+	}
+
+	file, parseErr := cst.Build(originalContent, ctx.File, cst.DefaultTopLevelPolicy())
+	if parseErr != nil {
+		return nil, nil //nolint:nilerr // parse error already surfaced by Check; Fix preserves no-op contract on partial trees
+	}
+
+	firstBlockIdx := -1
+	for i, item := range file.Body.Items {
+		if _, ok := item.(*cst.Block); ok {
+			firstBlockIdx = i
+			break
+		}
+	}
+	if firstBlockIdx < 0 {
 		return nil, nil
 	}
-	content, err := os.ReadFile(ctx.File)
-	if err != nil {
-		return nil, err
+
+	if topLevelBlocksAreCanonical(file.Body) {
+		return nil, nil
 	}
-	newContent, err := ReorderTopLevelBlocksByLineRange(content)
-	if err != nil {
-		return nil, err
+
+	var anchor cst.BodyItem
+	place := func(item cst.BodyItem) {
+		if anchor == nil {
+			file.Body.Move(item, firstBlockIdx)
+		} else {
+			file.Body.MoveAfter(item, anchor)
+		}
+		anchor = item
 	}
-	return WholeFileEdit(content, newContent), nil
+	for _, blockType := range topLevelCanonicalOrder {
+		for _, blk := range file.Body.FindBlocksByType(blockType) {
+			place(blk)
+		}
+	}
+
+	return WholeFileEdit(originalContent, file.Bytes()), nil
+}
+
+// topLevelBlocksAreCanonical reports whether the *cst.Block items in body
+// already appear in topLevelCanonicalOrder, with any unknown-type blocks
+// trailing the canonical prefix. BlankLine and StandaloneComment items are
+// ignored. When true, the Fix would only redistribute BlankLines (since
+// blocks are already canonically ordered) — return early to keep the input
+// byte-identical.
+func topLevelBlocksAreCanonical(body *cst.Body) bool {
+	priority := make(map[string]int, len(topLevelCanonicalOrder))
+	for i, t := range topLevelCanonicalOrder {
+		priority[t] = i + 1
+	}
+	prevPrio := 0
+	sawUnknown := false
+	for _, item := range body.Items {
+		blk, ok := item.(*cst.Block)
+		if !ok {
+			continue
+		}
+		p, known := priority[blk.Type]
+		if !known {
+			sawUnknown = true
+			continue
+		}
+		if sawUnknown || p < prevPrio {
+			return false
+		}
+		prevPrio = p
+	}
+	return true
+}
+
+// topLevelCanonicalOrder is the canonical Fix-time order for top-level blocks,
+// matching the pre-CST topLevelBlockPriority map in helpers.go. Blocks of
+// unknown type retain their relative source order after the canonical prefix.
+var topLevelCanonicalOrder = []string{
+	"terraform", "provider", "variable", "locals", "data", "resource", "module", "output",
 }
 
 // AttributeGroupSpacingRule ensures blank lines between attribute groups in blocks.

--- a/internal/engines/style/rules/ordering_test.go
+++ b/internal/engines/style/rules/ordering_test.go
@@ -3086,12 +3086,6 @@ provider "aws" {
 		})
 	}
 
-	t.Run("Fix returns nil when ctx is nil", func(t *testing.T) {
-		result, err := rule.Fix(nil, nil)
-		assert.NoError(t, err)
-		assert.Nil(t, result)
-	})
-
 	t.Run("Fix reorders terraform, resource, provider to terraform, provider, resource", func(t *testing.T) {
 		input := `terraform {
   required_version = ">= 1.0"
@@ -3114,6 +3108,12 @@ provider "aws" {
 	})
 
 	t.Run("Fix preserves all comments through reorder", func(t *testing.T) {
+		// Comments with a blank line above are StandaloneComments under
+		// DefaultTopLevelPolicy (StrictAdjacency=true) and stay in their slot
+		// as blocks reshuffle past them — the same mechanism that fixes the
+		// floating section-header bug in style.terraform-block-first. All four
+		// comments are still present in the output; only their position
+		// relative to blocks changes from the pre-CST line-based reorder.
 		//nolint:dupword // HCL content intentionally contains repeated block-type identifiers
 		input := `# File-level note at top.
 
@@ -3139,12 +3139,12 @@ terraform {
 		assert.Contains(t, out, "# About terraform")
 		assertOrderedSubstrings(t, out, []string{
 			"# File-level note at top.",
-			"# About terraform",
-			"terraform {",
-			"# About the provider",
-			`provider "aws"`,
 			"# About the resource",
+			"terraform {",
+			`provider "aws"`,
 			`resource "aws_instance"`,
+			"# About the provider",
+			"# About terraform",
 		})
 	})
 
@@ -3204,6 +3204,69 @@ resource "aws_instance" "x" {
 		require.NoError(t, err)
 		assert.Nil(t, second, "Fix(Fix(content)) must equal Fix(content)")
 	})
+
+	t.Run("Fix is a no-op when blocks are already in canonical order", func(t *testing.T) {
+		input := `terraform {
+  required_version = ">= 1.0"
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_instance" "x" {
+  ami = "ami-123"
+}
+`
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "test.tf")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(input), 0o644))
+
+		result, err := rule.Fix(&sdk.Context{File: tmpFile}, nil)
+		require.NoError(t, err)
+		assert.Nil(t, result, "Fix on already-canonical input must return nil via WholeFileEdit no-change guard")
+	})
+
+	t.Run("Fix surfaces read error for missing file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		ctx := &sdk.Context{File: filepath.Join(tmpDir, "does-not-exist.tf")}
+		result, err := rule.Fix(ctx, nil)
+		require.Error(t, err)
+		assert.Nil(t, result)
+	})
+}
+
+// TestProviderBlockOrder_NoBlocksInFile_FixIsNoOp pins the firstBlockIdx < 0
+// guard: a comment-only file with no *cst.Block items must return (nil, nil)
+// without mutation.
+func TestProviderBlockOrder_NoBlocksInFile_FixIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	rule := &ProviderBlockOrderRule{}
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "comments-only.tf")
+	require.NoError(t, os.WriteFile(tmpFile, []byte("# just a comment\n"), 0o644))
+
+	result, err := rule.Fix(&sdk.Context{File: tmpFile}, nil)
+	require.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+// TestProviderBlockOrder_ParseError_FixIsNoOp covers the cst.Build parse-error
+// branch. On a partial tree, Fix must return (nil, nil).
+func TestProviderBlockOrder_ParseError_FixIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	rule := &ProviderBlockOrderRule{}
+	content := "provider \"aws\" {\n  region = \"us-east-1\"\n"
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "broken.tf")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+
+	ctx := &sdk.Context{File: tmpFile}
+	result, err := rule.Fix(ctx, nil)
+	require.NoError(t, err)
+	assert.Nil(t, result)
 }
 
 // runRuleFix writes content to a tmp file, runs rule.Fix, and returns the output as a string.


### PR DESCRIPTION
## What and why

Rewrites `ProviderBlockOrderRule.Fix` on top of the CST (`cst.Build` + `Body.Move` / `Body.MoveAfter`) instead of the previous `ReorderTopLevelBlocksByLineRange` line-range helper. The canonical priority order (terraform, provider, variable, locals, data, resource, module, output) is materialized by anchoring at the first existing `*cst.Block` in `body.Items` and moving each block in priority order behind that anchor; unknown block types retain their relative source order trailing the canonical prefix.

Adds `topLevelBlocksAreCanonical`, a guard that returns nil when blocks are already canonically ordered so the Fix doesn't redistribute `BlankLine` items into a spurious diff. Adds explicit coverage for the no-blocks and parse-error branches.

**Why:** This continues the engine-wide migration of style Fixes off line-range reasoning and onto CST primitives — the same mechanism used by the depends-on-order, lifecycle-comment, and ordering Fixes. The behavioral consequence is that under `DefaultTopLevelPolicy` (`StrictAdjacency=true`), comments with a blank line above them are `StandaloneComment` items and stay in their slot as blocks reshuffle past them, instead of being carried along by the old `collectAdjacentLeadingComments` helper. That is the same mechanism that fixes the floating section-header bug in `style.terraform-block-first`.

## How to test

```bash
mise run check
go test ./internal/engines/style/rules/... -run ProviderBlockOrder
```

New cases pin the guards and behavior added in this rewrite:

- `Fix is a no-op when blocks are already in canonical order` — `topLevelBlocksAreCanonical` returns true, so `WholeFileEdit`'s no-change guard returns nil.
- `Fix surfaces read error for missing file` — `os.ReadFile` error propagates.
- `TestProviderBlockOrder_NoBlocksInFile_FixIsNoOp` — `firstBlockIdx < 0` branch on a comment-only file.
- `TestProviderBlockOrder_ParseError_FixIsNoOp` — `cst.Build` parse-error branch returns `(nil, nil)`.

The existing `Fix preserves all comments through reorder` case is updated to assert the new comment-positioning behavior: all four comments are still present, but standalone comments stay in their source slot rather than traveling with the block they were adjacent to.

## Notes for reviewers

- Behavior change is intentional and limited to standalone-comment positioning. Comments directly adjacent to a block (no blank line above) continue to travel with the block as part of its raw bytes — only standalone (blank-line-above) comments stay put.
- The `cst.Build` parse-error path returns `nil, nil` with a `nolint:nilerr`: Check already surfaces the diagnostic, and Fix preserves its no-op-on-partial-trees contract (matching the depends-on-order rewrite).
- The `if ctx == nil` guard from the old implementation is dropped — the runner always passes a non-nil `*sdk.Context`, and the obsolete `Fix returns nil when ctx is nil` test is removed accordingly.
- `ReorderTopLevelBlocksByLineRange` and `collectAdjacentLeadingComments` (in `helpers.go`) remain in place for now; they'll be removed when the last line-range Fix caller is migrated.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
