### PR TITLE
feat(style): add terragrunt-include-first rule on top of CST

### DIFF
--- a/internal/engines/style/rules/terragrunt_rules.go
+++ b/internal/engines/style/rules/terragrunt_rules.go
@@ -1,0 +1,169 @@
+package rules
+
+import (
+	"os"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/santosr2/TerraTidy/internal/cst"
+	"github.com/santosr2/TerraTidy/pkg/sdk"
+)
+
+// TerragruntIncludeFirstRule ensures top-level Terragrunt include blocks come
+// first, followed by dependency blocks, then everything else. This matches the
+// canonical layout of a terragrunt.hcl: parent wiring (include) precedes
+// upstream wiring (dependency) precedes module configuration (inputs, locals,
+// remote_state, etc.).
+type TerragruntIncludeFirstRule struct{}
+
+// Name returns the rule identifier.
+func (r *TerragruntIncludeFirstRule) Name() string {
+	return "style.terragrunt-include-first"
+}
+
+// Description returns a human-readable description of the rule.
+func (r *TerragruntIncludeFirstRule) Description() string {
+	return "Ensures top-level include blocks come first, then dependency blocks, then everything else"
+}
+
+// Check walks the top-level blocks and emits a finding for every include block
+// that follows a non-include block, and every dependency block that follows
+// any block other than include or dependency. The rule is structural and
+// applies to any file whose top-level body contains include or dependency
+// blocks; pure Terraform files produce no findings naturally.
+//
+// Only HCL blocks are evaluated. Top-level attributes (e.g. terragrunt's
+// `inputs = { ... }`, `iam_role = "..."`) are invisible to this rule because
+// they are not part of hclsyntax.Body.Blocks. A file that places `inputs =
+// {}` above `include "root" { ... }` therefore produces zero findings even
+// though "everything else" appears before the include — the rule scopes
+// "everything else" to other top-level blocks.
+func (r *TerragruntIncludeFirstRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Finding, error) {
+	var findings []sdk.Finding
+
+	hclFile, ok := file.Body.(*hclsyntax.Body)
+	if !ok {
+		return findings, nil
+	}
+
+	sawNonInclude := false
+	sawOther := false
+	for _, block := range hclFile.Blocks {
+		switch block.Type {
+		case "include":
+			if sawNonInclude {
+				findings = append(findings, sdk.Finding{
+					Rule:     r.Name(),
+					Message:  "include block should come before non-include blocks",
+					File:     ctx.File,
+					Location: sdk.LocationFromRange(block.Range()),
+					Severity: sdk.SeverityWarning,
+				})
+			}
+		case "dependency":
+			sawNonInclude = true
+			if sawOther {
+				findings = append(findings, sdk.Finding{
+					Rule:     r.Name(),
+					Message:  "dependency block should come after include blocks and before everything else",
+					File:     ctx.File,
+					Location: sdk.LocationFromRange(block.Range()),
+					Severity: sdk.SeverityWarning,
+				})
+			}
+		default:
+			sawNonInclude = true
+			sawOther = true
+		}
+	}
+
+	return findings, nil
+}
+
+// Fix reorders top-level include and dependency blocks into canonical position
+// using the CST. The fix is gated on cst.IsTerragruntFile so it never mutates
+// pure Terraform files; a hand-written .tf containing top-level include or
+// dependency blocks does satisfy IsTerragruntFile (the heuristic recognizes
+// the block names regardless of extension) and is fixed in the same way.
+//
+// Under DefaultTopLevelPolicy (StrictAdjacency=true), StandaloneComment items
+// separated from a block by a blank line stay where they are when the block
+// moves — section headers (the `### Inputs`-style comments common in
+// terragrunt.hcl) survive the reorder intact.
+func (r *TerragruntIncludeFirstRule) Fix(ctx *sdk.Context, _ *hcl.File) (*sdk.FixResult, error) {
+	originalContent, err := os.ReadFile(ctx.File)
+	if err != nil {
+		return nil, err
+	}
+
+	file, parseErr := cst.Build(originalContent, ctx.File, cst.DefaultTopLevelPolicy())
+	if parseErr != nil {
+		return nil, nil //nolint:nilerr // parse error already surfaced by Check; Fix preserves no-op contract on partial trees
+	}
+
+	if !cst.IsTerragruntFile(file, ctx.File) {
+		return nil, nil
+	}
+
+	if terragruntBlocksAreCanonical(file.Body) {
+		return nil, nil
+	}
+
+	firstBlockIdx := -1
+	for i, item := range file.Body.Items {
+		if _, ok := item.(*cst.Block); ok {
+			firstBlockIdx = i
+			break
+		}
+	}
+	if firstBlockIdx < 0 {
+		return nil, nil
+	}
+
+	var anchor cst.BodyItem
+	place := func(item cst.BodyItem) {
+		if anchor == nil {
+			file.Body.Move(item, firstBlockIdx)
+		} else {
+			file.Body.MoveAfter(item, anchor)
+		}
+		anchor = item
+	}
+	for _, blk := range file.Body.FindBlocksByType("include") {
+		place(blk)
+	}
+	for _, blk := range file.Body.FindBlocksByType("dependency") {
+		place(blk)
+	}
+
+	return WholeFileEdit(originalContent, file.Bytes()), nil
+}
+
+// terragruntBlocksAreCanonical reports whether the *cst.Block items in body
+// already appear in canonical order: include blocks first, then dependency
+// blocks, then everything else. BlankLine and StandaloneComment items are
+// ignored. When true, Fix would only redistribute BlankLines — return early
+// to keep the input byte-identical.
+func terragruntBlocksAreCanonical(body *cst.Body) bool {
+	prevPrio := 0
+	for _, item := range body.Items {
+		blk, ok := item.(*cst.Block)
+		if !ok {
+			continue
+		}
+		var p int
+		switch blk.Type {
+		case "include":
+			p = 1
+		case "dependency":
+			p = 2
+		default:
+			p = 3
+		}
+		if p < prevPrio {
+			return false
+		}
+		prevPrio = p
+	}
+	return true
+}

--- a/internal/engines/style/rules/terragrunt_rules_test.go
+++ b/internal/engines/style/rules/terragrunt_rules_test.go
@@ -1,0 +1,434 @@
+package rules
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/santosr2/TerraTidy/internal/cst"
+	"github.com/santosr2/TerraTidy/pkg/sdk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTerragruntIncludeFirstRule(t *testing.T) {
+	rule := &TerragruntIncludeFirstRule{}
+
+	t.Run("Name", func(t *testing.T) {
+		assert.Equal(t, "style.terragrunt-include-first", rule.Name())
+	})
+
+	t.Run("Description", func(t *testing.T) {
+		assert.NotEmpty(t, rule.Description())
+	})
+
+	tests := []struct {
+		name         string
+		filename     string
+		content      string
+		wantFindings int
+	}{
+		{
+			name:     "canonical order: include, dependency, inputs",
+			filename: "terragrunt.hcl",
+			content: `include "root" {
+  path = find_in_parent_folders()
+}
+
+dependency "vpc" {
+  config_path = "../vpc"
+}
+
+inputs = {
+  vpc_id = dependency.vpc.outputs.vpc_id
+}
+`,
+			wantFindings: 0,
+		},
+		{
+			name:     "dependency before include",
+			filename: "terragrunt.hcl",
+			content: `dependency "vpc" {
+  config_path = "../vpc"
+}
+
+include "root" {
+  path = find_in_parent_folders()
+}
+`,
+			wantFindings: 1,
+		},
+		{
+			name:     "include after locals",
+			filename: "terragrunt.hcl",
+			content: `locals {
+  region = "us-east-1"
+}
+
+include "root" {
+  path = find_in_parent_folders()
+}
+`,
+			wantFindings: 1,
+		},
+		{
+			name:     "dependency after locals (no include)",
+			filename: "terragrunt.hcl",
+			content: `locals {
+  region = "us-east-1"
+}
+
+dependency "vpc" {
+  config_path = "../vpc"
+}
+`,
+			wantFindings: 1,
+		},
+		{
+			name:     "pure terraform file with no terragrunt blocks",
+			filename: "main.tf",
+			content: `resource "aws_instance" "example" {
+  ami = "ami-123"
+}
+
+variable "name" {
+  type = string
+}
+`,
+			wantFindings: 0,
+		},
+		{
+			name:     "include block in a .tf file out of order",
+			filename: "main.tf",
+			content: `resource "aws_instance" "example" {
+  ami = "ami-123"
+}
+
+include "root" {
+  path = find_in_parent_folders()
+}
+`,
+			wantFindings: 1,
+		},
+		{
+			name:     "multiple includes, all before non-include",
+			filename: "terragrunt.hcl",
+			content: `include "root" {
+  path = find_in_parent_folders()
+}
+
+include "region" {
+  path = find_in_parent_folders("region.hcl")
+}
+
+inputs = {
+  foo = "bar"
+}
+`,
+			wantFindings: 0,
+		},
+		{
+			name:         "empty file",
+			filename:     "terragrunt.hcl",
+			content:      ``,
+			wantFindings: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, diags := hclsyntax.ParseConfig([]byte(tt.content), tt.filename, hcl.InitialPos)
+			require.False(t, diags.HasErrors())
+
+			hclFile := &hcl.File{Body: file.Body}
+			ctx := &sdk.Context{File: tt.filename}
+
+			findings, err := rule.Check(ctx, hclFile)
+			require.NoError(t, err)
+			assert.Len(t, findings, tt.wantFindings)
+		})
+	}
+
+	t.Run("Fix reorders dependency before include into canonical order", func(t *testing.T) {
+		input := `dependency "vpc" {
+  config_path = "../vpc"
+}
+
+include "root" {
+  path = find_in_parent_folders()
+}
+`
+		out := runTerragruntFix(t, rule, "terragrunt.hcl", input)
+		incIdx := strings.Index(out, "include ")
+		depIdx := strings.Index(out, "dependency ")
+		require.NotEqual(t, -1, incIdx, "include must remain in output")
+		require.NotEqual(t, -1, depIdx, "dependency must remain in output")
+		assert.Less(t, incIdx, depIdx, "include must precede dependency after fix")
+	})
+
+	t.Run("Fix moves include and dependency ahead of locals and inputs", func(t *testing.T) {
+		input := `locals {
+  region = "us-east-1"
+}
+
+dependency "vpc" {
+  config_path = "../vpc"
+}
+
+include "root" {
+  path = find_in_parent_folders()
+}
+
+inputs = {
+  region = local.region
+}
+`
+		out := runTerragruntFix(t, rule, "terragrunt.hcl", input)
+		incIdx := strings.Index(out, "include ")
+		depIdx := strings.Index(out, "dependency ")
+		locIdx := strings.Index(out, "locals ")
+		require.NotEqual(t, -1, incIdx)
+		require.NotEqual(t, -1, depIdx)
+		require.NotEqual(t, -1, locIdx)
+		assert.Less(t, incIdx, depIdx, "include must precede dependency after fix")
+		assert.Less(t, depIdx, locIdx, "dependency must precede locals after fix")
+		assert.Contains(t, out, "inputs = {", "inputs attribute survives the reorder")
+	})
+
+	t.Run("Fix is no-op on canonical order", func(t *testing.T) {
+		input := `include "root" {
+  path = find_in_parent_folders()
+}
+
+dependency "vpc" {
+  config_path = "../vpc"
+}
+
+inputs = {
+  vpc_id = dependency.vpc.outputs.vpc_id
+}
+`
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "terragrunt.hcl")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(input), 0o644))
+
+		ctx := &sdk.Context{File: tmpFile}
+		result, err := rule.Fix(ctx, nil)
+		require.NoError(t, err)
+		assert.Nil(t, result, "canonical order should produce no edits")
+	})
+
+	t.Run("Fix is no-op on pure Terraform file with no Terragrunt blocks", func(t *testing.T) {
+		input := `resource "aws_instance" "example" {
+  ami = "ami-123"
+}
+
+variable "name" {
+  type = string
+}
+`
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "main.tf")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(input), 0o644))
+
+		ctx := &sdk.Context{File: tmpFile}
+		result, err := rule.Fix(ctx, nil)
+		require.NoError(t, err)
+		assert.Nil(t, result, "non-Terragrunt files should not be modified")
+	})
+
+	t.Run("Fix applies to .tf file when include block is present", func(t *testing.T) {
+		input := `resource "aws_instance" "example" {
+  ami = "ami-123"
+}
+
+include "root" {
+  path = find_in_parent_folders()
+}
+`
+		out := runTerragruntFix(t, rule, "main.tf", input)
+		incIdx := strings.Index(out, "include ")
+		resIdx := strings.Index(out, "resource ")
+		require.NotEqual(t, -1, incIdx)
+		require.NotEqual(t, -1, resIdx)
+		assert.Less(t, incIdx, resIdx, "include must precede resource after fix on .tf file")
+	})
+
+	t.Run("Fix preserves standalone section-header comments in place", func(t *testing.T) {
+		// Under DefaultTopLevelPolicy a comment separated from a block by a
+		// blank line is a StandaloneComment and stays where it is when blocks
+		// reorder around it. Assert both survival AND position: the header
+		// must land after the moved include/dependency blocks and above the
+		// inputs attribute that originally followed it.
+		input := `dependency "vpc" {
+  config_path = "../vpc"
+}
+
+include "root" {
+  path = find_in_parent_folders()
+}
+
+### Inputs
+
+inputs = {
+  vpc_id = dependency.vpc.outputs.vpc_id
+}
+`
+		out := runTerragruntFix(t, rule, "terragrunt.hcl", input)
+		assertOrderedSubstrings(t, out, []string{
+			"include ",
+			"dependency ",
+			"### Inputs",
+			"inputs = {",
+		})
+	})
+
+	t.Run("Fix reorders dependency-only when no include blocks present", func(t *testing.T) {
+		input := `locals {
+  region = "us-east-1"
+}
+
+dependency "vpc" {
+  config_path = "../vpc"
+}
+`
+		out := runTerragruntFix(t, rule, "terragrunt.hcl", input)
+		assertOrderedSubstrings(t, out, []string{
+			"dependency ",
+			"locals ",
+		})
+	})
+
+	t.Run("Fix is idempotent", func(t *testing.T) {
+		input := `locals {
+  region = "us-east-1"
+}
+
+dependency "vpc" {
+  config_path = "../vpc"
+}
+
+include "root" {
+  path = find_in_parent_folders()
+}
+`
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "terragrunt.hcl")
+		require.NoError(t, os.WriteFile(tmpFile, []byte(input), 0o644))
+
+		ctx := &sdk.Context{File: tmpFile}
+		firstResult, err := rule.Fix(ctx, nil)
+		require.NoError(t, err)
+		require.NotNil(t, firstResult)
+		require.Len(t, firstResult.Edits, 1)
+		// Persist the first-pass output so the second pass reads canonical input.
+		require.NoError(t, os.WriteFile(tmpFile, firstResult.Edits[0].Replacement, 0o644))
+
+		secondResult, err := rule.Fix(ctx, nil)
+		require.NoError(t, err)
+		assert.Nil(t, secondResult, "second Fix pass on canonical input must be a no-op")
+	})
+}
+
+// TestTerragruntIncludeFirst_ParseError_FixIsNoOp covers the cst.Build
+// parse-error branch. On a partial tree, Fix must return (nil, nil) — Check
+// already surfaces the diagnostic and Fix preserves its no-op contract.
+func TestTerragruntIncludeFirst_ParseError_FixIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	rule := &TerragruntIncludeFirstRule{}
+	// Unterminated block: cst.Build returns a parse error.
+	content := "include \"root\" {\n  path = find_in_parent_folders()\n"
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "broken.hcl")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+
+	ctx := &sdk.Context{File: tmpFile}
+	result, err := rule.Fix(ctx, nil)
+	require.NoError(t, err, "Fix must swallow parse errors; Check surfaces them")
+	assert.Nil(t, result)
+}
+
+// TestTerragruntIncludeFirst_ReadError_FixSurfacesError covers the
+// os.ReadFile error branch — Fix must propagate I/O errors to the caller
+// rather than returning a partial result.
+func TestTerragruntIncludeFirst_ReadError_FixSurfacesError(t *testing.T) {
+	t.Parallel()
+
+	rule := &TerragruntIncludeFirstRule{}
+	ctx := &sdk.Context{File: filepath.Join(t.TempDir(), "does-not-exist.hcl")}
+	result, err := rule.Fix(ctx, nil)
+	require.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestTerragruntBlocksAreCanonical(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name: "include, dependency, other",
+			content: `include "root" { path = "x" }
+dependency "vpc" { config_path = "../vpc" }
+locals { region = "us-east-1" }`,
+			want: true,
+		},
+		{
+			name: "dependency before include",
+			content: `dependency "vpc" { config_path = "../vpc" }
+include "root" { path = "x" }`,
+			want: false,
+		},
+		{
+			name: "other before include",
+			content: `locals { region = "us-east-1" }
+include "root" { path = "x" }`,
+			want: false,
+		},
+		{
+			name: "only other blocks",
+			content: `locals { region = "us-east-1" }
+inputs = { foo = "bar" }`,
+			want: true,
+		},
+		{
+			name:    "empty",
+			content: ``,
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, parseErr := cst.Build([]byte(tt.content), "terragrunt.hcl", cst.DefaultTopLevelPolicy())
+			require.NoError(t, parseErr)
+			got := terragruntBlocksAreCanonical(file.Body)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// runTerragruntFix is a Terragrunt variant of runRuleFix that lets the test
+// pick the on-disk filename so cst.IsTerragruntFile's filename-check path is
+// exercised alongside the block-content path.
+func runTerragruntFix(t *testing.T, rule sdk.Rule, filename, content string) string {
+	t.Helper()
+	fixer, ok := rule.(sdk.Fixer)
+	require.True(t, ok, "rule must implement sdk.Fixer")
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, filename)
+	require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0o644))
+
+	ctx := &sdk.Context{File: tmpFile}
+	result, err := fixer.Fix(ctx, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Edits, 1)
+	return string(result.Edits[0].Replacement)
+}

--- a/internal/engines/style/style.go
+++ b/internal/engines/style/style.go
@@ -706,6 +706,7 @@ func (e *Engine) registerRules() {
 	// Block ordering
 	e.rules = append(e.rules, &rules.TerraformBlockFirstRule{})
 	e.rules = append(e.rules, &rules.ProviderBlockOrderRule{})
+	e.rules = append(e.rules, &rules.TerragruntIncludeFirstRule{})
 
 	// Attribute ordering within blocks (runs first to reorder attributes)
 	e.rules = append(e.rules, &rules.ForEachCountFirstRule{})

--- a/internal/engines/style/style_test.go
+++ b/internal/engines/style/style_test.go
@@ -746,19 +746,19 @@ func TestEngine_GetAllRules(t *testing.T) {
 	engine := New(nil)
 	rules := engine.GetAllRules()
 
-	// Verify we have all 33 rules registered
+	// Verify we have all 34 rules registered
 	// 1. BlankLineBetweenBlocksRule
 	// 2-5. BlockLabelCaseRule, VariableNamingRule, OutputNamingRule, LocalNamingRule
-	// 6-7. TerraformBlockFirstRule, ProviderBlockOrderRule
-	// 8-12. ForEachCountFirstRule, SourceVersionGroupedRule, TagsAtEndRule, DependsOnOrderRule, LifecycleAtEndRule
-	// 13-14. VariableOrderRule, OutputOrderRule
-	// 15. AttributeGroupSpacingRule
-	// 16-17. NoLeadingTrailingBlankLinesRule, NoEmptyBlocksRule
-	// 18-22. VariablesInFileRule, OutputsInFileRule, ProvidersInFileRule, ScopedFileOrganizationRule, TerraformFilesStructureRule
-	// 23-25. ResourceNameMatchesTypeRule, OutputPrefixRule, ModuleNameConventionRule
-	// 26-29. MetaArgumentsOrderRule, LifecycleAttributeOrderRule, NestedBlockOrderRule, OneLineAttributeSpacingRule
-	// 30-33. CommentSyntaxRule, NoTrailingWhitespaceRule, ConsistentQuotesRule, NoConsecutiveBlankLinesRule
-	assert.Len(t, rules, 33, "should have 33 rules registered")
+	// 6-8. TerraformBlockFirstRule, ProviderBlockOrderRule, TerragruntIncludeFirstRule
+	// 9-13. ForEachCountFirstRule, SourceVersionGroupedRule, TagsAtEndRule, DependsOnOrderRule, LifecycleAtEndRule
+	// 14-15. VariableOrderRule, OutputOrderRule
+	// 16. AttributeGroupSpacingRule
+	// 17-18. NoLeadingTrailingBlankLinesRule, NoEmptyBlocksRule
+	// 19-23. VariablesInFileRule, OutputsInFileRule, ProvidersInFileRule, ScopedFileOrganizationRule, TerraformFilesStructureRule
+	// 24-26. ResourceNameMatchesTypeRule, OutputPrefixRule, ModuleNameConventionRule
+	// 27-30. MetaArgumentsOrderRule, LifecycleAttributeOrderRule, NestedBlockOrderRule, OneLineAttributeSpacingRule
+	// 31-34. CommentSyntaxRule, NoTrailingWhitespaceRule, ConsistentQuotesRule, NoConsecutiveBlankLinesRule
+	assert.Len(t, rules, 34, "should have 34 rules registered")
 
 	// Verify each rule has required methods
 	for _, rule := range rules {
@@ -1243,8 +1243,8 @@ func TestNew_AcceptsPluginRules(t *testing.T) {
 		engine := New(nil)
 		rules := engine.GetAllRules()
 
-		// Should have 33 built-in rules
-		assert.Len(t, rules, 33)
+		// Should have 34 built-in rules
+		assert.Len(t, rules, 34)
 	})
 
 	t.Run("with single plugin rule", func(t *testing.T) {
@@ -1252,8 +1252,8 @@ func TestNew_AcceptsPluginRules(t *testing.T) {
 		engine := New(nil, pluginRule)
 		rules := engine.GetAllRules()
 
-		// Should have 33 built-in + 1 plugin = 34 rules
-		assert.Len(t, rules, 34)
+		// Should have 34 built-in + 1 plugin = 35 rules
+		assert.Len(t, rules, 35)
 
 		// Plugin rule should be present
 		found := false
@@ -1273,8 +1273,8 @@ func TestNew_AcceptsPluginRules(t *testing.T) {
 		engine := New(nil, plugin1, plugin2, plugin3)
 		rules := engine.GetAllRules()
 
-		// Should have 33 built-in + 3 plugin = 36 rules
-		assert.Len(t, rules, 36)
+		// Should have 34 built-in + 3 plugin = 37 rules
+		assert.Len(t, rules, 37)
 	})
 }
 


### PR DESCRIPTION
## What and why

Adds `style.terragrunt-include-first`, a new structural rule that ensures top-level `include` blocks come first in a Terragrunt file, followed by `dependency` blocks, then everything else. This matches the canonical terragrunt.hcl layout: parent wiring (include) precedes upstream wiring (dependency) precedes module configuration (inputs, locals, remote_state).

**Why:** This is the first Terragrunt-aware structural rule to ship on top of the new CST. It proves the CST handles Terragrunt-specific block types (`include`, `dependency`) end-to-end alongside the eleven Terraform rules already migrated, and gives users an actionable structural lint for the most common terragrunt.hcl ordering mistake.

## How to test

```bash
mise run check
go test ./internal/engines/style/rules/ -run 'TestTerragruntIncludeFirst|TestTerragruntBlocksAreCanonical' -v
```

Manual smoke test:

```bash
mise run build
cat > /tmp/terragrunt.hcl <<'EOF'
dependency "vpc" {
  config_path = "../vpc"
}

include "root" {
  path = find_in_parent_folders()
}
EOF
./bin/terratidy style /tmp/terragrunt.hcl                # reports the misorder
./bin/terratidy style --fix /tmp/terragrunt.hcl          # reorders to include-first
```

## Notes for reviewers

- The rule's Check walks `hclsyntax.Body.Blocks` only. Top-level attributes (e.g. `inputs = { ... }`) are out of scope by design; this is documented inline on the Check godoc to prevent confusion.
- Fix is gated on `cst.IsTerragruntFile` so a plain Terraform file with no Terragrunt blocks is never mutated. A hand-written `.tf` that happens to contain a top-level `include` block does satisfy the heuristic and is fixed in place — covered by the "Fix applies to .tf file when include block is present" subtest.
- Standalone section-header comments separated from a block by a blank line stay in place when blocks reorder around them, using the same `DefaultTopLevelPolicy` mechanism that fixed the floating-header behavior in `style.terraform-block-first`. The section-header test now asserts position via `assertOrderedSubstrings`, not just presence.
- Error-path coverage matches the precedent in `ordering_test.go`: parse error → Fix returns `(nil, nil)` (Check surfaces the diagnostic); read error → Fix propagates.
- A small `runTerragruntFix(t, rule, filename, content)` helper lives next to the tests because the existing `runRuleFix` hard-codes `test.tf` and this rule needs to exercise both the filename-driven (`terragrunt.hcl`) and content-driven (`.tf` with `include`) detection paths.
- Rule registered alongside `TerraformBlockFirstRule` and `ProviderBlockOrderRule`; rule-count assertions in `style_test.go` bumped from 33 to 34.
- Docs (`docs/site/docs/rules/style-rules.md`) and example fixtures (`examples/configs/terragrunt.yaml` + `examples/rule-test-files/`) follow in a separate PR.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
