### PR TITLE
docs(ci): correct workflow trigger table + add vscode.yml row

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,14 +326,15 @@ FILE="$1"
 | `release.yml` | tag `v*` | GoReleaser, Docker, Homebrew, cosign signing |
 | `quality.yml` | push/PR | PR title validation, pre-commit hooks |
 | `security.yml` | push/PR | govulncheck, gitleaks, license check, API compat |
-| `fuzz.yml` | push/PR + weekly | Fuzz tests (30s CI, 5m scheduled) |
+| `fuzz.yml` | labeled PRs (fuzz) + weekly | Fuzz tests (30s CI, 5m scheduled) |
 | `docs.yml` | push main | MkDocs build + GitHub Pages deploy |
 | `action-test.yml` | push/PR | GitHub Action self-test on 3 OSes |
-| `benchmark.yml` | push/PR (Go files) | Performance benchmarks with regression detection |
+| `vscode.yml` | push (paths or v* tag), PR (paths) | Lint, build, test VSCode extension on Ubuntu + macOS; publish on v* tags |
+| `benchmark.yml` | push on benchmarks/baseline.txt + labeled PRs (benchmark) | Performance benchmarks with regression detection |
 | `container-test.yml` | push/PR (Dockerfile, Go) | Docker build, version, check, healthcheck, non-root |
 | `examples-test.yml` | push/PR (examples/) | Test example rules (Go, YAML, Bash) |
 | `precommit-test.yml` | push/PR (.pre-commit-hooks.yaml, Go) | Pre-commit hook validation |
-| `scorecard.yml` | weekly | OpenSSF security scorecard |
+| `scorecard.yml` | weekly + push to main | OpenSSF security scorecard |
 
 PR requirements: conventional commit title, all tests pass on 3 OSes, coverage maintained.
 


### PR DESCRIPTION
## What and why

The CI/CD workflow table in `CLAUDE.md` drifted from the actual `on:` blocks in `.github/workflows/`. Three rows described triggers that no longer match reality, and the `vscode.yml` workflow was missing entirely.

- `fuzz.yml`: described as `push/PR + weekly`; actually runs on labeled PRs (`fuzz`) + weekly cron
- `benchmark.yml`: described as `push/PR (Go files)`; actually runs on push to `benchmarks/baseline.txt` + labeled PRs (`benchmark`)
- `scorecard.yml`: described as `weekly`; actually also runs on push to `main`
- `vscode.yml`: not listed at all; runs on push (paths or `v*` tag) + PR (paths), lints/builds/tests the extension on Ubuntu + macOS, and publishes on `v*` tags

**Why:** The table is the entry point new contributors use to map a workflow file to what triggers it. Stale rows actively misinform; missing rows leave a whole surface invisible.

## How to test

- Compare each updated row against its workflow's `on:` block:
  - `.github/workflows/fuzz.yml` lines 3-10 + job `if` at 23-25
  - `.github/workflows/benchmark.yml` lines 3-12 + job `if` at 25-27
  - `.github/workflows/scorecard.yml` lines 3-8
  - `.github/workflows/vscode.yml` lines 3-18 (publish step gated on `v*` tag)
- Render `CLAUDE.md` and confirm the table still scans cleanly (the new `vscode.yml` row is the longest by a margin but the column widths absorb it).

## Notes for reviewers

- Pure doc edit; no code paths touched. `mise run check` was not run because there is nothing for it to exercise (markdownlint ran via pre-commit and passed).
- Row placement: `vscode.yml` sits between `action-test.yml` and `benchmark.yml`, clustered with the other peripheral/integration-test workflows.
- The mirror table in `.claude/rules/ci-cd.md` was updated alongside but is gitignored, so only `CLAUDE.md` appears in the diff.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works (N/A: doc-only)
- [ ] All checks pass (`mise run check` runs fmt, vet, lint, and test) (N/A: doc-only; markdownlint passed via pre-commit)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
