### PR TITLE
ci(fuzz,benchmark): scope pull-requests: write to job level

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,7 +13,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 concurrency:
   group: ci-benchmark-${{ github.head_ref || github.ref }}
@@ -27,6 +26,9 @@ jobs:
       (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'benchmark'))
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -11,7 +11,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 concurrency:
   group: ci-fuzz-${{ github.head_ref || github.ref }}
@@ -25,6 +24,9 @@ jobs:
       (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'fuzz'))
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
## What and why

Move `pull-requests: write` in the `fuzz` and `benchmark` workflows from workflow scope to the single job in each file that posts the PR comment. Top-level `permissions:` stays at `contents: read`.

**Why:** having `pull-requests: write` at workflow scope grants the token to every present and future job unconditionally. Each workflow currently has only one job, so the runtime token surface is unchanged today — but the scope-down means any future second job (a triage step, an artifact upload, a housekeeping task) starts from `contents: read` instead of silently inheriting write. Cheap defense-in-depth, no behavior change.

## How to test

Local, before merge:

```bash
zizmor .github/workflows/fuzz.yml .github/workflows/benchmark.yml
# expected: "No findings to report. Good job! (4 suppressed)"
```

Post-merge:

- Next PR labeled `benchmark` should still post the benchmark comment (and update it on re-runs).
- Next PR labeled `fuzz` should still post the fuzz comment.

Both comment steps are guarded by `if: github.event_name == 'pull_request'`, so scheduled fuzz runs and push-to-main benchmark runs never exercise the write scope regardless of where it lives.

## Notes for reviewers

Workflow-level `contents: read` is now formally redundant with the job-level block (both jobs re-declare `contents: read`), but leaving it matches the pattern in `docs.yml`, `vscode.yml`, `security.yml`, `release.yml`, and `scorecard.yml`, and acts as a safe default for any future job that omits its own permissions block. Not worth removing.

Block form (multi-line) is used for the new job-level `permissions:` blocks to match the rest of the repo's workflow style.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works — N/A, CI-only workflow permission scope reduction; `zizmor` covers this.
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test) — no Go code touched; pre-commit hooks (actionlint, zizmor, yamllint, conventional commit) passed on commit.
- [x] I have updated documentation as needed — no docs catalog per-job permission scopes; nothing to update.
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
