### PR TITLE
refactor(style): rewrite meta-arguments-order Fix on top of CST

### DIFF
--- a/internal/engines/style/rules/block_organization.go
+++ b/internal/engines/style/rules/block_organization.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/santosr2/TerraTidy/internal/cst"
 	"github.com/santosr2/TerraTidy/pkg/sdk"
 )
 
@@ -107,63 +108,75 @@ func (r *MetaArgumentsOrderRule) checkBlock(ctx *sdk.Context, block *hclsyntax.B
 	return findings
 }
 
-// Fix reorders meta-arguments in all blocks.
-func (r *MetaArgumentsOrderRule) Fix(ctx *sdk.Context, file *hcl.File) (*sdk.FixResult, error) {
-	// Short-circuit when nothing needs reordering. Without this guard,
-	// ReorderBlockAttrs below removes and re-adds attributes via
-	// SetAttributeRaw, which triggers hclwrite to re-align them — producing
-	// a byte-different output even when the source order is already
-	// canonical. Calling Check first matches LifecycleAttributeOrderRule's
-	// no-op contract and keeps the engine from writing spurious edits.
-	findings, err := r.Check(ctx, file)
+// metaArgsFirstNames is the canonical leading-meta-argument order: for_each
+// or count (mutually exclusive in Terraform) followed by provider. They share
+// the top of the block body in this sequence.
+var metaArgsFirstNames = []string{"for_each", "count", "provider"}
+
+// metaArgsLastNames is the canonical trailing-meta-argument order. depends_on
+// is the only trailing meta-arg today; the slice shape leaves room for future
+// trailing meta-args without restructuring the Fix.
+var metaArgsLastNames = []string{"depends_on"}
+
+// Fix reorders meta-arguments in resource, data, and module blocks. Leading
+// meta-args (for_each/count, provider) move to the start of the body in
+// canonical order; depends_on moves to the last body slot. Sibling rules
+// (depends-on-order, lifecycle-at-end, tags-at-end) refine the trailing
+// position when nested blocks like lifecycle are present.
+//
+// Already-canonical input round-trips byte-identically: each Move on an
+// attribute at its target index is a successful no-op (cst.Body.Move
+// returns early when src == newIndex), so file.Bytes() equals the source
+// and WholeFileEdit collapses the result to nil.
+func (r *MetaArgumentsOrderRule) Fix(ctx *sdk.Context, _ *hcl.File) (*sdk.FixResult, error) {
+	originalContent, err := os.ReadFile(ctx.File)
 	if err != nil {
 		return nil, err
 	}
-	if len(findings) == 0 {
-		return nil, nil
+
+	cstFile, parseErr := cst.Build(originalContent, ctx.File, cst.DefaultTopLevelPolicy())
+	if parseErr != nil {
+		// No-op on parse error: do not mutate a partial tree, and do not
+		// surface the diagnostic as a Fix error (Check already produced it).
+		return nil, nil //nolint:nilerr // parse error already surfaced by Check; Fix preserves no-op contract on partial trees
 	}
 
-	content, err := os.ReadFile(ctx.File)
-	if err != nil {
-		return nil, err
-	}
-
-	syntaxFile, ok := file.Body.(*hclsyntax.Body)
-	if !ok {
-		return nil, nil
-	}
-
-	writeFile, diags := hclwrite.ParseConfig(content, ctx.File, hcl.InitialPos)
-	if diags.HasErrors() {
-		return nil, diags
-	}
-
-	syntaxBlocks := make(map[string]*hclsyntax.Body)
-	for _, block := range syntaxFile.Blocks {
-		if block.Type == "resource" || block.Type == "data" || block.Type == "module" {
-			key := BlockKey(block.Type, block.Labels)
-			syntaxBlocks[key] = block.Body
-		}
-	}
-
-	for _, block := range writeFile.Body().Blocks() {
-		if block.Type() != "resource" && block.Type() != "data" && block.Type() != "module" {
-			continue
-		}
-
-		key := BlockKey(block.Type(), block.Labels())
-		syntaxBody, ok := syntaxBlocks[key]
+	for _, item := range cstFile.Body.Items {
+		block, ok := item.(*cst.Block)
 		if !ok {
 			continue
 		}
-
-		orderedNames := GetOrderedAttrNames(syntaxBody)
-		firstAttrs := []string{"for_each", "count", "provider"}
-		lastAttrs := []string{"depends_on"}
-		ReorderBlockAttrs(block.Body(), orderedNames, firstAttrs, lastAttrs)
+		if block.Type != "resource" && block.Type != "data" && block.Type != "module" {
+			continue
+		}
+		reorderMetaArgs(block.Body)
 	}
 
-	return WholeFileEdit(content, FormatAndCleanBlankLines(writeFile.Bytes())), nil
+	return WholeFileEdit(originalContent, cstFile.Bytes()), nil
+}
+
+// reorderMetaArgs positions leading meta-args at the start of body and
+// trailing meta-args at the end, both in canonical order. Move on an item
+// already at its target index is a successful no-op, so blocks that don't
+// need rearrangement round-trip byte-identically.
+func reorderMetaArgs(body *cst.Body) {
+	if body == nil {
+		return
+	}
+
+	anchorIdx := 0
+	for _, name := range metaArgsFirstNames {
+		if attr := body.FindAttribute(name); attr != nil {
+			body.Move(attr, anchorIdx)
+			anchorIdx++
+		}
+	}
+
+	for _, name := range metaArgsLastNames {
+		if attr := body.FindAttribute(name); attr != nil {
+			body.Move(attr, len(body.Items)-1)
+		}
+	}
 }
 
 // LifecycleAttributeOrderRule ensures lifecycle block attributes are ordered correctly.

--- a/internal/engines/style/rules/block_organization_golden_test.go
+++ b/internal/engines/style/rules/block_organization_golden_test.go
@@ -1,0 +1,114 @@
+package rules
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/santosr2/TerraTidy/pkg/sdk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Byte-exact goldens for MetaArgumentsOrderRule.Fix.
+//
+// The Fix walks the CST and relocates leading meta-args (for_each/count,
+// provider) to the start of each block body, then depends_on to the last
+// slot. Each item keeps its original source bytes, so column alignment
+// and intra-block blank lines round-trip verbatim — only the slice order
+// changes. Any future refactor of the Fix path can be evaluated against
+// these goldens with a byte-exact diff: whitespace-only divergence in
+// regenerated regions is an expected outcome of changing the structural
+// algorithm and may justify a golden update; a semantic divergence
+// (different attribute order, dropped comment, changed value, etc.)
+// indicates a correctness regression.
+//
+// Fixtures live alongside TestMetaArgumentsOrderRule in
+// block_organization_test.go (metaArgsReorderInput,
+// metaArgsProviderBeforeCountInput) so the semantic assertion and the
+// byte-exact snapshot share the same input — a fixture change cannot
+// silently desync the two.
+//
+// Capture / re-capture: UPDATE_GOLDEN=1 go test -run TestMetaArgumentsOrderRule_FixGoldens ./internal/engines/style/rules/
+func TestMetaArgumentsOrderRule_FixGoldens(t *testing.T) {
+	rule := &MetaArgumentsOrderRule{}
+
+	fixtures := []struct {
+		name   string
+		golden string
+		input  string
+	}{
+		{
+			name:   "reorder depends_on after for_each",
+			golden: "meta_arguments_order/reorder_depends_on_after_for_each",
+			input:  metaArgsReorderInput,
+		},
+		{
+			name:   "reorder count before provider",
+			golden: "meta_arguments_order/reorder_count_before_provider",
+			input:  metaArgsProviderBeforeCountInput,
+		},
+		{
+			// Pins the lifecycle-block interaction: depends_on goes to the
+			// last body slot, which is after the lifecycle nested block.
+			// Sibling rules own any further refinement of that position.
+			name:   "reorder depends_on after lifecycle",
+			golden: "meta_arguments_order/reorder_depends_on_after_lifecycle",
+			input:  metaArgsWithLifecycleInput,
+		},
+	}
+
+	for _, tc := range fixtures {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			tmpFile := filepath.Join(tmpDir, "test.tf")
+			require.NoError(t, os.WriteFile(tmpFile, []byte(tc.input), 0o644))
+
+			file, diags := hclsyntax.ParseConfig([]byte(tc.input), tmpFile, hcl.InitialPos)
+			require.False(t, diags.HasErrors(), "fixture failed to parse: %v", diags)
+
+			hclFile := &hcl.File{Body: file.Body}
+			ctx := &sdk.Context{File: tmpFile}
+
+			result, err := rule.Fix(ctx, hclFile)
+			require.NoError(t, err)
+			require.NotNil(t, result, "fixture must produce a fix; the no-op case belongs in the main test")
+			require.Len(t, result.Edits, 1)
+
+			assertRuleGolden(t, tc.golden, result.Edits[0].Replacement)
+		})
+	}
+}
+
+// assertRuleGolden compares actual bytes to testdata/goldens/<name>.golden.
+// Set UPDATE_GOLDEN=1 to write the golden instead of asserting.
+//
+// Line endings are normalized to \n on read so the comparison is stable on
+// Windows checkouts; writes preserve the bytes the rule produced.
+func assertRuleGolden(t *testing.T, name string, actual []byte) {
+	t.Helper()
+
+	path := filepath.Join("testdata", "goldens", name+".golden")
+
+	if os.Getenv("UPDATE_GOLDEN") == "1" {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755), "failed to create golden directory for %s", path)
+		require.NoError(t, os.WriteFile(path, actual, 0o644), "failed to write golden %s", path)
+		t.Logf("wrote golden %s (%d bytes)", path, len(actual))
+		return
+	}
+
+	expected, err := os.ReadFile(path)
+	require.NoError(t, err, "missing golden %s — re-run with UPDATE_GOLDEN=1 to create", path)
+
+	normalizedExpected := bytes.ReplaceAll(expected, []byte("\r\n"), []byte("\n"))
+	normalizedActual := bytes.ReplaceAll(actual, []byte("\r\n"), []byte("\n"))
+
+	assert.Equal(
+		t, string(normalizedExpected), string(normalizedActual),
+		"output diverged from golden %s — whitespace-only diffs in realigned attribute columns are acceptable with reviewer sign-off and an UPDATE_GOLDEN=1 refresh; any semantic diff (reordered attributes, dropped comments, changed values) indicates a correctness regression",
+		path,
+	)
+}

--- a/internal/engines/style/rules/block_organization_test.go
+++ b/internal/engines/style/rules/block_organization_test.go
@@ -12,6 +12,53 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// metaArgsReorderInput is the canonical "depends_on placed before for_each"
+// fixture used by both TestMetaArgumentsOrderRule's "Fix reorders
+// meta-arguments" subtest (semantic assertion) and
+// TestMetaArgumentsOrderRule_FixGoldens (byte-exact snapshot). Shared so a
+// fixture edit is forced to update the byte golden in lock-step rather than
+// silently decoupling the two checks.
+const metaArgsReorderInput = `resource "aws_instance" "web" {
+  depends_on = [aws_vpc.main]
+  for_each   = var.instances
+
+  ami           = "ami-123"
+  instance_type = "t2.micro"
+}
+`
+
+// metaArgsProviderBeforeCountInput pins the second "wrong order" pattern
+// asserted at Check level (provider placed before count). Used by
+// TestMetaArgumentsOrderRule_FixGoldens to capture a second column-alignment
+// shape independent from metaArgsReorderInput.
+const metaArgsProviderBeforeCountInput = `resource "aws_instance" "web" {
+  provider = aws.west
+  count    = 3
+
+  ami           = "ami-123"
+  instance_type = "t2.micro"
+}
+`
+
+// metaArgsWithLifecycleInput pins the "depends_on lands after the lifecycle
+// nested block" semantic. MetaArgumentsOrderRule moves depends_on to the
+// last body slot; with a lifecycle block at the end of body.Items, that
+// is index len-1, so depends_on lands AFTER lifecycle. Sibling rules
+// (depends-on-order) own further refinement of depends_on relative to
+// lifecycle if a deployment style requires it. Used by
+// TestMetaArgumentsOrderRule_FixGoldens.
+const metaArgsWithLifecycleInput = `resource "aws_instance" "web" {
+  depends_on = [aws_vpc.main]
+  for_each   = var.instances
+
+  ami = "ami-123"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+`
+
 func TestMetaArgumentsOrderRule(t *testing.T) {
 	rule := &MetaArgumentsOrderRule{}
 
@@ -134,13 +181,7 @@ func TestMetaArgumentsOrderRule(t *testing.T) {
 	t.Run("Fix reorders meta-arguments", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		tmpFile := filepath.Join(tmpDir, "test.tf")
-		content := `resource "aws_instance" "web" {
-  depends_on = [aws_vpc.main]
-  for_each   = var.instances
-
-  ami           = "ami-123"
-  instance_type = "t2.micro"
-}`
+		content := metaArgsReorderInput
 		err := os.WriteFile(tmpFile, []byte(content), 0o644)
 		require.NoError(t, err)
 
@@ -204,6 +245,25 @@ func TestMetaArgumentsOrderRule(t *testing.T) {
 		require.NoError(t, err)
 		assert.Nil(t, result, "already-canonical input must produce no edits")
 	})
+}
+
+// TestMetaArgumentsOrderRule_ParseError_FixIsNoOp covers the cst.Build
+// parse-error branch in MetaArgumentsOrderRule.Fix: on a partial tree, Fix
+// must return (nil, nil) so the diagnostic stays on Check and Fix does not
+// mutate a tree it cannot trust.
+func TestMetaArgumentsOrderRule_ParseError_FixIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	rule := &MetaArgumentsOrderRule{}
+	content := "resource \"aws_instance\" \"x\" {\n  depends_on = [aws_vpc.main]\n  for_each   = var.instances\n"
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "broken.tf")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+
+	ctx := &sdk.Context{File: tmpFile}
+	result, err := rule.Fix(ctx, nil)
+	require.NoError(t, err, "Fix must swallow parse errors; Check surfaces them")
+	assert.Nil(t, result)
 }
 
 func TestLifecycleAttributeOrderRule(t *testing.T) {

--- a/internal/engines/style/rules/testdata/goldens/meta_arguments_order/reorder_count_before_provider.golden
+++ b/internal/engines/style/rules/testdata/goldens/meta_arguments_order/reorder_count_before_provider.golden
@@ -1,0 +1,7 @@
+resource "aws_instance" "web" {
+  count    = 3
+  provider = aws.west
+
+  ami           = "ami-123"
+  instance_type = "t2.micro"
+}

--- a/internal/engines/style/rules/testdata/goldens/meta_arguments_order/reorder_depends_on_after_for_each.golden
+++ b/internal/engines/style/rules/testdata/goldens/meta_arguments_order/reorder_depends_on_after_for_each.golden
@@ -1,0 +1,7 @@
+resource "aws_instance" "web" {
+  for_each   = var.instances
+
+  ami           = "ami-123"
+  instance_type = "t2.micro"
+  depends_on = [aws_vpc.main]
+}

--- a/internal/engines/style/rules/testdata/goldens/meta_arguments_order/reorder_depends_on_after_lifecycle.golden
+++ b/internal/engines/style/rules/testdata/goldens/meta_arguments_order/reorder_depends_on_after_lifecycle.golden
@@ -1,0 +1,10 @@
+resource "aws_instance" "web" {
+  for_each   = var.instances
+
+  ami = "ami-123"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+  depends_on = [aws_vpc.main]
+}


### PR DESCRIPTION
## What and why

Rebuild `MetaArgumentsOrderRule.Fix` on top of the CST (`cst.Body.Move`) instead of the hclwrite-token reorder path (`ReorderBlockAttrs` + `SetAttributeRaw`).

Leading meta-args (`for_each`, `count`, `provider`) anchor at the start of the body in canonical order; `depends_on` slides to the last body slot. Sibling rules (`depends-on-order`, `lifecycle-at-end`, `tags-at-end`) continue to refine the trailing position when nested blocks like `lifecycle` are present.

**Why:** continues the rule-by-rule CST migration (sibling PRs #189, #190, #191, #192, #193). Each `Move` on an item already at its target index is a no-op, so canonical input round-trips byte-identically — the explicit Check-first short-circuit drops out and the rule loses its dependency on `hclwrite.SetAttributeRaw` re-alignment. After this PR, `ReorderBlockAttrs` has zero production callers and is ready for deletion in the helpers cleanup PR.

## How to test

```bash
mise run check
go test -run 'TestMetaArgumentsOrderRule' ./internal/engines/style/rules/ -v
```

Three byte-exact goldens pin the new output under `testdata/goldens/meta_arguments_order/`:

- `reorder_depends_on_after_for_each.golden` — depends_on/for_each swap
- `reorder_count_before_provider.golden` — count/provider swap
- `reorder_depends_on_after_lifecycle.golden` — depends_on lands after a `lifecycle {}` nested block

Re-capture goldens with `UPDATE_GOLDEN=1 go test -run TestMetaArgumentsOrderRule_FixGoldens ./internal/engines/style/rules/`.

`TestMetaArgumentsOrderRule_ParseError_FixIsNoOp` covers the `cst.Build` partial-tree branch.

## Notes for reviewers

- Whitespace divergence vs the pre-migration output is expected and is captured in the goldens: source-preserved column alignment (`for_each   = ` keeps 3 spaces from source vs. the pre-migration 6-space realign), the intra-block blank between meta-args and regular attrs is preserved (was previously collapsed by `FormatAndCleanBlankLines`), and there is no spurious trailing newline rewrite. Semantic faithfulness — attribute order, comments, values — is unchanged.
- `Fix` signature drops the unused `*hcl.File` (becomes `_`) so the new parse-error test can call `Fix(ctx, nil)` consistently with sibling rules.
- Fixtures (`metaArgsReorderInput`, `metaArgsProviderBeforeCountInput`, `metaArgsWithLifecycleInput`) extracted as package-level `const`s shared between the semantic subtest and the byte-exact golden test — a fixture edit forces a lock-step golden refresh rather than silently desyncing the two checks.
- `ReorderBlockAttrs` now has zero production callers. Helpers cleanup will land in a follow-up PR.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
