### PR TITLE
docs: refresh architecture, configuration, and commands pages

### DIFF
--- a/docs/site/docs/development/architecture.md
+++ b/docs/site/docs/development/architecture.md
@@ -38,12 +38,22 @@ terratidy/
 │       ├── style.go         # Style command
 │       ├── lint.go          # Lint command
 │       ├── policy.go        # Policy command
+│       ├── fix.go           # Fix command
+│       ├── dev.go           # Dev (file watcher) command
+│       ├── init.go          # Init (scaffold .terratidy.yaml) command
+│       ├── init_rule.go     # Init rule (scaffold a rule)
+│       ├── version.go       # Version command
+│       ├── rules.go         # Rules (list/show) command
+│       ├── config.go        # Config (show/validate) command
+│       ├── plugins.go       # Plugins (list/check) command
+│       ├── helpers.go       # Shared CLI helpers
+│       ├── test_rule.go     # Test-rule command
 │       └── lsp.go           # LSP server command
 ├── internal/
-│   ├── runner/              # Engine runner, parallel execution
-│   │   └── runner.go        # Engine interface, Runner struct
+│   ├── annotations/         # Suppression annotation parsing and filtering
+│   ├── buildinfo/           # Build information and versioning
+│   ├── cache/               # Caching layer
 │   ├── config/              # Configuration loading
-│   ├── output/              # Output formatting
 │   ├── cst/                 # Concrete Syntax Tree (structural fix substrate)
 │   ├── engines/             # Engine implementations
 │   │   ├── fmt/             # Format engine
@@ -51,23 +61,30 @@ terratidy/
 │   │   ├── lint/            # Lint engine
 │   │   └── policy/          # Policy engine
 │   ├── lsp/                 # Language server
-│   └── plugins/             # Plugin system
+│   ├── output/              # Output formatting
+│   ├── plugins/             # Plugin system
+│   ├── runner/              # Engine runner, parallel execution
+│   │   └── runner.go        # Runner struct, engine orchestration
+│   └── vcs/                 # Git integration (--changed flag)
 ├── pkg/
 │   └── sdk/                 # Public SDK
-│       └── types.go         # Rule interface, Finding, Context types
+│       └── types.go         # Engine, Rule, Fixer interfaces; Finding, Context types
 └── docs/                    # Documentation
 ```
+
+The canonical layout lives in `CLAUDE.md` at the repo root; update both whenever
+packages move so the tree here stays in sync.
 
 ## Core Components
 
 ### Engine Interface
 
-All engines implement the `Engine` interface defined in `internal/runner/runner.go`:
+All engines implement the `Engine` interface defined in `pkg/sdk/types.go`:
 
 ```go
 type Engine interface {
     Name() string
-    Run(ctx context.Context, files []string) ([]sdk.Finding, error)
+    Run(ctx context.Context, files []string) ([]Finding, error)
 }
 ```
 
@@ -103,7 +120,8 @@ printing it as plain text.
 
 ### Runner
 
-The runner coordinates engine execution:
+The runner coordinates engine execution. `Run` returns a flat slice of findings
+and stops at the first engine error:
 
 ```go
 type Runner struct {
@@ -119,11 +137,34 @@ func (r *Runner) Run(ctx context.Context, files []string) ([]sdk.Finding, error)
 }
 ```
 
+`RunWithResults` returns per-engine results so callers can render output and
+exit codes per engine even when one fails:
+
+```go
+type EngineResult struct {
+    Engine   string
+    Findings []sdk.Finding
+    Error    error
+}
+
+func (r *Runner) RunWithResults(ctx context.Context, files []string) []EngineResult {
+    if r.parallel {
+        return r.runParallelWithResults(ctx, files)
+    }
+    return r.runSequentialWithResults(ctx, files)
+}
+```
+
+`Run` is for callers that only need a combined findings slice; `RunWithResults`
+is what `cmd/terratidy/check.go` actually invokes, because the CLI reports
+issue counts per engine.
+
 ## Engine Implementations
 
 ### Format Engine
 
-Uses the HCL formatter:
+Uses the HCL formatter. The snippets below are simplified pseudo-code for
+readability; the production code lives in `internal/engines/format/`:
 
 ```go
 func (e *FmtEngine) Run(ctx context.Context, files []string) ([]Finding, error) {
@@ -133,7 +174,7 @@ func (e *FmtEngine) Run(ctx context.Context, files []string) ([]Finding, error) 
 
         if !bytes.Equal(content, formatted) {
             findings = append(findings, Finding{
-                Rule:    "fmt",
+                Rule:    "fmt.needs-formatting",
                 Message: "File is not formatted",
                 File:    file,
                 Fixable: true,
@@ -146,16 +187,20 @@ func (e *FmtEngine) Run(ctx context.Context, files []string) ([]Finding, error) 
 
 ### Style Engine
 
-Implements custom style rules:
+Implements custom style rules. Simplified pseudo-code:
 
 ```go
 func (e *StyleEngine) Run(ctx context.Context, files []string) ([]Finding, error) {
     for _, file := range files {
-        ast, _ := hclparse.ParseHCLFile(file)
+        parsed, _ := hclparse.NewParser().ParseHCLFile(file)
 
         for _, rule := range e.rules {
             if e.config.IsRuleEnabled(rule.Name()) {
-                findings = append(findings, rule.Check(ast)...)
+                // sdk.Context embeds context.Context and adds per-file fields
+                // like File and AllFiles; the real engine builds one per file.
+                ruleCtx := &sdk.Context{Context: ctx, File: file}
+                ruleFindings, _ := rule.Check(ruleCtx, parsed)
+                findings = append(findings, ruleFindings...)
             }
         }
     }

--- a/docs/site/docs/getting-started/configuration.md
+++ b/docs/site/docs/getting-started/configuration.md
@@ -33,11 +33,14 @@ Each engine can be enabled/disabled and configured:
 engines:
   fmt:
     enabled: true
+    check: false   # Report formatting issues without modifying files
+    diff: false    # Show diff of formatting changes
 
   style:
     enabled: true
-    fix: false  # Auto-fix mode
-    rules:      # Rule configuration goes under each engine
+    fix: false     # Auto-fix mode
+    diff: false    # Show diff of style fixes
+    rules:         # Rule configuration goes under each engine
       style.block-label-case:
         enabled: true
         severity: warning
@@ -45,12 +48,40 @@ engines:
   lint:
     enabled: true
     config_file: .tflint.hcl  # Path to TFLint config
+    args:                     # Extra arguments forwarded to the TFLint subprocess
+      - --force
 
   policy:
     enabled: true
     policy_dirs:
       - ./policies
+    policy_files:             # Individual policy files (in addition to policy_dirs)
+      - ./custom-policy.rego
+    data_files:               # JSON/YAML data files passed to policy evaluation
+      - ./policy-data.json
 ```
+
+### Engine Options Reference
+
+| Engine   | Option         | Type     | Default | Purpose |
+| -------- | -------------- | -------- | ------- | ------- |
+| `fmt`    | `enabled`      | bool     | `true`  | Enable the format engine |
+| `fmt`    | `check`        | bool     | `false` | Report formatting issues without rewriting files; mirrored by the `--check` CLI flag |
+| `fmt`    | `diff`         | bool     | `false` | Print a unified diff of the format changes that would be applied |
+| `style`  | `enabled`      | bool     | `true`  | Enable the style engine |
+| `style`  | `fix`          | bool     | `false` | Apply auto-fixes for rules that implement `sdk.Fixer` |
+| `style`  | `diff`         | bool     | `false` | Print a unified diff of the fixes that would be applied |
+| `lint`   | `enabled`      | bool     | `true`  | Enable the lint engine ([engine docs](../user-guide/engines/lint.md)) |
+| `lint`   | `use_tflint`   | bool     | `false` | Invoke TFLint as a subprocess in addition to the built-in rules |
+| `lint`   | `tflint_path`  | string   | `""`    | Custom TFLint binary path (defaults to `tflint` on `PATH`) |
+| `lint`   | `fallback_builtin` | bool | `false` | Fall back to built-in rules when TFLint is unavailable (recommended: `true`) |
+| `lint`   | `config_file`  | string   | `""`    | Path to a TFLint config file (`.tflint.hcl`) |
+| `lint`   | `plugins`      | []string | `[]`    | TFLint plugins to enable when `use_tflint: true` |
+| `lint`   | `args`         | []string | `[]`    | Extra arguments forwarded to the TFLint subprocess |
+| `policy` | `enabled`      | bool     | `false` | Enable the policy engine ([engine docs](../user-guide/engines/policy.md)) |
+| `policy` | `policy_dirs`  | []string | `[]`    | Directories containing Rego policy files |
+| `policy` | `policy_files` | []string | `[]`    | Individual Rego files to evaluate (in addition to `policy_dirs`) |
+| `policy` | `data_files`   | []string | `[]`    | JSON/YAML data files passed to policy evaluation |
 
 ## Configuration Precedence
 
@@ -195,6 +226,9 @@ plugins:
     - ~/.terratidy/plugins
     - ./plugins
   verify_integrity: true  # Verify plugin checksums (default: true)
+  tags:                   # Only load rules matching these tags (empty = load all)
+    - aws
+    - production
 ```
 
 ### Plugin Rule Configuration
@@ -215,6 +249,22 @@ plugins:
 ```
 
 Plugin rules not listed in `plugins.rules` use their defaults (enabled with their defined severity).
+
+### Plugin Tag Filtering
+
+Set `plugins.tags` to load only the plugin rules tagged with one or more of the
+listed values. An empty list (the default) loads every rule. Rules that do not
+expose tags are skipped while a filter is active.
+
+```yaml
+plugins:
+  enabled: true
+  directories:
+    - ./plugins
+  tags:
+    - aws        # Load rules tagged "aws"
+    - security   # ...or "security"
+```
 
 ### Plugin Integrity Verification
 
@@ -434,11 +484,13 @@ engines:
     enabled: true
     use_tflint: false           # Enable TFLint integration (default: false)
     tflint_path: ""             # Custom path to TFLint binary (optional)
-    fallback_builtin: true      # Use built-in rules if TFLint unavailable (default: true)
+    fallback_builtin: true      # Use built-in rules if TFLint unavailable (default: false; recommended on)
     config_file: .tflint.hcl    # Path to TFLint config (optional)
     plugins:                     # TFLint plugins to enable (optional)
       - aws
       - terraform
+    args:                        # Extra arguments forwarded to the TFLint subprocess
+      - --force
 ```
 
 Built-in rules work without TFLint. If TFLint is installed and configured, provider-specific

--- a/docs/site/docs/user-guide/commands.md
+++ b/docs/site/docs/user-guide/commands.md
@@ -29,7 +29,7 @@ All commands use consistent exit codes for scripting and CI/CD:
 | `2`  | Configuration error (invalid config file, missing required config, plugin loading failure) |
 | `3`  | Internal error (engine failure, filesystem errors, unexpected issues) |
 
-The `--check` flag on `fmt` and `style` exits with code 1 if any issues are found.
+The `--check` flag on `fmt` and `style` exits with code 1 if any issues are found (findings at or above `severity_threshold`).
 The `check` command exits with code 1 when error-severity findings are present.
 
 **Scripting example:**
@@ -260,11 +260,11 @@ terratidy fmt [paths...] [flags]
 
 **Flags:**
 
-| Flag      | Description                                              |
-| --------- | -------------------------------------------------------- |
-| `--check` | Check formatting without modifying                       |
-| `--diff`  | Show diff of changes                                     |
-| `--all`   | Also apply style fixes (equivalent to fmt + style --fix) |
+| Flag      | Description |
+| --------- | ----------- |
+| `--check` | Check formatting without modifying |
+| `--diff`  | Show diff of changes |
+| `--all`   | Also run style engine alongside fmt (fixes in default mode, checks with `--check`) |
 
 **`--diff` behavior:**
 

--- a/examples/terratidy.yaml
+++ b/examples/terratidy.yaml
@@ -140,6 +140,10 @@ plugins:
   directories:
     - .terratidy/plugins
     - ~/.terratidy/plugins
+  # verify_integrity: true   # Verify plugin SHA256 checksums (default: true)
+  # tags:                    # Only load rules matching these tags (empty = load all)
+  #   - aws
+  #   - production
   # Per-plugin rule configuration (enable/disable, severity override)
   rules:
     require-description:


### PR DESCRIPTION
## What and why

Refresh three docs pages that had drifted from the code, and mirror the new defaults in `examples/terratidy.yaml`.

- **architecture.md** — point the `Engine` interface ref at `pkg/sdk` (its actual home), expand the `cmd/terratidy` and `internal/` trees to match `CLAUDE.md`, mark engine snippets as pseudo-code, and show the real `Rule.Check` signature plus the `fmt.needs-formatting` rule ID. Adds a `RunWithResults` snippet next to `Run`.
- **configuration.md** — add an Engine Options Reference table that covers every option (`enabled`, `check`, `diff`, `fix`, `use_tflint`, `args`, `policy_files`, `data_files`, …) with type, default, and purpose. Expand the `engines.*` YAML examples, add a Plugin Tag Filtering section, and fix the stale `lint.fallback_builtin` default (docs said `true`; code defaults to `false`).
- **commands.md** — restate `fmt --all` so it matches `cmd/terratidy/fmt.go` (also runs the style engine — fixes by default, checks under `--check`), and append a `severity_threshold` caveat to the fmt/style `--check` exit-code line. The `check` command's exit code already gates strictly on `error` severity and is unchanged.
- **examples/terratidy.yaml** — mirror `plugins.tags` and `plugins.verify_integrity` as commented defaults so the example matches the documented schema.

**Why:** the pages were silently lagging the actual interfaces in `pkg/sdk/types.go`, the runner orchestration in `internal/runner/runner.go`, and the CLI flag behavior in `cmd/terratidy/`. Contributors reading the docs were getting wrong defaults and missing engine/plugin keys.

## How to test

Docs-only change — no behavior change to verify. To sanity-check:

- Render the site: `mise run docs:serve` and open the three pages.
- Spot-check the Engine Options Reference table against `internal/config/config.go` defaults.
- Confirm `examples/terratidy.yaml` still parses: `mise run build && ./bin/terratidy check examples/`.

## Notes for reviewers

- No code, test, or workflow changes — only `docs/site/docs/**` and one `examples/` file.
- The `lint.fallback_builtin` flip from `true` → `false` is a docs correction, not a behavior change; the code already defaults to `false`.
- `mise run check` was not re-run because nothing under `internal/`, `pkg/`, or `cmd/` was touched.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works (n/a — docs only)
- [ ] All checks pass (`mise run check` runs fmt, vet, lint, and test) (n/a — docs only)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
