### PR TITLE
refactor(lsp,vscode): remove dead on-save settings

### DIFF
--- a/docs/site/docs/integrations/lsp.md
+++ b/docs/site/docs/integrations/lsp.md
@@ -195,10 +195,7 @@ The server reads these options from the client's `initializationOptions`:
       "lint": true,
       "policy": false
     },
-    "severityThreshold": "warning",
-    "formatOnSave": false,
-    "runOnSave": false,
-    "fixOnSave": false
+    "severityThreshold": "warning"
   }
 }
 ```

--- a/docs/site/docs/integrations/vscode.md
+++ b/docs/site/docs/integrations/vscode.md
@@ -118,15 +118,6 @@ Configure in VS Code settings (`Ctrl+,` / `Cmd+,`):
   // Configuration profile to use
   "terratidy.profile": "",
 
-  // Run checks on save (default: false)
-  "terratidy.runOnSave": false,
-
-  // Format on save (default: false)
-  "terratidy.formatOnSave": false,
-
-  // Auto-fix on save
-  "terratidy.fixOnSave": false,
-
   // Enable/disable engines
   "terratidy.engines.fmt": true,
   "terratidy.engines.style": true,
@@ -140,6 +131,19 @@ Configure in VS Code settings (`Ctrl+,` / `Cmd+,`):
   "terratidy.trace.server": "off"
 }
 ```
+
+### Severity Threshold
+
+`terratidy.severityThreshold` is forwarded to the language server only when
+you have written the key into your workspace, workspace folder, or user
+`settings.json`. If you have not set it there, the extension omits the value
+and the LSP server falls back to `severity_threshold:` in `.terratidy.yaml`
+(see [Configuration](../getting-started/configuration.md#severity_threshold)).
+
+To let VS Code control the threshold instead of `.terratidy.yaml`, add the
+key to one of those `settings.json` files. Even setting it to the value
+shown in the Settings UI counts as an explicit override and takes precedence
+over `.terratidy.yaml`.
 
 ## Workspace Settings
 
@@ -220,7 +224,6 @@ For large projects:
 
 ```json
 {
-  "terratidy.runOnSave": false,
   "terratidy.engines.lint": false
 }
 ```

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -631,8 +631,6 @@ func TestServer_HandleInitialize_WithOptions(t *testing.T) {
 				Lint:   false,
 				Policy: true,
 			},
-			FormatOnSave: true,
-			RunOnSave:    true,
 		},
 	}
 	paramsJSON, _ := json.Marshal(params)
@@ -654,7 +652,6 @@ func TestServer_HandleInitialize_WithOptions(t *testing.T) {
 	assert.True(t, server.initOptions.Engines.Fmt)
 	assert.True(t, server.initOptions.Engines.Policy)
 	assert.False(t, server.initOptions.Engines.Lint)
-	assert.True(t, server.initOptions.FormatOnSave)
 
 	// Severity threshold should be applied to config
 	assert.Equal(t, "error", server.config.SeverityThreshold)
@@ -1040,9 +1037,6 @@ engines:
 //	terratidy.engines.lint      -> engines.lint
 //	terratidy.engines.policy    -> engines.policy
 //	terratidy.severityThreshold -> severityThreshold
-//	terratidy.formatOnSave      -> formatOnSave
-//	terratidy.runOnSave         -> runOnSave
-//	terratidy.fixOnSave         -> fixOnSave
 //
 // Settings NOT sent to LSP:
 //
@@ -1059,10 +1053,7 @@ func TestVSCodeSettings_MapsToLSPOptions(t *testing.T) {
 			"lint": false,
 			"policy": true
 		},
-		"severityThreshold": "warning",
-		"formatOnSave": true,
-		"runOnSave": false,
-		"fixOnSave": true
+		"severityThreshold": "warning"
 	}`
 
 	var opts InitializationOptions
@@ -1077,9 +1068,6 @@ func TestVSCodeSettings_MapsToLSPOptions(t *testing.T) {
 	assert.False(t, opts.Engines.Lint)
 	assert.True(t, opts.Engines.Policy)
 	assert.Equal(t, "warning", opts.SeverityThreshold)
-	assert.True(t, opts.FormatOnSave)
-	assert.False(t, opts.RunOnSave)
-	assert.True(t, opts.FixOnSave)
 }
 
 // TestServer_ConfigChangesOnRestart verifies that when the LSP server is
@@ -1158,10 +1146,7 @@ func TestVSCodeSettings_EmptyValues(t *testing.T) {
 			"style": true,
 			"lint": true,
 			"policy": false
-		},
-		"formatOnSave": false,
-		"runOnSave": false,
-		"fixOnSave": false
+		}
 	}`
 
 	var opts InitializationOptions

--- a/internal/lsp/types.go
+++ b/internal/lsp/types.go
@@ -55,9 +55,6 @@ type InitializationOptions struct {
 	ConfigPath        string        `json:"configPath,omitempty"`
 	Engines           EngineToggles `json:"engines"`
 	SeverityThreshold string        `json:"severityThreshold,omitempty"`
-	FormatOnSave      bool          `json:"formatOnSave,omitempty"`
-	RunOnSave         bool          `json:"runOnSave,omitempty"`
-	FixOnSave         bool          `json:"fixOnSave,omitempty"`
 }
 
 // EngineToggles represents which engines are enabled

--- a/internal/lsp/types_test.go
+++ b/internal/lsp/types_test.go
@@ -25,19 +25,13 @@ func TestInitializationOptions_JSONParsing(t *testing.T) {
 					"lint": true,
 					"policy": false
 				},
-				"severityThreshold": "error",
-				"formatOnSave": true,
-				"runOnSave": false,
-				"fixOnSave": true
+				"severityThreshold": "error"
 			}`,
 			expected: InitializationOptions{
 				Profile:           "production",
 				ConfigPath:        "/path/to/config.yaml",
 				Engines:           EngineToggles{Fmt: true, Style: false, Lint: true, Policy: false},
 				SeverityThreshold: "error",
-				FormatOnSave:      true,
-				RunOnSave:         false,
-				FixOnSave:         true,
 			},
 		},
 		{

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -59,9 +59,6 @@ This extension contributes the following settings:
 | `terratidy.executablePath` | `""` | Path to the terratidy executable |
 | `terratidy.configPath` | `""` | Path to terratidy configuration file |
 | `terratidy.profile` | `""` | Configuration profile to use |
-| `terratidy.runOnSave` | `false` | Run TerraTidy checks when saving |
-| `terratidy.formatOnSave` | `false` | Format files on save |
-| `terratidy.fixOnSave` | `false` | Auto-fix issues on save |
 | `terratidy.engines.fmt` | `true` | Enable format engine |
 | `terratidy.engines.style` | `true` | Enable style engine |
 | `terratidy.engines.lint` | `true` | Enable lint engine |
@@ -182,8 +179,6 @@ For the best experience, add these settings to your `settings.json`:
 
 ```json
 {
-  "terratidy.runOnSave": true,
-  "terratidy.formatOnSave": true,
   "[terraform]": {
     "editor.defaultFormatter": "santosr2.vscode-terratidy",
     "editor.formatOnSave": true

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -81,21 +81,6 @@
 					"default": "",
 					"description": "Configuration profile to use."
 				},
-				"terratidy.runOnSave": {
-					"type": "boolean",
-					"default": false,
-					"description": "Run TerraTidy checks when saving a file."
-				},
-				"terratidy.formatOnSave": {
-					"type": "boolean",
-					"default": false,
-					"description": "Format Terraform files on save using TerraTidy."
-				},
-				"terratidy.fixOnSave": {
-					"type": "boolean",
-					"default": false,
-					"description": "Auto-fix issues on save."
-				},
 				"terratidy.engines.fmt": {
 					"type": "boolean",
 					"default": true,

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -253,9 +253,6 @@ export function getInitializationOptions(): Record<string, unknown> {
     configPath: config.get<string>('configPath') || undefined,
     engines: engines,
     severityThreshold: severityThreshold,
-    formatOnSave: config.get<boolean>('formatOnSave', false),
-    runOnSave: config.get<boolean>('runOnSave', false),
-    fixOnSave: config.get<boolean>('fixOnSave', false),
   };
 }
 

--- a/vscode/src/test/configuration.test.ts
+++ b/vscode/src/test/configuration.test.ts
@@ -7,9 +7,6 @@ suite('Configuration', () => {
 
     assert.ok(typeof options === 'object', 'Should return an object');
     assert.ok('engines' in options, 'Should have engines');
-    assert.ok('formatOnSave' in options, 'Should have formatOnSave');
-    assert.ok('runOnSave' in options, 'Should have runOnSave');
-    assert.ok('fixOnSave' in options, 'Should have fixOnSave');
   });
 
   test('engines have correct defaults', () => {
@@ -29,13 +26,6 @@ suite('Configuration', () => {
     assert.strictEqual(options.severityThreshold, undefined);
   });
 
-  test('save options default to false', () => {
-    const options = getInitializationOptions();
-    assert.strictEqual(options.formatOnSave, false);
-    assert.strictEqual(options.runOnSave, false);
-    assert.strictEqual(options.fixOnSave, false);
-  });
-
   /**
    * This test documents the mapping between VSCode settings and LSP InitializationOptions.
    * The mapping must match what the LSP server expects in internal/lsp/types.go.
@@ -48,9 +38,6 @@ suite('Configuration', () => {
    *   terratidy.engines.lint      -> engines.lint (boolean)
    *   terratidy.engines.policy    -> engines.policy (boolean)
    *   terratidy.severityThreshold -> severityThreshold (string, only if explicitly set)
-   *   terratidy.formatOnSave      -> formatOnSave (boolean)
-   *   terratidy.runOnSave         -> runOnSave (boolean)
-   *   terratidy.fixOnSave         -> fixOnSave (boolean)
    *
    * Settings NOT sent to LSP:
    *   terratidy.executablePath    -> used by extension to locate binary
@@ -60,15 +47,7 @@ suite('Configuration', () => {
     const options = getInitializationOptions();
 
     // These keys must match the JSON field names in internal/lsp/types.go InitializationOptions
-    const expectedKeys = [
-      'profile',
-      'configPath',
-      'engines',
-      'severityThreshold',
-      'formatOnSave',
-      'runOnSave',
-      'fixOnSave',
-    ];
+    const expectedKeys = ['profile', 'configPath', 'engines', 'severityThreshold'];
 
     for (const key of expectedKeys) {
       assert.ok(key in options, `Missing LSP option: ${key}`);

--- a/vscode/src/test/settings-behavior.test.ts
+++ b/vscode/src/test/settings-behavior.test.ts
@@ -122,59 +122,6 @@ suite('Settings Behavior', () => {
     }
   });
 
-  // Test: formatOnSave setting is reflected in initialization options
-  // Note: Default value test is in configuration.test.ts
-  test('formatOnSave: update reflected in initialization options', async function () {
-    this.timeout(10000);
-    assert.ok(ext, 'Extension should be activated');
-
-    try {
-      // Enable formatOnSave
-      await updateConfig('formatOnSave', true);
-
-      // getInitializationOptions reads config synchronously - no wait needed
-      const options = getInitializationOptions();
-      assert.strictEqual(options.formatOnSave, true, 'formatOnSave should be true when enabled');
-    } finally {
-      await resetConfig('formatOnSave');
-    }
-  });
-
-  // Test: fixOnSave setting is reflected in initialization options
-  // Note: Default value test is in configuration.test.ts
-  test('fixOnSave: update reflected in initialization options', async function () {
-    this.timeout(10000);
-    assert.ok(ext, 'Extension should be activated');
-
-    try {
-      // Enable fixOnSave
-      await updateConfig('fixOnSave', true);
-
-      const options = getInitializationOptions();
-      assert.strictEqual(options.fixOnSave, true, 'fixOnSave should be true when enabled');
-    } finally {
-      await resetConfig('fixOnSave');
-    }
-  });
-
-  // Test: runOnSave setting is reflected in initialization options
-  // Note: Default value test is in configuration.test.ts
-  // Note: Actual "triggers diagnostics on save" behavior requires LSP server
-  test('runOnSave: update reflected in initialization options', async function () {
-    this.timeout(10000);
-    assert.ok(ext, 'Extension should be activated');
-
-    try {
-      // Enable runOnSave
-      await updateConfig('runOnSave', true);
-
-      const options = getInitializationOptions();
-      assert.strictEqual(options.runOnSave, true, 'runOnSave should be true when enabled');
-    } finally {
-      await resetConfig('runOnSave');
-    }
-  });
-
   // Test: profile setting is reflected in initialization options
   // Note: Default value test is in configuration.test.ts
   test('profile: update reflected in initialization options', async function () {
@@ -206,36 +153,6 @@ suite('Settings Behavior', () => {
       assert.strictEqual(options.severityThreshold, 'error', 'severityThreshold should be set to error');
     } finally {
       await resetConfig('severityThreshold');
-    }
-  });
-
-  // Test: multiple settings changes don't cause issues
-  test('multiple settings changes: handled gracefully', async function () {
-    this.timeout(20000);
-    assert.ok(ext, 'Extension should be activated');
-
-    try {
-      // Change multiple settings in rapid succession
-      await updateConfig('profile', 'test-profile');
-      await updateConfig('engines.lint', false);
-      await updateConfig('formatOnSave', true);
-      await updateConfig('fixOnSave', true);
-
-      // All changes should be reflected (synchronous read)
-      const options = getInitializationOptions();
-      assert.strictEqual(options.profile, 'test-profile', 'profile should be updated');
-      assert.strictEqual((options.engines as Record<string, boolean>).lint, false, 'lint should be disabled');
-      assert.strictEqual(options.formatOnSave, true, 'formatOnSave should be enabled');
-      assert.strictEqual(options.fixOnSave, true, 'fixOnSave should be enabled');
-
-      // Extension should still be active
-      assert.strictEqual(ext.isActive, true, 'Extension should remain active');
-    } finally {
-      // Reset all settings
-      await resetConfig('profile');
-      await resetConfig('engines.lint');
-      await resetConfig('formatOnSave');
-      await resetConfig('fixOnSave');
     }
   });
 


### PR DESCRIPTION
## What and why

Remove the `terratidy.formatOnSave`, `terratidy.runOnSave`, and `terratidy.fixOnSave` settings from the VSCode extension and the matching `FormatOnSave`, `RunOnSave`, `FixOnSave` fields from the LSP server's `InitializationOptions`. The extension forwarded these values to the server, the server stored them on the init options struct, and nothing read them afterwards — no save handler, no formatting trigger, no fixer hook. Tests asserted only that the fields round-tripped.

**Why:** Settings shown in the VSCode UI that do nothing are worse than missing settings; users toggle them, nothing happens, and they file a bug. Cleaner to drop the surface until a save pipeline actually exists.

Also added a short section to the VSCode integration docs explaining when `terratidy.severityThreshold` is forwarded to the LSP server (only when explicitly written into a `settings.json`), since that behavior is non-obvious from the Settings UI.

## How to test

- `mise run test` passes locally; golangci-lint and biome clean via pre-commit.
- `cd vscode && bun run compile && bun run test` — extension build and mocha suite should run green in CI (not exercised in the headless dev shell).
- Open VSCode settings UI and confirm `terratidy.formatOnSave`, `runOnSave`, `fixOnSave` no longer appear.
- Set `terratidy.severityThreshold` in `settings.json`, restart the LSP server, confirm the threshold is applied; remove it and confirm `.terratidy.yaml`'s `severity_threshold:` takes over.

## Notes for reviewers

- Breaking change to the extension's setting surface. Acceptable pre-v1.0; no migration shim added per project policy.
- LSP `InitializationOptions` shrinks by three fields. Any out-of-tree clients sending these keys will see them silently ignored by the JSON decoder, which is the same behavior they get today.
- Doc addition is intentionally scoped to severity forwarding so the page doesn't grow a section about every now-removed setting.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
