### PR TITLE
refactor: drop error returns from functions that never fail

### DIFF
--- a/cmd/terratidy/dev.go
+++ b/cmd/terratidy/dev.go
@@ -107,7 +107,8 @@ func runFileWatcher() error {
 	fmt.Println("Watching for changes... (Ctrl+C to stop)")
 	fmt.Println()
 
-	return runWatchLoop(watcher)
+	runWatchLoop(watcher)
+	return nil
 }
 
 func setupWatchDirs(watcher *fsnotify.Watcher) error {
@@ -138,7 +139,7 @@ func setupWatchDirs(watcher *fsnotify.Watcher) error {
 	return nil
 }
 
-func runWatchLoop(watcher *fsnotify.Watcher) error {
+func runWatchLoop(watcher *fsnotify.Watcher) {
 	var debounceTimer *time.Timer
 	debounceDelay := 500 * time.Millisecond
 
@@ -146,13 +147,13 @@ func runWatchLoop(watcher *fsnotify.Watcher) error {
 		select {
 		case event, ok := <-watcher.Events:
 			if !ok {
-				return nil
+				return
 			}
 			debounceTimer = handleWatchEvent(event, debounceTimer, debounceDelay)
 
 		case err, ok := <-watcher.Errors:
 			if !ok {
-				return nil
+				return
 			}
 			fmt.Printf("Watcher error: %v\n", err)
 		}

--- a/internal/engines/policy/policy.go
+++ b/internal/engines/policy/policy.go
@@ -141,22 +141,10 @@ func (e *Engine) Run(ctx context.Context, files []string) ([]sdk.Finding, error)
 
 		// Parse and convert all files in the module to JSON representation
 		// Also collect suppression annotations per file
-		moduleData, fileSuppressions, err := e.parseModuleToJSONWithSuppressions(dirFileList)
-		if err != nil {
-			allFindings = append(allFindings, sdk.Finding{
-				Rule:     "policy.parse-error",
-				Message:  fmt.Sprintf("Failed to parse module: %v", err),
-				File:     dir,
-				Severity: sdk.SeverityError,
-			})
-			continue
-		}
+		moduleData, fileSuppressions := e.parseModuleToJSONWithSuppressions(dirFileList)
 
 		// Evaluate policies against the module data
-		findings, err := e.evaluatePolicies(ctx, policies, moduleData, dir, dataStore)
-		if err != nil {
-			return nil, fmt.Errorf("evaluating policies for %s: %w", dir, err)
-		}
+		findings := e.evaluatePolicies(ctx, policies, moduleData, dir, dataStore)
 
 		// Filter findings based on per-file suppression annotations
 		findings = e.filterSuppressedFindings(findings, fileSuppressions)
@@ -246,18 +234,18 @@ func (e *Engine) loadDataFiles() (storage.Store, error) {
 }
 
 // parseModuleToJSON parses Terraform files and converts to JSON representation for OPA
-func (e *Engine) parseModuleToJSON(files []string) (map[string]any, error) {
+func (e *Engine) parseModuleToJSON(files []string) map[string]any {
 	moduleData := newModuleData()
 
 	for _, file := range files {
 		e.parseFileIntoModule(file, moduleData)
 	}
 
-	return moduleData, nil
+	return moduleData
 }
 
 // parseModuleToJSONWithSuppressions parses files and also collects suppression annotations
-func (e *Engine) parseModuleToJSONWithSuppressions(files []string) (map[string]any, map[string][]annotations.Suppression, error) {
+func (e *Engine) parseModuleToJSONWithSuppressions(files []string) (map[string]any, map[string][]annotations.Suppression) {
 	moduleData := newModuleData()
 	fileSuppressions := make(map[string][]annotations.Suppression)
 
@@ -274,7 +262,7 @@ func (e *Engine) parseModuleToJSONWithSuppressions(files []string) (map[string]a
 		e.parseFileIntoModule(file, moduleData)
 	}
 
-	return moduleData, fileSuppressions, nil
+	return moduleData, fileSuppressions
 }
 
 // filterSuppressedFindings filters findings based on per-file suppression annotations
@@ -436,7 +424,7 @@ func (e *Engine) evaluatePolicies(
 	moduleData map[string]any,
 	dir string,
 	dataStore storage.Store,
-) ([]sdk.Finding, error) {
+) []sdk.Finding {
 	var findings []sdk.Finding
 
 	evalCtx := &policyEvalContext{
@@ -452,7 +440,7 @@ func (e *Engine) evaluatePolicies(
 		findings = append(findings, policyFindings...)
 	}
 
-	return findings, nil
+	return findings
 }
 
 // evaluatePolicyWithPrepare compiles the policy once and evaluates both deny and warn rules.
@@ -569,10 +557,7 @@ func parseSeverity(severity string) sdk.Severity {
 
 // GetInput returns the module data as JSON for debugging
 func (e *Engine) GetInput(files []string) ([]byte, error) {
-	data, err := e.parseModuleToJSON(files)
-	if err != nil {
-		return nil, err
-	}
+	data := e.parseModuleToJSON(files)
 	return json.MarshalIndent(data, "", "  ")
 }
 

--- a/internal/engines/policy/policy_benchmark_test.go
+++ b/internal/engines/policy/policy_benchmark_test.go
@@ -499,9 +499,6 @@ func BenchmarkPolicyEngine_ParseModuleToJSONInternal(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := engine.parseModuleToJSON([]string{tmpFile})
-		if err != nil {
-			b.Fatalf("parseModuleToJSON() error = %v", err)
-		}
+		_ = engine.parseModuleToJSON([]string{tmpFile})
 	}
 }

--- a/internal/engines/policy/policy_test.go
+++ b/internal/engines/policy/policy_test.go
@@ -169,11 +169,10 @@ output "instance_id" {
 	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "variables.tf"), []byte(varsContent), 0o644))
 
 	engine := New(nil)
-	data, err := engine.parseModuleToJSON([]string{
+	data := engine.parseModuleToJSON([]string{
 		filepath.Join(tmpDir, "main.tf"),
 		filepath.Join(tmpDir, "variables.tf"),
 	})
-	require.NoError(t, err)
 
 	// Verify resources
 	resources := data["resources"].([]any)

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -448,7 +448,7 @@ func (s *Server) republishAllDiagnostics() {
 
 // initSessionTempDir creates a private temp directory for this server session.
 // It also cleans up stale session directories older than sessionTempMaxAge.
-func (s *Server) initSessionTempDir() error {
+func (s *Server) initSessionTempDir() {
 	baseDir := getSessionTempBaseDir()
 
 	// Clean up old session directories
@@ -462,12 +462,11 @@ func (s *Server) initSessionTempDir() error {
 		// Fall back to system temp dir
 		s.logWarn("failed to create session temp dir %s, using system temp: %v", sessionDir, err)
 		s.sessionTempDir = os.TempDir()
-		return nil
+		return
 	}
 
 	s.sessionTempDir = sessionDir
 	s.logDebug("using session temp directory: %s", sessionDir)
-	return nil
 }
 
 // getSessionTempBaseDir returns the base directory for LSP session temp files.
@@ -732,11 +731,9 @@ func (s *Server) handleInitialize(msg RequestMessage) error {
 
 	s.config = cfg
 
-	// Initialize session temp directory for document analysis
-	if err := s.initSessionTempDir(); err != nil {
-		s.logWarn("failed to initialize session temp dir: %v", err)
-		// Not fatal - will fall back to system temp
-	}
+	// Initialize session temp directory for document analysis.
+	// Falls back to the system temp dir internally if creation fails.
+	s.initSessionTempDir()
 
 	// Load plugin rules if plugins are enabled
 	if cfg.Plugins.Enabled {

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -2836,8 +2836,7 @@ func TestServer_InitSessionTempDir(t *testing.T) {
 	out := &bytes.Buffer{}
 	server := NewServer(strings.NewReader(""), out)
 
-	err := server.initSessionTempDir()
-	require.NoError(t, err)
+	server.initSessionTempDir()
 
 	// Should have created a session temp directory
 	assert.NotEmpty(t, server.sessionTempDir)
@@ -2847,7 +2846,7 @@ func TestServer_InitSessionTempDir(t *testing.T) {
 	assert.Contains(t, server.sessionTempDir, "terratidy")
 
 	// Clean up
-	err = server.Close()
+	err := server.Close()
 	require.NoError(t, err)
 
 	// Directory should be removed after Close
@@ -2865,8 +2864,7 @@ func TestServer_SessionTempDir_UsedForDocs(t *testing.T) {
 	server.workspaceRoot = tmpDir
 
 	// Initialize session temp dir
-	err := server.initSessionTempDir()
-	require.NoError(t, err)
+	server.initSessionTempDir()
 
 	// Add a document
 	uri := pathToFileURI(testFile)


### PR DESCRIPTION
## What and why

Drops the `error` return from a handful of functions that only ever returned `nil`: the policy engine's `parseModuleToJSON`, `parseModuleToJSONWithSuppressions`, and `evaluatePolicies`; the LSP server's `initSessionTempDir`; and the dev command's `runWatchLoop`. Each call site loses a dead error-handling branch, and `initSessionTempDir` gains a comment noting it falls back to the system temp dir internally.

**Why:** These signatures advertised a failure mode that could never happen, forcing every caller to write `if err != nil` branches that were unreachable. Removing the phantom errors makes the "this can't fail" contract explicit and deletes ~20 lines of dead handling.

## How to test

Behavior is unchanged; this is a signature-only refactor. `mise run check` (fmt, vet, lint, test) covers it. golangci-lint already passed via pre-commit.

## Notes for reviewers

Pure internal refactor with no behavior change: all affected functions are unexported, no `pkg/sdk` surface is touched, and no CLI flags, output formats, config keys, or user-facing messages change. Test and benchmark call sites are updated in the same commit.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works <!-- N/A: signature-only refactor, no behavior change; existing test call sites updated -->
- [x] Existing tests updated for the new signatures and pass
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
