### PR TITLE
ci: harden scorecard concurrency and document test cache choice

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -8,6 +8,10 @@ on:
 
 permissions: read-all
 
+concurrency:
+  group: scorecard-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   scorecard:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,11 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: ${{ matrix.go-version }}
+          # cache: true (default) is intentional here; the test job's matrix
+          # (3 OSes x 2 Go versions) is the hottest in CI and cache keys are
+          # isolated per Go version, bounding poisoning risk. Other workflows
+          # disable cache to avoid poisoning: vscode.yml and security.yml on
+          # every push/PR, release.yml on tag-triggered release builds.
 
       - name: Download dependencies
         run: go mod download


### PR DESCRIPTION
## What and why

Two small CI workflow refinements:

- **scorecard.yml** — add a `concurrency` group keyed on `github.ref` with `cancel-in-progress: true`, so a newer push to a ref cancels the in-progress scorecard run.
- **test.yml** — add a comment documenting why the Go build cache stays enabled here (cache keys are isolated per Go version, bounding poisoning risk) while vscode/security/release workflows disable it.

**Why:** Cuts redundant scorecard CI runs and records the reasoning behind an intentional cache-enabled/cache-disabled split so future workflow edits don't "fix" it by mistake.

## How to test

- Push a second commit to this branch and confirm the earlier scorecard run is cancelled.
- CI passes on this PR (workflow lint / zizmor / yamllint already pass locally via pre-commit).

## Notes for reviewers

Documentation/hardening only. No code, no runtime behavior, no public API changes. The test.yml change is a comment; scorecard.yml adds concurrency control.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works <!-- N/A: CI config only -->
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test)
- [ ] I have updated documentation as needed <!-- N/A -->
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
