### PR TITLE
build: bump Go toolchain to 1.26.4

### DIFF
--- a/docs/site/docs/development/plugins.md
+++ b/docs/site/docs/development/plugins.md
@@ -114,7 +114,7 @@ const (
 
 ### Prerequisites
 
-- Go 1.26.3 or later
+- Go 1.26.4 or later
 - TerraTidy SDK (`pkg/sdk`)
 - TerraTidy plugin types (`internal/plugins`)
 

--- a/docs/site/docs/getting-started/upgrade.md
+++ b/docs/site/docs/getting-started/upgrade.md
@@ -61,7 +61,7 @@ version: 1  # Required
 
 ### Go Version
 
-TerraTidy requires Go 1.26.3 or later for building from source and compiling Go plugins.
+TerraTidy requires Go 1.26.4 or later for building from source and compiling Go plugins.
 Go plugins (`.so` files) must be compiled with the same Go version as TerraTidy.
 
 ### OPA Version

--- a/docs/site/docs/integrations/ci-cd.md
+++ b/docs/site/docs/integrations/ci-cd.md
@@ -61,7 +61,7 @@ pipelines:
     '**':
       - step:
           name: TerraTidy
-          image: golang:1.26.3
+          image: golang:1.26.4
           script:
             - go install github.com/santosr2/TerraTidy/cmd/terratidy@latest
             - terratidy check --format text

--- a/docs/site/docs/user-guide/commands.md
+++ b/docs/site/docs/user-guide/commands.md
@@ -795,6 +795,6 @@ terratidy version --format json-compact
 TerraTidy version 0.2.0-alpha.4
   Commit:      abc1234
   Build date:  2025-12-22
-  Go version:  go1.26.3
+  Go version:  go1.26.4
   Platform:    darwin/arm64
 ```

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-go = "1.26"
+go = "1.26.4"
 pre-commit = "4"
 terraform = "1"
 terragrunt = "0"


### PR DESCRIPTION
## What and why

Pins the dev/CI Go toolchain to `go1.26.4` in `mise.toml` and syncs the four docs that hardcoded the previous patch version.

**Why:** `govulncheck` flagged two reachable Go standard-library vulnerabilities on `go1.26.3` — GO-2026-5039 (`net/textproto`) and GO-2026-5037 (`crypto/x509`), both fixed in `1.26.4`. Bumping the toolchain resolves them at the source rather than suppressing them. `go.mod` stays at `go 1.25.0`, so library consumers are unaffected; only the binary and Go-plugin build toolchain moves.

## How to test

- `mise install go && mise exec -- go version` → `go1.26.4`
- `mise run vuln` → "No vulnerabilities found" (was failing on `1.26.3` with the two reachable vulns)
- `mise run check` → clean (fmt + vet + lint + test)
- `mise run docs:build` → clean

## Notes for reviewers

- The four doc edits (`development/plugins.md`, `getting-started/upgrade.md`, `integrations/ci-cd.md`, `user-guide/commands.md`) update hardcoded `go1.26.3` references to `1.26.4`. Go plugins must be compiled with the same toolchain as the binary, so the plugin-prerequisite and upgrade docs need to track the pin.
- No CI workflow changes are needed: every workflow already uses `go-version: 1.26.x` (with `check-latest`) or `go-version-file: go.mod`, so `1.26.x` auto-resolves to `1.26.4`. The test matrix still exercises `1.25.x` to guard the library floor declared in `go.mod`.
- No `osv-scanner.toml` allowlist is included. Scorecard's Go-vulnerability check is already green (zero `VulnerabilitiesID` alerts), so there is nothing to suppress; the only open vuln alerts are JS `bun.lock` findings tracked separately.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] Tests: N/A — toolchain pin and doc sync, no code behavior change (existing `mise run check` suite passes on 1.26.4)
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
