### PR TITLE
fix(docs): close unclosed code fence + wire CST into project setup

### DIFF
--- a/.github/workflows/examples-test.yml
+++ b/.github/workflows/examples-test.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'examples/**'
+      - 'internal/cst/**'
       - 'internal/plugins/**'
       - 'internal/engines/style/**'
       - '.github/workflows/examples-test.yml'
@@ -12,6 +13,7 @@ on:
     branches: [main]
     paths:
       - 'examples/**'
+      - 'internal/cst/**'
       - 'internal/plugins/**'
       - 'internal/engines/style/**'
       - '.github/workflows/examples-test.yml'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ internal/
   buildinfo/            # Build information and versioning
   cache/                # Caching layer
   config/               # YAML config with imports, profiles, glob patterns
+  cst/                  # Concrete syntax tree for structural Fix methods
   engines/              # format, style, lint, policy
   lsp/                  # Language Server Protocol implementation
   output/               # Text, JSON, SARIF, JUnit, Markdown, HTML, Table, GitHub Actions formatters

--- a/docs/site/docs/rules/style-rules.md
+++ b/docs/site/docs/rules/style-rules.md
@@ -1220,6 +1220,7 @@ resource "aws_instance" "web" {
   # This comment describes the instance type
   instance_type = "t3.micro"
 }
+```
 
 ## Configuration
 


### PR DESCRIPTION
## What and why

Three small follow-up fixes discovered after the CST refactor shipped, all from a cross-area consistency sweep.

- **`docs/site/docs/rules/style-rules.md` — unclosed code fence.** The `Comment Preservation` example opens a ```` ```hcl ```` fence at the "Before fix" header but never closes it. The runaway block swallows the next `## Configuration` heading and YAML example on the rendered site until the next fence reopens it. Adds the missing close.
- **`.github/workflows/examples-test.yml` — missing CST path trigger.** The workflow triggered on `internal/engines/style/**` but not on `internal/cst/**`. A CST regression that broke the `terragrunt-include-first` example fixture would not have fired this workflow on a CST-only PR. Adds `internal/cst/**` to both the `push` and `pull_request` path filters.
- **`CLAUDE.md` — architecture tree missing `internal/cst/`.** The CST package is now a real internal package, but the architecture tree in the contributor-facing CLAUDE.md hadn't been updated. Adds one line.

**Why:** the docs bug is user-visible on the published site, the CI gap means a future CST-only regression could slip past local checks until the broader `test.yml` runs, and the CLAUDE.md gap quietly invites contributors to write structural Fix methods on the old `helpers.go` paths instead of the CST substrate.

## How to test

- **Docs:** `mise run docs:build` runs `mkdocs build --strict` and succeeds. Visually verify on a local serve that `## Configuration` renders as a heading (not as code) on the style-rules page.
- **CI:** the path-filter change has no test target; review the YAML diff. A future PR that touches only `internal/cst/` should now trigger `Test Example Rules`.
- **CLAUDE.md:** no test target; review the architecture-tree diff.

## Notes for reviewers

- The change is documentation + CI + project-setup. No Go or test code touched, so `Test` / `Container Tests` / `Security` workflows will likely path-filter skip on this PR.
- One known follow-up tracked separately (not in this PR): the `BenchmarkStructuralFix` wall-time budget is currently over the +10% threshold while memory and allocations improved substantially. Filed for a dedicated perf-vs-baseline decision.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works <!-- N/A: docs/CI/setup-only change; `mkdocs --strict` + `zizmor` are the relevant gates and both pass locally -->
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
