### PR TITLE
fix(config): accumulate plugins.tags across imports

### DIFF
--- a/docs/site/docs/getting-started/configuration.md
+++ b/docs/site/docs/getting-started/configuration.md
@@ -256,6 +256,11 @@ Set `plugins.tags` to load only the plugin rules tagged with one or more of the
 listed values. An empty list (the default) loads every rule. Rules that do not
 expose tags are skipped while a filter is active.
 
+When set in more than one config (e.g. a base config and an imported file),
+`plugins.tags` accumulates: the merged list is the union of every `tags`
+entry across the base config and its imports, matching `plugins.directories`
+above. A tag anywhere in that combined list is enough to include a rule.
+
 ```yaml
 plugins:
   enabled: true
@@ -306,6 +311,12 @@ engines:
 Imported files can themselves contain `imports`, which are loaded recursively.
 Circular imports (e.g., `a.yaml` imports `b.yaml` which imports `a.yaml`) are
 detected and produce a clear error.
+
+List-type keys accumulate across the base config and its imports rather than
+the last one winning: `exclude`, `plugins.directories`, and `plugins.tags` are
+all concatenated. Scalar keys (e.g. `severity_threshold`, `plugins.enabled`)
+and maps (`plugins.rules`, `profiles`) follow override semantics instead — a
+later import replaces the earlier value.
 
 ## Full Example
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -642,6 +642,13 @@ func (c *Config) merge(other *Config) {
 			c.Plugins.Rules[k] = v
 		}
 	}
+	// Tags accumulate (union) across imports rather than replacing, so an import
+	// only ever loosens the filter, never narrows it (tags are any-match at load
+	// time). Accumulate-don't-replace mirrors Directories; the widening effect is
+	// specific to Tags being a filter rather than a search-path list.
+	if len(other.Plugins.Tags) > 0 {
+		c.Plugins.Tags = append(c.Plugins.Tags, other.Plugins.Tags...)
+	}
 }
 
 // SetDefaults fills in default values for unset fields.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1795,6 +1795,43 @@ func TestConfig_merge_PluginDirectoriesAppended(t *testing.T) {
 	assert.Equal(t, []string{"./base-plugins", "./extra-plugins"}, base.Plugins.Directories)
 }
 
+func TestConfig_merge_PluginTagsAppended(t *testing.T) {
+	// Tags from an imported config must reach the merged result; they were
+	// silently dropped before, so a tag filter set in an import had no effect.
+	t.Run("base and import tags combine", func(t *testing.T) {
+		base := &Config{
+			Plugins: PluginsConfig{
+				Enabled: true,
+				Tags:    []string{"aws"},
+			},
+		}
+		other := &Config{
+			Plugins: PluginsConfig{
+				Tags: []string{"gcp"},
+			},
+		}
+
+		base.merge(other)
+
+		assert.Equal(t, []string{"aws", "gcp"}, base.Plugins.Tags)
+	})
+
+	t.Run("import tags flow into empty base", func(t *testing.T) {
+		base := &Config{
+			Plugins: PluginsConfig{Enabled: true},
+		}
+		other := &Config{
+			Plugins: PluginsConfig{
+				Tags: []string{"aws"},
+			},
+		}
+
+		base.merge(other)
+
+		assert.Equal(t, []string{"aws"}, base.Plugins.Tags)
+	})
+}
+
 func TestLoadPartialConfig_ReadError(t *testing.T) {
 	_, err := loadPartialConfig("/nonexistent/path/does-not-exist.yaml")
 	require.Error(t, err)


### PR DESCRIPTION
## What and why

When a config imports another file, `merge()` combined most fields but silently dropped `plugins.tags`. A tag filter defined in an imported config therefore had no effect: rules were loaded as if no filter existed. This unions the imported tags into the base, mirroring how `plugins.directories` already accumulates.

**Why:** `plugins.tags` is an any-match filter applied at plugin load time, so accumulation only ever widens it (an import can loosen the filter, never narrow it). Previously the field was write-only from an import's perspective, making modular tag configuration impossible.

## How to test

```bash
mise run test -- -run TestConfig_merge_PluginTagsAppended ./internal/config/
```

Covers two cases: base and import tags combining into a union, and import tags flowing into an empty base.

## Notes for reviewers

- Behavior change users can observe: tag filters set in imported configs now take effect. It fixes previously-broken behavior rather than changing a documented contract, so it is not a breaking change.
- Docs updated in `configuration.md`: documents tag accumulation and the broader list-vs-scalar merge split (`exclude`, `plugins.directories`, `plugins.tags` accumulate; scalars and maps override).

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
