### PR TITLE
refactor(style): make snake_case explicit in naming case switch

### DIFF
--- a/internal/engines/style/rules/helpers.go
+++ b/internal/engines/style/rules/helpers.go
@@ -331,6 +331,8 @@ func GetNamingConventionFromConfig(config map[string]any) (NamingCase, string) {
 	convention := SnakeCase
 	if caseStr, ok := options["case"].(string); ok {
 		switch caseStr {
+		case "snake_case":
+			convention = SnakeCase
 		case "camelCase":
 			convention = CamelCase
 		case "kebab-case":


### PR DESCRIPTION
## What and why

Add an explicit `case "snake_case"` branch to the naming-convention switch in `GetNamingConventionFromConfig`. Previously `snake_case` worked only via the `default` fallthrough (which also assigns `SnakeCase`), so the switch left readers guessing which values were actually accepted.

**Why:** Self-documenting config parsing. Enumerating every accepted value next to the other conventions (`camelCase`, `kebab-case`, `PascalCase`, `custom`) makes the schema obvious without cross-referencing the default arm.

## How to test

No behavior change — `snake_case` maps to `SnakeCase` before and after. Existing style-engine tests exercise this path via naming rules.

```bash
mise run check
```

## Notes for reviewers

- Two-line addition, no functional change.
- `default` still returns `SnakeCase` so any unrecognized value keeps the historical fallback behavior.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works <!-- N/A: no behavior change -->
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test)
- [x] I have updated documentation as needed <!-- N/A: no user-facing surface -->
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
