### PR TITLE
refactor(style): rewrite lifecycle-attribute-order Fix on top of CST

### DIFF
--- a/internal/engines/style/rules/block_organization.go
+++ b/internal/engines/style/rules/block_organization.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
-	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/santosr2/TerraTidy/internal/cst"
 	"github.com/santosr2/TerraTidy/pkg/sdk"
 )
@@ -202,6 +201,17 @@ var lifecycleAttrOrder = map[string]int{
 	"postcondition":         6,
 }
 
+// lifecycleAttrCanonicalOrder is the canonical lifecycle attribute order
+// driven into the Fix output. Precondition/postcondition are nested blocks
+// in Terraform, not attributes, so they are excluded from the reorder slice
+// — sibling rules (nested-block-order) own ordering for those.
+var lifecycleAttrCanonicalOrder = []string{
+	"create_before_destroy",
+	"prevent_destroy",
+	"ignore_changes",
+	"replace_triggered_by",
+}
+
 // Check examines lifecycle blocks for attribute ordering.
 func (r *LifecycleAttributeOrderRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Finding, error) {
 	var findings []sdk.Finding
@@ -282,61 +292,67 @@ func (r *LifecycleAttributeOrderRule) checkLifecycleBlock(ctx *sdk.Context, life
 	return findings
 }
 
-// Fix reorders lifecycle attributes in all blocks.
+// Fix reorders canonical lifecycle attributes (create_before_destroy,
+// prevent_destroy, ignore_changes, replace_triggered_by) to the start of
+// each lifecycle body in canonical order. Non-canonical body items
+// (unknown attributes, precondition/postcondition nested blocks, comments)
+// keep their relative source position; only the canonical attrs reshuffle.
+//
+// Already-canonical input round-trips byte-identically: each Move on an
+// attribute at its target index is a successful no-op (cst.Body.Move
+// returns early when src == newIndex), so file.Bytes() equals the source
+// and WholeFileEdit collapses the result to nil.
 func (r *LifecycleAttributeOrderRule) Fix(ctx *sdk.Context, _ *hcl.File) (*sdk.FixResult, error) {
-	content, err := os.ReadFile(ctx.File)
+	originalContent, err := os.ReadFile(ctx.File)
 	if err != nil {
 		return nil, err
 	}
 
-	writeFile, diags := hclwrite.ParseConfig(content, ctx.File, hcl.InitialPos)
-	if diags.HasErrors() {
-		return nil, diags
+	cstFile, parseErr := cst.Build(originalContent, ctx.File, cst.DefaultTopLevelPolicy())
+	if parseErr != nil {
+		// No-op on parse error: do not mutate a partial tree, and do not
+		// surface the diagnostic as a Fix error (Check already produced it).
+		return nil, nil //nolint:nilerr // parse error already surfaced by Check; Fix preserves no-op contract on partial trees
 	}
 
-	for _, block := range writeFile.Body().Blocks() {
-		if block.Type() != "resource" {
+	for _, item := range cstFile.Body.Items {
+		block, ok := item.(*cst.Block)
+		if !ok {
 			continue
 		}
-
-		for _, nested := range block.Body().Blocks() {
-			if nested.Type() != "lifecycle" {
+		if block.Type != "resource" {
+			continue
+		}
+		for _, inner := range block.Body.Items {
+			nested, ok := inner.(*cst.Block)
+			if !ok {
 				continue
 			}
-
-			attrOrder := []string{"create_before_destroy", "prevent_destroy", "ignore_changes", "replace_triggered_by"}
-
-			attrExprs := make(map[string]hclwrite.Tokens)
-			for name, attr := range nested.Body().Attributes() {
-				attrExprs[name] = getExprTokensWithTrailingComment(attr)
+			if nested.Type != "lifecycle" {
+				continue
 			}
-
-			for _, name := range attrOrder {
-				nested.Body().RemoveAttribute(name)
-			}
-
-			for _, name := range attrOrder {
-				if tokens, ok := attrExprs[name]; ok {
-					nested.Body().SetAttributeRaw(name, tokens)
-				}
-			}
-
-			for name, tokens := range attrExprs {
-				found := false
-				for _, orderedName := range attrOrder {
-					if name == orderedName {
-						found = true
-						break
-					}
-				}
-				if !found {
-					nested.Body().SetAttributeRaw(name, tokens)
-				}
-			}
+			reorderLifecycleAttrs(nested.Body)
 		}
 	}
 
-	return WholeFileEdit(content, FormatAndCleanBlankLines(writeFile.Bytes())), nil
+	return WholeFileEdit(originalContent, cstFile.Bytes()), nil
+}
+
+// reorderLifecycleAttrs positions canonical lifecycle attributes at the
+// start of body in canonical order. Move on an item already at its target
+// index is a successful no-op, so a lifecycle block that doesn't need
+// rearrangement round-trips byte-identically.
+func reorderLifecycleAttrs(body *cst.Body) {
+	if body == nil {
+		return
+	}
+	anchorIdx := 0
+	for _, name := range lifecycleAttrCanonicalOrder {
+		if attr := body.FindAttribute(name); attr != nil {
+			body.Move(attr, anchorIdx)
+			anchorIdx++
+		}
+	}
 }
 
 // NestedBlockOrderRule ensures nested blocks follow consistent ordering.

--- a/internal/engines/style/rules/block_organization_golden_test.go
+++ b/internal/engines/style/rules/block_organization_golden_test.go
@@ -83,6 +83,81 @@ func TestMetaArgumentsOrderRule_FixGoldens(t *testing.T) {
 	}
 }
 
+// Byte-exact goldens for LifecycleAttributeOrderRule.Fix.
+//
+// The Fix walks the CST and relocates canonical lifecycle attributes
+// (create_before_destroy, prevent_destroy, ignore_changes,
+// replace_triggered_by) to the start of each lifecycle nested block body
+// in canonical order. Each item keeps its original source bytes, so column
+// alignment and intra-block blank lines round-trip verbatim — only the
+// slice order changes. Whitespace-only divergence in regenerated regions
+// is an expected outcome of swapping the structural algorithm and may
+// justify a golden update; a semantic divergence (different attribute
+// order, dropped comment, changed value) indicates a correctness
+// regression.
+//
+// Fixtures live alongside TestLifecycleAttributeOrderRule in
+// block_organization_test.go (lifecycleAttrsReorderInput,
+// lifecycleAttrsAllReorderedInput) so the semantic assertion and the
+// byte-exact snapshot share the same input — a fixture change cannot
+// silently desync the two.
+//
+// Capture / re-capture: UPDATE_GOLDEN=1 go test -run TestLifecycleAttributeOrderRule_FixGoldens ./internal/engines/style/rules/
+func TestLifecycleAttributeOrderRule_FixGoldens(t *testing.T) {
+	rule := &LifecycleAttributeOrderRule{}
+
+	fixtures := []struct {
+		name   string
+		golden string
+		input  string
+	}{
+		{
+			name:   "reorder ignore_changes after create_before_destroy",
+			golden: "lifecycle_attribute_order/reorder_ignore_changes_after_create_before_destroy",
+			input:  lifecycleAttrsReorderInput,
+		},
+		{
+			// Pins the canonical four-attribute order:
+			// create_before_destroy → prevent_destroy → ignore_changes →
+			// replace_triggered_by, with all four authored in reverse.
+			name:   "reorder all four canonical attrs",
+			golden: "lifecycle_attribute_order/reorder_all_four_canonical_attrs",
+			input:  lifecycleAttrsAllReorderedInput,
+		},
+		{
+			// Pins the lifecycle/precondition interaction: the
+			// precondition nested block keeps its relative source
+			// position when canonical attrs around it reshuffle.
+			// Sibling rules (nested-block-order) own ordering of
+			// nested validation blocks themselves.
+			name:   "lifecycle with precondition block",
+			golden: "lifecycle_attribute_order/lifecycle_with_precondition_block",
+			input:  lifecycleAttrsWithPreconditionInput,
+		},
+	}
+
+	for _, tc := range fixtures {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			tmpFile := filepath.Join(tmpDir, "test.tf")
+			require.NoError(t, os.WriteFile(tmpFile, []byte(tc.input), 0o644))
+
+			file, diags := hclsyntax.ParseConfig([]byte(tc.input), tmpFile, hcl.InitialPos)
+			require.False(t, diags.HasErrors(), "fixture failed to parse: %v", diags)
+
+			hclFile := &hcl.File{Body: file.Body}
+			ctx := &sdk.Context{File: tmpFile}
+
+			result, err := rule.Fix(ctx, hclFile)
+			require.NoError(t, err)
+			require.NotNil(t, result, "fixture must produce a fix; the no-op case belongs in the main test")
+			require.Len(t, result.Edits, 1)
+
+			assertRuleGolden(t, tc.golden, result.Edits[0].Replacement)
+		})
+	}
+}
+
 // assertRuleGolden compares actual bytes to testdata/goldens/<name>.golden.
 // Set UPDATE_GOLDEN=1 to write the golden instead of asserting.
 //

--- a/internal/engines/style/rules/block_organization_test.go
+++ b/internal/engines/style/rules/block_organization_test.go
@@ -59,6 +59,61 @@ const metaArgsWithLifecycleInput = `resource "aws_instance" "web" {
 }
 `
 
+// lifecycleAttrsReorderInput is the canonical "ignore_changes placed before
+// create_before_destroy" fixture used by both TestLifecycleAttributeOrderRule's
+// "Fix reorders lifecycle attributes" subtest (semantic assertion) and
+// TestLifecycleAttributeOrderRule_FixGoldens (byte-exact snapshot). Shared so a
+// fixture edit forces a golden update in lock-step rather than silently
+// decoupling the two checks.
+const lifecycleAttrsReorderInput = `resource "aws_instance" "web" {
+  ami           = "ami-123"
+  instance_type = "t2.micro"
+
+  lifecycle {
+    ignore_changes        = [tags]
+    create_before_destroy = true
+  }
+}
+`
+
+// lifecycleAttrsAllReorderedInput pins the four-canonical-attr reorder shape:
+// all four meta-attributes (create_before_destroy, prevent_destroy,
+// ignore_changes, replace_triggered_by) authored in reverse order. The
+// expected output is canonical order at the top of the lifecycle body.
+const lifecycleAttrsAllReorderedInput = `resource "aws_instance" "web" {
+  ami = "ami-123"
+
+  lifecycle {
+    replace_triggered_by  = [aws_vpc.main]
+    ignore_changes        = [tags]
+    prevent_destroy       = false
+    create_before_destroy = true
+  }
+}
+`
+
+// lifecycleAttrsWithPreconditionInput pins the lifecycle/precondition
+// interaction: a precondition nested block keeps its relative source
+// position when the canonical attributes around it reshuffle. The Fix
+// only Moves the four canonical attributes; non-canonical body items
+// (nested precondition/postcondition blocks, unknown attributes, comments)
+// shift passively as side-effects of the attribute moves, never as
+// explicit targets. Sibling rules own ordering of nested validation blocks.
+const lifecycleAttrsWithPreconditionInput = `resource "aws_instance" "web" {
+  ami = "ami-123"
+
+  lifecycle {
+    ignore_changes        = [tags]
+    create_before_destroy = true
+
+    precondition {
+      condition     = var.ami != ""
+      error_message = "ami required"
+    }
+  }
+}
+`
+
 func TestMetaArgumentsOrderRule(t *testing.T) {
 	rule := &MetaArgumentsOrderRule{}
 
@@ -355,15 +410,7 @@ func TestLifecycleAttributeOrderRule(t *testing.T) {
 	t.Run("Fix reorders lifecycle attributes", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		tmpFile := filepath.Join(tmpDir, "test.tf")
-		content := `resource "aws_instance" "web" {
-  ami           = "ami-123"
-  instance_type = "t2.micro"
-
-  lifecycle {
-    ignore_changes        = [tags]
-    create_before_destroy = true
-  }
-}`
+		content := lifecycleAttrsReorderInput
 		err := os.WriteFile(tmpFile, []byte(content), 0o644)
 		require.NoError(t, err)
 
@@ -437,6 +484,25 @@ func TestLifecycleAttributeOrderRule(t *testing.T) {
 		require.NoError(t, err)
 		assert.Nil(t, result, "already-canonical input must produce no edits")
 	})
+}
+
+// TestLifecycleAttributeOrderRule_ParseError_FixIsNoOp covers the cst.Build
+// parse-error branch in LifecycleAttributeOrderRule.Fix: on a partial tree,
+// Fix must return (nil, nil) so the diagnostic stays on Check and Fix does
+// not mutate a tree it cannot trust.
+func TestLifecycleAttributeOrderRule_ParseError_FixIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	rule := &LifecycleAttributeOrderRule{}
+	content := "resource \"aws_instance\" \"x\" {\n  lifecycle {\n    ignore_changes        = [tags]\n    create_before_destroy = true\n"
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "broken.tf")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+
+	ctx := &sdk.Context{File: tmpFile}
+	result, err := rule.Fix(ctx, nil)
+	require.NoError(t, err, "Fix must swallow parse errors; Check surfaces them")
+	assert.Nil(t, result)
 }
 
 func TestNestedBlockOrderRule(t *testing.T) {

--- a/internal/engines/style/rules/block_organization_test.go
+++ b/internal/engines/style/rules/block_organization_test.go
@@ -505,6 +505,21 @@ func TestLifecycleAttributeOrderRule_ParseError_FixIsNoOp(t *testing.T) {
 	assert.Nil(t, result)
 }
 
+// TestLifecycleAttributeOrderRule_FileReadError_FixReturnsError covers the
+// os.ReadFile error branch in LifecycleAttributeOrderRule.Fix: a missing
+// file (or any other read failure) must surface as a Fix error so the
+// runner records it instead of silently producing a nil edit.
+func TestLifecycleAttributeOrderRule_FileReadError_FixReturnsError(t *testing.T) {
+	t.Parallel()
+
+	rule := &LifecycleAttributeOrderRule{}
+	ctx := &sdk.Context{File: filepath.Join(t.TempDir(), "does-not-exist.tf")}
+
+	result, err := rule.Fix(ctx, nil)
+	require.Error(t, err, "Fix must surface ReadFile errors")
+	assert.Nil(t, result)
+}
+
 func TestNestedBlockOrderRule(t *testing.T) {
 	rule := &NestedBlockOrderRule{}
 

--- a/internal/engines/style/rules/testdata/goldens/lifecycle_attribute_order/lifecycle_with_precondition_block.golden
+++ b/internal/engines/style/rules/testdata/goldens/lifecycle_attribute_order/lifecycle_with_precondition_block.golden
@@ -1,0 +1,13 @@
+resource "aws_instance" "web" {
+  ami = "ami-123"
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [tags]
+
+    precondition {
+      condition     = var.ami != ""
+      error_message = "ami required"
+    }
+  }
+}

--- a/internal/engines/style/rules/testdata/goldens/lifecycle_attribute_order/reorder_all_four_canonical_attrs.golden
+++ b/internal/engines/style/rules/testdata/goldens/lifecycle_attribute_order/reorder_all_four_canonical_attrs.golden
@@ -1,0 +1,10 @@
+resource "aws_instance" "web" {
+  ami = "ami-123"
+
+  lifecycle {
+    create_before_destroy = true
+    prevent_destroy       = false
+    ignore_changes        = [tags]
+    replace_triggered_by  = [aws_vpc.main]
+  }
+}

--- a/internal/engines/style/rules/testdata/goldens/lifecycle_attribute_order/reorder_ignore_changes_after_create_before_destroy.golden
+++ b/internal/engines/style/rules/testdata/goldens/lifecycle_attribute_order/reorder_ignore_changes_after_create_before_destroy.golden
@@ -1,0 +1,9 @@
+resource "aws_instance" "web" {
+  ami           = "ami-123"
+  instance_type = "t2.micro"
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [tags]
+  }
+}


### PR DESCRIPTION
## What and why

Rewrite `LifecycleAttributeOrderRule.Fix` (`internal/engines/style/rules/block_organization.go`) on top of the CST. The old implementation walked an `hclwrite` tree and remove-then-reinsert canonical attributes, which lost column alignment and intra-block blank lines. The new implementation finds canonical attributes on the CST and `Move`s them to the start of each lifecycle body in canonical order. Each item keeps its original source bytes, so column alignment and blank lines round-trip verbatim. Already-canonical input collapses to a nil edit (each `Move` is a no-op when src == newIndex). Parse errors return `(nil, nil)` so the diagnostic stays on `Check`.

Canonical attributes (the only items the Fix `Move`s):

- `create_before_destroy`
- `prevent_destroy`
- `ignore_changes`
- `replace_triggered_by`

Non-canonical body items (unknown attributes, `precondition` / `postcondition` nested blocks, comments) keep their relative source position. Sibling rules (`nested-block-order`) own ordering of nested validation blocks.

**Why:** Continues the style-engine CST migration (most recent: #194, #193, #192, #191, #190). Removes the last `hclwrite` write-tree usage in this rule, eliminating the rewrite-everything blast radius and the post-`FormatAndCleanBlankLines` cleanup that the hclwrite output required.

## How to test

```bash
mise run check
mise run test -- -run 'TestLifecycleAttributeOrderRule|TestLifecycleAttributeOrderRule_FixGoldens|TestLifecycleAttributeOrderRule_ParseError_FixIsNoOp' ./internal/engines/style/rules/
```

Goldens are byte-exact snapshots. To regenerate after an intentional shape change:

```bash
UPDATE_GOLDEN=1 go test -run TestLifecycleAttributeOrderRule_FixGoldens ./internal/engines/style/rules/
```

## Notes for reviewers

- **Fixture sharing.** `lifecycleAttrsReorderInput` is consumed by both the semantic assertion in `TestLifecycleAttributeOrderRule` ("Fix reorders lifecycle attributes") and `TestLifecycleAttributeOrderRule_FixGoldens`. Editing the fixture forces a golden update in lock-step rather than silently decoupling the two checks.
- **Parse-error contract.** `TestLifecycleAttributeOrderRule_ParseError_FixIsNoOp` pins the `(nil, nil)` return on a partial tree. `Check` already surfaces the diagnostic; `Fix` must not mutate a tree it cannot trust. The `//nolint:nilerr` is justified inline.
- **No user-facing change.** Same rule, same canonical order, same diagnostic. Behavior change is whitespace-preservation on the Fix output, not finding semantics.
- **Three new goldens** (one per fixture): two-attribute reorder, four-attribute reverse-order reorder, and lifecycle-with-precondition (pins that the precondition nested block keeps its relative source position).

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
