### PR TITLE
refactor(style): unexport internal rule helpers

### DIFF
--- a/internal/cst/build.go
+++ b/internal/cst/build.go
@@ -145,7 +145,7 @@ func buildBody(
 
 // collectStructural returns the body's attrs and blocks merged into one
 // slice and sorted by source-order start byte. body.Attributes is an
-// unordered map; this is the same trick GetOrderedAttrNames uses in
+// unordered map; this is the same trick getOrderedAttrNames uses in
 // internal/engines/style/rules/helpers.go.
 func collectStructural(b *hclsyntax.Body) []structuralItem {
 	items := make([]structuralItem, 0, len(b.Attributes)+len(b.Blocks))

--- a/internal/engines/style/rules/advanced_naming.go
+++ b/internal/engines/style/rules/advanced_naming.go
@@ -268,7 +268,7 @@ func (r *ModuleNameConventionRule) Check(ctx *sdk.Context, file *hcl.File) ([]sd
 	}
 
 	// Get naming convention from config
-	convention, customPattern := GetNamingConventionFromConfig(ctx.Options)
+	convention, customPattern := getNamingConventionFromConfig(ctx.Options)
 
 	for _, block := range hclFile.Blocks {
 		if block.Type != "module" {
@@ -282,7 +282,7 @@ func (r *ModuleNameConventionRule) Check(ctx *sdk.Context, file *hcl.File) ([]sd
 		moduleName := block.Labels[0]
 
 		// Validate naming convention
-		isValid, caseName := ValidateNaming(moduleName, convention, customPattern)
+		isValid, caseName := validateNaming(moduleName, convention, customPattern)
 		if !isValid {
 			findings = append(findings, sdk.Finding{
 				Rule:     r.Name(),

--- a/internal/engines/style/rules/block_organization.go
+++ b/internal/engines/style/rules/block_organization.go
@@ -470,7 +470,7 @@ func (r *OneLineAttributeSpacingRule) Check(ctx *sdk.Context, file *hcl.File) ([
 	if err != nil {
 		return nil, err
 	}
-	lines := SplitLines(content)
+	lines := splitLines(content)
 
 	for _, block := range hclFile.Blocks {
 		if block.Type != "resource" && block.Type != "module" && block.Type != "data" {

--- a/internal/engines/style/rules/comments.go
+++ b/internal/engines/style/rules/comments.go
@@ -31,7 +31,7 @@ func (r *CommentSyntaxRule) Check(ctx *sdk.Context, _ *hcl.File) ([]sdk.Finding,
 		return nil, err
 	}
 
-	lines := SplitLines(content)
+	lines := splitLines(content)
 
 	for i, line := range lines {
 		lineNum := i + 1
@@ -68,7 +68,7 @@ func (r *CommentSyntaxRule) hasDoubleSlashComment(line string) bool {
 }
 
 func (r *CommentSyntaxRule) fixContent(content []byte) []byte {
-	lines := SplitLines(content)
+	lines := splitLines(content)
 	var result []string
 
 	for _, line := range lines {
@@ -128,7 +128,7 @@ func (r *NoTrailingWhitespaceRule) Check(ctx *sdk.Context, _ *hcl.File) ([]sdk.F
 		return nil, err
 	}
 
-	lines := SplitLines(content)
+	lines := splitLines(content)
 
 	for i, line := range lines {
 		lineNum := i + 1
@@ -154,7 +154,7 @@ func (r *NoTrailingWhitespaceRule) Check(ctx *sdk.Context, _ *hcl.File) ([]sdk.F
 }
 
 func (r *NoTrailingWhitespaceRule) fixContent(content []byte) []byte {
-	lines := SplitLines(content)
+	lines := splitLines(content)
 	var result []string
 
 	for _, line := range lines {
@@ -197,7 +197,7 @@ func (r *ConsistentQuotesRule) Check(ctx *sdk.Context, _ *hcl.File) ([]sdk.Findi
 		return nil, err
 	}
 
-	lines := SplitLines(content)
+	lines := splitLines(content)
 
 	for i, line := range lines {
 		lineNum := i + 1
@@ -275,7 +275,7 @@ func (r *NoConsecutiveBlankLinesRule) Check(ctx *sdk.Context, _ *hcl.File) ([]sd
 		return nil, err
 	}
 
-	lines := SplitLines(content)
+	lines := splitLines(content)
 
 	consecutiveBlank := 0
 
@@ -309,7 +309,7 @@ func (r *NoConsecutiveBlankLinesRule) Check(ctx *sdk.Context, _ *hcl.File) ([]sd
 }
 
 func (r *NoConsecutiveBlankLinesRule) fixContent(content []byte) []byte {
-	lines := SplitLines(content)
+	lines := splitLines(content)
 	var result []string
 	lastWasBlank := false
 

--- a/internal/engines/style/rules/comments_test.go
+++ b/internal/engines/style/rules/comments_test.go
@@ -525,7 +525,7 @@ resource "aws_instance" "api" {
 		require.Len(t, result.Edits, 1)
 
 		// Count blank lines between resources
-		lines := SplitLines(result.Edits[0].Replacement)
+		lines := splitLines(result.Edits[0].Replacement)
 		consecutiveBlank := 0
 		maxConsecutive := 0
 		for _, line := range lines {

--- a/internal/engines/style/rules/helpers.go
+++ b/internal/engines/style/rules/helpers.go
@@ -63,20 +63,20 @@ var (
 	pascalCaseRegex = regexp.MustCompile(`^[A-Z][a-zA-Z0-9]*$`)
 )
 
-// NamingCase represents supported naming conventions.
-type NamingCase string
+// namingCase represents supported naming conventions.
+type namingCase string
 
 // Supported naming convention constants.
 const (
-	SnakeCase  NamingCase = "snake_case"
-	CamelCase  NamingCase = "camelCase"
-	KebabCase  NamingCase = "kebab-case"
-	PascalCase NamingCase = "PascalCase"
-	CustomCase NamingCase = "custom"
+	snakeCase  namingCase = "snake_case"
+	camelCase  namingCase = "camelCase"
+	kebabCase  namingCase = "kebab-case"
+	pascalCase namingCase = "PascalCase"
+	customCase namingCase = "custom"
 )
 
-// GetOrderedAttrNames returns attribute names from hclsyntax sorted by line number.
-func GetOrderedAttrNames(syntaxBody *hclsyntax.Body) []string {
+// getOrderedAttrNames returns attribute names from hclsyntax sorted by line number.
+func getOrderedAttrNames(syntaxBody *hclsyntax.Body) []string {
 	type attrPos struct {
 		name string
 		line int
@@ -101,14 +101,14 @@ func GetOrderedAttrNames(syntaxBody *hclsyntax.Body) []string {
 	return result
 }
 
-// FormatAndCleanBlankLines applies hclwrite.Format and removes leading/trailing blank lines inside blocks.
+// formatAndCleanBlankLines applies hclwrite.Format and removes leading/trailing blank lines inside blocks.
 // It preserves internal blank lines for readability.
-func FormatAndCleanBlankLines(content []byte) []byte {
+func formatAndCleanBlankLines(content []byte) []byte {
 	// First apply hclwrite.Format
 	formatted := hclwrite.Format(content)
 
 	// Only remove leading/trailing blank lines inside blocks, preserve internal ones
-	lines := SplitLines(formatted)
+	lines := splitLines(formatted)
 	var result []byte
 
 	// First pass: identify block boundaries
@@ -169,8 +169,8 @@ func FormatAndCleanBlankLines(content []byte) []byte {
 	return result
 }
 
-// SplitLines splits content into lines.
-func SplitLines(content []byte) []string {
+// splitLines splits content into lines.
+func splitLines(content []byte) []string {
 	var lines []string
 	start := 0
 	for i, b := range content {
@@ -185,8 +185,8 @@ func SplitLines(content []byte) []string {
 	return lines
 }
 
-// TrimLeftWhitespace trims leading whitespace from a string.
-func TrimLeftWhitespace(s string) string {
+// trimLeftWhitespace trims leading whitespace from a string.
+func trimLeftWhitespace(s string) string {
 	for i, r := range s {
 		if r != ' ' && r != '\t' {
 			return s[i:]
@@ -195,9 +195,9 @@ func TrimLeftWhitespace(s string) string {
 	return ""
 }
 
-// CountBlankLinesBetween counts actual blank lines (not comments) between two line numbers.
+// countBlankLinesBetween counts actual blank lines (not comments) between two line numbers.
 // Line numbers are 1-indexed (HCL convention).
-func CountBlankLinesBetween(lines []string, endLine, startLine int) int {
+func countBlankLinesBetween(lines []string, endLine, startLine int) int {
 	blankCount := 0
 
 	// Lines between endLine and startLine (exclusive of both)
@@ -206,7 +206,7 @@ func CountBlankLinesBetween(lines []string, endLine, startLine int) int {
 			continue
 		}
 		line := lines[lineNum-1] // Convert to 0-indexed
-		trimmed := TrimLeftWhitespace(line)
+		trimmed := trimLeftWhitespace(line)
 
 		// Count as blank if empty or whitespace-only
 		// Don't count comment lines as blank lines
@@ -218,9 +218,9 @@ func CountBlankLinesBetween(lines []string, endLine, startLine int) int {
 	return blankCount
 }
 
-// HasCommentBetween checks if there's a comment line between two line numbers.
+// hasCommentBetween checks if there's a comment line between two line numbers.
 // Line numbers are 1-indexed (HCL convention).
-func HasCommentBetween(lines []string, endLine, startLine int) bool {
+func hasCommentBetween(lines []string, endLine, startLine int) bool {
 	for lineNum := endLine + 1; lineNum < startLine; lineNum++ {
 		if lineNum-1 >= len(lines) {
 			continue
@@ -236,8 +236,8 @@ func HasCommentBetween(lines []string, endLine, startLine int) bool {
 	return false
 }
 
-// BlockKey creates a unique key for a block based on type and labels.
-func BlockKey(blockType string, labels []string) string {
+// blockKey creates a unique key for a block based on type and labels.
+func blockKey(blockType string, labels []string) string {
 	key := blockType
 	for _, l := range labels {
 		key += "." + l
@@ -245,16 +245,16 @@ func BlockKey(blockType string, labels []string) string {
 	return key
 }
 
-// FindAttribute finds an attribute by name in the attributes map.
-func FindAttribute(attrs hclsyntax.Attributes, name string) *hclsyntax.Attribute {
+// findAttribute finds an attribute by name in the attributes map.
+func findAttribute(attrs hclsyntax.Attributes, name string) *hclsyntax.Attribute {
 	if attr, ok := attrs[name]; ok {
 		return attr
 	}
 	return nil
 }
 
-// FindNestedBlock finds a nested block by type in the blocks slice.
-func FindNestedBlock(blocks hclsyntax.Blocks, blockType string) *hclsyntax.Block {
+// findNestedBlock finds a nested block by type in the blocks slice.
+func findNestedBlock(blocks hclsyntax.Blocks, blockType string) *hclsyntax.Block {
 	for _, b := range blocks {
 		if b.Type == blockType {
 			return b
@@ -263,28 +263,28 @@ func FindNestedBlock(blocks hclsyntax.Blocks, blockType string) *hclsyntax.Block
 	return nil
 }
 
-// IsSnakeCase checks if a string is valid snake_case.
-func IsSnakeCase(s string) bool {
+// isSnakeCase checks if a string is valid snake_case.
+func isSnakeCase(s string) bool {
 	return snakeCaseRegex.MatchString(s)
 }
 
-// IsCamelCase checks if a string is valid camelCase.
-func IsCamelCase(s string) bool {
+// isCamelCase checks if a string is valid camelCase.
+func isCamelCase(s string) bool {
 	return camelCaseRegex.MatchString(s)
 }
 
-// IsKebabCase checks if a string is valid kebab-case.
-func IsKebabCase(s string) bool {
+// isKebabCase checks if a string is valid kebab-case.
+func isKebabCase(s string) bool {
 	return kebabCaseRegex.MatchString(s)
 }
 
-// IsPascalCase checks if a string is valid PascalCase.
-func IsPascalCase(s string) bool {
+// isPascalCase checks if a string is valid PascalCase.
+func isPascalCase(s string) bool {
 	return pascalCaseRegex.MatchString(s)
 }
 
-// MatchesCustomPattern checks if a string matches a custom regex pattern.
-func MatchesCustomPattern(s, pattern string) bool {
+// matchesCustomPattern checks if a string matches a custom regex pattern.
+func matchesCustomPattern(s, pattern string) bool {
 	if pattern == "" {
 		return true
 	}
@@ -295,54 +295,54 @@ func MatchesCustomPattern(s, pattern string) bool {
 	return re.MatchString(s)
 }
 
-// ValidateNaming checks if a name matches the specified naming convention.
+// validateNaming checks if a name matches the specified naming convention.
 // Returns (isValid, caseName) where caseName is the human-readable convention name.
-func ValidateNaming(name string, convention NamingCase, customPattern string) (bool, string) {
+func validateNaming(name string, convention namingCase, customPattern string) (bool, string) {
 	switch convention {
-	case CamelCase:
-		return IsCamelCase(name), "camelCase"
-	case KebabCase:
-		return IsKebabCase(name), "kebab-case"
-	case PascalCase:
-		return IsPascalCase(name), "PascalCase"
-	case CustomCase:
+	case camelCase:
+		return isCamelCase(name), "camelCase"
+	case kebabCase:
+		return isKebabCase(name), "kebab-case"
+	case pascalCase:
+		return isPascalCase(name), "PascalCase"
+	case customCase:
 		if customPattern == "" {
 			return true, "custom"
 		}
-		return MatchesCustomPattern(name, customPattern), "custom pattern"
+		return matchesCustomPattern(name, customPattern), "custom pattern"
 	default:
 		// Default to snake_case
-		return IsSnakeCase(name), "snake_case"
+		return isSnakeCase(name), "snake_case"
 	}
 }
 
-// GetNamingConventionFromConfig extracts naming convention settings from rule config.
+// getNamingConventionFromConfig extracts naming convention settings from rule config.
 // Returns (convention, customPattern).
-func GetNamingConventionFromConfig(config map[string]any) (NamingCase, string) {
+func getNamingConventionFromConfig(config map[string]any) (namingCase, string) {
 	if config == nil {
-		return SnakeCase, ""
+		return snakeCase, ""
 	}
 
 	options, ok := config["options"].(map[string]any)
 	if !ok {
-		return SnakeCase, ""
+		return snakeCase, ""
 	}
 
-	convention := SnakeCase
+	convention := snakeCase
 	if caseStr, ok := options["case"].(string); ok {
 		switch caseStr {
 		case "snake_case":
-			convention = SnakeCase
+			convention = snakeCase
 		case "camelCase":
-			convention = CamelCase
+			convention = camelCase
 		case "kebab-case":
-			convention = KebabCase
+			convention = kebabCase
 		case "PascalCase":
-			convention = PascalCase
+			convention = pascalCase
 		case "custom":
-			convention = CustomCase
+			convention = customCase
 		default:
-			convention = SnakeCase
+			convention = snakeCase
 		}
 	}
 
@@ -354,9 +354,9 @@ func GetNamingConventionFromConfig(config map[string]any) (NamingCase, string) {
 	return convention, customPattern
 }
 
-// GetAttributeOrderFromConfig extracts attribute ordering configuration from rule config.
+// getAttributeOrderFromConfig extracts attribute ordering configuration from rule config.
 // Returns a map of attribute name to position, and the default order if not configured.
-func GetAttributeOrderFromConfig(config map[string]any, defaultOrder map[string]int) map[string]int {
+func getAttributeOrderFromConfig(config map[string]any, defaultOrder map[string]int) map[string]int {
 	if config == nil {
 		return defaultOrder
 	}
@@ -386,8 +386,8 @@ func GetAttributeOrderFromConfig(config map[string]any, defaultOrder map[string]
 	return customOrder
 }
 
-// MatchBlockLabels checks if block labels match expected labels.
-func MatchBlockLabels(labels, expectedLabels []string) bool {
+// matchBlockLabels checks if block labels match expected labels.
+func matchBlockLabels(labels, expectedLabels []string) bool {
 	if len(labels) != len(expectedLabels) {
 		return false
 	}
@@ -399,34 +399,34 @@ func MatchBlockLabels(labels, expectedLabels []string) bool {
 	return true
 }
 
-// FindSyntaxBody finds the syntax body for a block matching the given type and labels.
-func FindSyntaxBody(syntaxFile *hclsyntax.Body, blockType string, blockLabels []string) *hclsyntax.Body {
+// findSyntaxBody finds the syntax body for a block matching the given type and labels.
+func findSyntaxBody(syntaxFile *hclsyntax.Body, blockType string, blockLabels []string) *hclsyntax.Body {
 	for _, block := range syntaxFile.Blocks {
 		if block.Type != blockType {
 			continue
 		}
-		if MatchBlockLabels(block.Labels, blockLabels) {
+		if matchBlockLabels(block.Labels, blockLabels) {
 			return block.Body
 		}
 	}
 	return nil
 }
 
-// FindWriteBlock finds a block in hclwrite file matching the given type and labels.
-func FindWriteBlock(writeFile *hclwrite.File, blockType string, blockLabels []string) *hclwrite.Block {
+// findWriteBlock finds a block in hclwrite file matching the given type and labels.
+func findWriteBlock(writeFile *hclwrite.File, blockType string, blockLabels []string) *hclwrite.Block {
 	for _, block := range writeFile.Body().Blocks() {
 		if block.Type() != blockType {
 			continue
 		}
-		if MatchBlockLabels(block.Labels(), blockLabels) {
+		if matchBlockLabels(block.Labels(), blockLabels) {
 			return block
 		}
 	}
 	return nil
 }
 
-// ParseBothFormats parses content with both hclsyntax (for positions) and hclwrite (for modifications).
-func ParseBothFormats(content []byte, filePath string) (*hclsyntax.Body, *hclwrite.File, error) {
+// parseBothFormats parses content with both hclsyntax (for positions) and hclwrite (for modifications).
+func parseBothFormats(content []byte, filePath string) (*hclsyntax.Body, *hclwrite.File, error) {
 	// Parse with hclsyntax to get attribute ordering
 	syntaxFile, diags := hclsyntax.ParseConfig(content, filePath, hcl.InitialPos)
 	if diags.HasErrors() {

--- a/internal/engines/style/rules/helpers_test.go
+++ b/internal/engines/style/rules/helpers_test.go
@@ -47,7 +47,7 @@ func TestGetOrderedAttrNames(t *testing.T) {
 
 			body := file.Body.(*hclsyntax.Body)
 			if len(body.Blocks) > 0 {
-				result := GetOrderedAttrNames(body.Blocks[0].Body)
+				result := getOrderedAttrNames(body.Blocks[0].Body)
 				assert.Equal(t, tt.expected, result)
 			}
 		})
@@ -128,7 +128,7 @@ resource "test" "b" {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := FormatAndCleanBlankLines([]byte(tt.input))
+			result := formatAndCleanBlankLines([]byte(tt.input))
 			assert.Equal(t, tt.expected, string(result))
 		})
 	}
@@ -164,7 +164,7 @@ func TestSplitLines(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := SplitLines([]byte(tt.input))
+			result := splitLines([]byte(tt.input))
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -186,7 +186,7 @@ func TestTrimLeftWhitespace(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := TrimLeftWhitespace(tt.input)
+			result := trimLeftWhitespace(tt.input)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -225,7 +225,7 @@ func TestCountBlankLinesBetween(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := CountBlankLinesBetween(tt.lines, tt.endLine, tt.startLine)
+			result := countBlankLinesBetween(tt.lines, tt.endLine, tt.startLine)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -334,7 +334,7 @@ func TestHasCommentBetween(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := HasCommentBetween(tt.lines, tt.endLine, tt.startLine)
+			result := hasCommentBetween(tt.lines, tt.endLine, tt.startLine)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -354,7 +354,7 @@ func TestBlockKey(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := BlockKey(tt.blockType, tt.labels)
+			result := blockKey(tt.blockType, tt.labels)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -372,12 +372,12 @@ func TestFindAttribute(t *testing.T) {
 	attrs := body.Blocks[0].Body.Attributes
 
 	t.Run("finds existing attribute", func(t *testing.T) {
-		attr := FindAttribute(attrs, "ami")
+		attr := findAttribute(attrs, "ami")
 		assert.NotNil(t, attr)
 	})
 
 	t.Run("returns nil for missing attribute", func(t *testing.T) {
-		attr := FindAttribute(attrs, "nonexistent")
+		attr := findAttribute(attrs, "nonexistent")
 		assert.Nil(t, attr)
 	})
 }
@@ -397,12 +397,12 @@ func TestFindNestedBlock(t *testing.T) {
 	blocks := body.Blocks[0].Body.Blocks
 
 	t.Run("finds existing nested block", func(t *testing.T) {
-		block := FindNestedBlock(blocks, "lifecycle")
+		block := findNestedBlock(blocks, "lifecycle")
 		assert.NotNil(t, block)
 	})
 
 	t.Run("returns nil for missing block", func(t *testing.T) {
-		block := FindNestedBlock(blocks, "provisioner")
+		block := findNestedBlock(blocks, "provisioner")
 		assert.Nil(t, block)
 	})
 }
@@ -425,7 +425,7 @@ func TestIsSnakeCase(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := IsSnakeCase(tt.input)
+			result := isSnakeCase(tt.input)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -449,7 +449,7 @@ func TestIsCamelCase(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := IsCamelCase(tt.input)
+			result := isCamelCase(tt.input)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -473,7 +473,7 @@ func TestIsKebabCase(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := IsKebabCase(tt.input)
+			result := isKebabCase(tt.input)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -497,7 +497,7 @@ func TestIsPascalCase(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := IsPascalCase(tt.input)
+			result := isPascalCase(tt.input)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -519,7 +519,7 @@ func TestMatchesCustomPattern(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := MatchesCustomPattern(tt.input, tt.pattern)
+			result := matchesCustomPattern(tt.input, tt.pattern)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -529,28 +529,28 @@ func TestValidateNaming(t *testing.T) {
 	tests := []struct {
 		name          string
 		input         string
-		convention    NamingCase
+		convention    namingCase
 		customPattern string
 		expectValid   bool
 		expectCase    string
 	}{
-		{"snake_case valid", "my_var", SnakeCase, "", true, "snake_case"},
-		{"snake_case invalid", "myVar", SnakeCase, "", false, "snake_case"},
-		{"camelCase valid", "myVar", CamelCase, "", true, "camelCase"},
-		{"camelCase invalid", "my_var", CamelCase, "", false, "camelCase"},
-		{"kebab-case valid", "my-var", KebabCase, "", true, "kebab-case"},
-		{"kebab-case invalid", "my_var", KebabCase, "", false, "kebab-case"},
-		{"PascalCase valid", "MyVar", PascalCase, "", true, "PascalCase"},
-		{"PascalCase invalid", "myVar", PascalCase, "", false, "PascalCase"},
-		{"custom pattern valid", "prefix_name", CustomCase, "^prefix_", true, "custom pattern"},
-		{"custom pattern invalid", "name", CustomCase, "^prefix_", false, "custom pattern"},
-		{"custom empty pattern", "anything", CustomCase, "", true, "custom"},
+		{"snake_case valid", "my_var", snakeCase, "", true, "snake_case"},
+		{"snake_case invalid", "myVar", snakeCase, "", false, "snake_case"},
+		{"camelCase valid", "myVar", camelCase, "", true, "camelCase"},
+		{"camelCase invalid", "my_var", camelCase, "", false, "camelCase"},
+		{"kebab-case valid", "my-var", kebabCase, "", true, "kebab-case"},
+		{"kebab-case invalid", "my_var", kebabCase, "", false, "kebab-case"},
+		{"PascalCase valid", "MyVar", pascalCase, "", true, "PascalCase"},
+		{"PascalCase invalid", "myVar", pascalCase, "", false, "PascalCase"},
+		{"custom pattern valid", "prefix_name", customCase, "^prefix_", true, "custom pattern"},
+		{"custom pattern invalid", "name", customCase, "^prefix_", false, "custom pattern"},
+		{"custom empty pattern", "anything", customCase, "", true, "custom"},
 		{"default to snake_case", "my_var", "", "", true, "snake_case"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			valid, caseName := ValidateNaming(tt.input, tt.convention, tt.customPattern)
+			valid, caseName := validateNaming(tt.input, tt.convention, tt.customPattern)
 			assert.Equal(t, tt.expectValid, valid)
 			assert.Equal(t, tt.expectCase, caseName)
 		})
@@ -561,19 +561,19 @@ func TestGetNamingConventionFromConfig(t *testing.T) {
 	tests := []struct {
 		name             string
 		config           map[string]any
-		expectConvention NamingCase
+		expectConvention namingCase
 		expectPattern    string
 	}{
 		{
 			name:             "nil config returns snake_case",
 			config:           nil,
-			expectConvention: SnakeCase,
+			expectConvention: snakeCase,
 			expectPattern:    "",
 		},
 		{
 			name:             "empty config returns snake_case",
 			config:           map[string]any{},
-			expectConvention: SnakeCase,
+			expectConvention: snakeCase,
 			expectPattern:    "",
 		},
 		{
@@ -583,7 +583,7 @@ func TestGetNamingConventionFromConfig(t *testing.T) {
 					"case": "snake_case",
 				},
 			},
-			expectConvention: SnakeCase,
+			expectConvention: snakeCase,
 			expectPattern:    "",
 		},
 		{
@@ -593,7 +593,7 @@ func TestGetNamingConventionFromConfig(t *testing.T) {
 					"case": "camelCase",
 				},
 			},
-			expectConvention: CamelCase,
+			expectConvention: camelCase,
 			expectPattern:    "",
 		},
 		{
@@ -603,7 +603,7 @@ func TestGetNamingConventionFromConfig(t *testing.T) {
 					"case": "kebab-case",
 				},
 			},
-			expectConvention: KebabCase,
+			expectConvention: kebabCase,
 			expectPattern:    "",
 		},
 		{
@@ -613,7 +613,7 @@ func TestGetNamingConventionFromConfig(t *testing.T) {
 					"case": "PascalCase",
 				},
 			},
-			expectConvention: PascalCase,
+			expectConvention: pascalCase,
 			expectPattern:    "",
 		},
 		{
@@ -624,7 +624,7 @@ func TestGetNamingConventionFromConfig(t *testing.T) {
 					"pattern": "^prefix_",
 				},
 			},
-			expectConvention: CustomCase,
+			expectConvention: customCase,
 			expectPattern:    "^prefix_",
 		},
 		{
@@ -634,14 +634,14 @@ func TestGetNamingConventionFromConfig(t *testing.T) {
 					"case": "UNKNOWN",
 				},
 			},
-			expectConvention: SnakeCase,
+			expectConvention: snakeCase,
 			expectPattern:    "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			convention, pattern := GetNamingConventionFromConfig(tt.config)
+			convention, pattern := getNamingConventionFromConfig(tt.config)
 			assert.Equal(t, tt.expectConvention, convention)
 			assert.Equal(t, tt.expectPattern, pattern)
 		})
@@ -724,7 +724,7 @@ func TestGetAttributeOrderFromConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := GetAttributeOrderFromConfig(tt.config, defaultOrder)
+			result := getAttributeOrderFromConfig(tt.config, defaultOrder)
 			assert.Equal(t, tt.expectedOrder, result)
 		})
 	}
@@ -745,7 +745,7 @@ func TestMatchBlockLabels(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := MatchBlockLabels(tt.labels, tt.expected)
+			result := matchBlockLabels(tt.labels, tt.expected)
 			assert.Equal(t, tt.match, result)
 		})
 	}
@@ -765,17 +765,17 @@ resource "aws_instance" "other" {
 	body := file.Body.(*hclsyntax.Body)
 
 	t.Run("finds matching block", func(t *testing.T) {
-		result := FindSyntaxBody(body, "resource", []string{"aws_instance", "example"})
+		result := findSyntaxBody(body, "resource", []string{"aws_instance", "example"})
 		assert.NotNil(t, result)
 	})
 
 	t.Run("returns nil for non-matching block", func(t *testing.T) {
-		result := FindSyntaxBody(body, "resource", []string{"aws_instance", "nonexistent"})
+		result := findSyntaxBody(body, "resource", []string{"aws_instance", "nonexistent"})
 		assert.Nil(t, result)
 	})
 
 	t.Run("returns nil for wrong block type", func(t *testing.T) {
-		result := FindSyntaxBody(body, "data", []string{"aws_instance", "example"})
+		result := findSyntaxBody(body, "data", []string{"aws_instance", "example"})
 		assert.Nil(t, result)
 	})
 }
@@ -792,12 +792,12 @@ resource "aws_instance" "other" {
 	require.False(t, diags.HasErrors())
 
 	t.Run("finds matching block", func(t *testing.T) {
-		result := FindWriteBlock(file, "resource", []string{"aws_instance", "example"})
+		result := findWriteBlock(file, "resource", []string{"aws_instance", "example"})
 		assert.NotNil(t, result)
 	})
 
 	t.Run("returns nil for non-matching block", func(t *testing.T) {
-		result := FindWriteBlock(file, "resource", []string{"aws_instance", "nonexistent"})
+		result := findWriteBlock(file, "resource", []string{"aws_instance", "nonexistent"})
 		assert.Nil(t, result)
 	})
 }
@@ -808,14 +808,14 @@ func TestParseBothFormats(t *testing.T) {
 }`
 
 	t.Run("parses valid HCL", func(t *testing.T) {
-		syntaxBody, writeFile, err := ParseBothFormats([]byte(content), "test.tf")
+		syntaxBody, writeFile, err := parseBothFormats([]byte(content), "test.tf")
 		assert.NoError(t, err)
 		assert.NotNil(t, syntaxBody)
 		assert.NotNil(t, writeFile)
 	})
 
 	t.Run("returns error for invalid HCL", func(t *testing.T) {
-		_, _, err := ParseBothFormats([]byte("invalid { content"), "test.tf")
+		_, _, err := parseBothFormats([]byte("invalid { content"), "test.tf")
 		assert.Error(t, err)
 	})
 }

--- a/internal/engines/style/rules/naming.go
+++ b/internal/engines/style/rules/naming.go
@@ -29,7 +29,7 @@ func (r *BlockLabelCaseRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Find
 	}
 
 	// Get naming convention from config (defaults to snake_case)
-	convention, customPattern := GetNamingConventionFromConfig(ctx.Options)
+	convention, customPattern := getNamingConventionFromConfig(ctx.Options)
 
 	for _, block := range hclFile.Blocks {
 		blockType := block.Type
@@ -57,7 +57,7 @@ func (r *BlockLabelCaseRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Find
 
 		// Validate naming convention for resources and data sources
 		if blockType == "resource" || blockType == "data" {
-			valid, caseName := ValidateNaming(name, convention, customPattern)
+			valid, caseName := validateNaming(name, convention, customPattern)
 			if !valid {
 				findings = append(findings, sdk.Finding{
 					Rule:     r.Name(),
@@ -96,7 +96,7 @@ func (r *VariableNamingRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Find
 	}
 
 	// Get naming convention from config (defaults to snake_case)
-	convention, customPattern := GetNamingConventionFromConfig(ctx.Options)
+	convention, customPattern := getNamingConventionFromConfig(ctx.Options)
 
 	for _, block := range hclFile.Blocks {
 		if block.Type != "variable" {
@@ -108,7 +108,7 @@ func (r *VariableNamingRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Find
 		}
 
 		name := block.Labels[0]
-		valid, caseName := ValidateNaming(name, convention, customPattern)
+		valid, caseName := validateNaming(name, convention, customPattern)
 		if !valid {
 			findings = append(findings, sdk.Finding{
 				Rule:     r.Name(),
@@ -146,7 +146,7 @@ func (r *OutputNamingRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Findin
 	}
 
 	// Get naming convention from config (defaults to snake_case)
-	convention, customPattern := GetNamingConventionFromConfig(ctx.Options)
+	convention, customPattern := getNamingConventionFromConfig(ctx.Options)
 
 	for _, block := range hclFile.Blocks {
 		if block.Type != "output" {
@@ -158,7 +158,7 @@ func (r *OutputNamingRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Findin
 		}
 
 		name := block.Labels[0]
-		valid, caseName := ValidateNaming(name, convention, customPattern)
+		valid, caseName := validateNaming(name, convention, customPattern)
 		if !valid {
 			findings = append(findings, sdk.Finding{
 				Rule:     r.Name(),
@@ -196,7 +196,7 @@ func (r *LocalNamingRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Finding
 	}
 
 	// Get naming convention from config (defaults to snake_case)
-	convention, customPattern := GetNamingConventionFromConfig(ctx.Options)
+	convention, customPattern := getNamingConventionFromConfig(ctx.Options)
 
 	for _, block := range hclFile.Blocks {
 		if block.Type != "locals" {
@@ -205,7 +205,7 @@ func (r *LocalNamingRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Finding
 
 		// Check each attribute in the locals block
 		for name, attr := range block.Body.Attributes {
-			valid, caseName := ValidateNaming(name, convention, customPattern)
+			valid, caseName := validateNaming(name, convention, customPattern)
 			if !valid {
 				findings = append(findings, sdk.Finding{
 					Rule:     r.Name(),

--- a/internal/engines/style/rules/ordering.go
+++ b/internal/engines/style/rules/ordering.go
@@ -302,7 +302,7 @@ func (r *TagsAtEndRule) checkTagsBlock(ctx *sdk.Context, block *hclsyntax.Block)
 		return findings
 	}
 
-	lifecycleBlock := FindNestedBlock(body.Blocks, "lifecycle")
+	lifecycleBlock := findNestedBlock(body.Blocks, "lifecycle")
 	tagsLine := tagsAttr.Range().Start.Line
 
 	// Single-finding policy: the "before lifecycle" and "near the end" conditions both
@@ -462,7 +462,7 @@ func (r *DependsOnOrderRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Find
 	}
 
 	for _, block := range hclFile.Blocks {
-		if !IsDependsOnRelevantBlock(block.Type) {
+		if !isDependsOnRelevantBlock(block.Type) {
 			continue
 		}
 		blockFindings := r.checkDependsOnBlock(ctx, block)
@@ -472,8 +472,8 @@ func (r *DependsOnOrderRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Find
 	return findings, nil
 }
 
-// IsDependsOnRelevantBlock checks if a block type supports depends_on attribute.
-func IsDependsOnRelevantBlock(blockType string) bool {
+// isDependsOnRelevantBlock checks if a block type supports depends_on attribute.
+func isDependsOnRelevantBlock(blockType string) bool {
 	return blockType == "resource" || blockType == "module" || blockType == "data"
 }
 
@@ -481,12 +481,12 @@ func (r *DependsOnOrderRule) checkDependsOnBlock(ctx *sdk.Context, block *hclsyn
 	var findings []sdk.Finding
 	body := block.Body
 
-	dependsOnAttr := FindAttribute(body.Attributes, "depends_on")
+	dependsOnAttr := findAttribute(body.Attributes, "depends_on")
 	if dependsOnAttr == nil {
 		return findings
 	}
 
-	lifecycleBlock := FindNestedBlock(body.Blocks, "lifecycle")
+	lifecycleBlock := findNestedBlock(body.Blocks, "lifecycle")
 	dependsOnLine := dependsOnAttr.Range().Start.Line
 
 	// Single-finding policy: the "before lifecycle" and "near the end" conditions both
@@ -569,7 +569,7 @@ func (r *DependsOnOrderRule) Fix(ctx *sdk.Context, _ *hcl.File) (*sdk.FixResult,
 		if !ok {
 			continue
 		}
-		if !IsDependsOnRelevantBlock(block.Type) {
+		if !isDependsOnRelevantBlock(block.Type) {
 			continue
 		}
 		moveDependsOnToEnd(block.Body)
@@ -685,8 +685,8 @@ func (r *SourceVersionGroupedRule) checkModuleBlock(ctx *sdk.Context, block *hcl
 	var findings []sdk.Finding
 	body := block.Body
 
-	sourceAttr := FindAttribute(body.Attributes, "source")
-	versionAttr := FindAttribute(body.Attributes, "version")
+	sourceAttr := findAttribute(body.Attributes, "source")
+	versionAttr := findAttribute(body.Attributes, "version")
 
 	if sourceAttr != nil {
 		if finding := r.checkSourcePosition(ctx, body.Attributes, sourceAttr); finding != nil {
@@ -847,7 +847,7 @@ func (r *VariableOrderRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Findi
 	}
 
 	// Get attribute order from config (defaults to varAttrOrder)
-	attrOrder := GetAttributeOrderFromConfig(ctx.Options, varAttrOrder)
+	attrOrder := getAttributeOrderFromConfig(ctx.Options, varAttrOrder)
 
 	for _, block := range hclFile.Blocks {
 		if block.Type != "variable" {
@@ -1045,7 +1045,7 @@ func (r *OutputOrderRule) Check(ctx *sdk.Context, file *hcl.File) ([]sdk.Finding
 	}
 
 	// Get attribute order from config (defaults to outputAttrOrder)
-	attrOrder := GetAttributeOrderFromConfig(ctx.Options, outputAttrOrder)
+	attrOrder := getAttributeOrderFromConfig(ctx.Options, outputAttrOrder)
 
 	for _, block := range hclFile.Blocks {
 		if block.Type != "output" {
@@ -1515,7 +1515,7 @@ func (r *AttributeGroupSpacingRule) Check(ctx *sdk.Context, file *hcl.File) ([]s
 	if err != nil {
 		return nil, err
 	}
-	lines := SplitLines(content)
+	lines := splitLines(content)
 
 	for _, block := range hclFile.Blocks {
 		// Check resource, module, data, variable, and output blocks
@@ -1579,7 +1579,7 @@ func (r *AttributeGroupSpacingRule) checkBlock(ctx *sdk.Context, block *hclsynta
 		hasBlankLine := false
 		for lineNum := curr.line + 1; lineNum < next.line; lineNum++ {
 			if lineNum-1 < len(lines) {
-				trimmed := TrimLeftWhitespace(lines[lineNum-1])
+				trimmed := trimLeftWhitespace(lines[lineNum-1])
 				if len(trimmed) == 0 {
 					hasBlankLine = true
 					break
@@ -1620,7 +1620,7 @@ func (r *AttributeGroupSpacingRule) checkBlock(ctx *sdk.Context, block *hclsynta
 // stay at their source positions.
 //
 // Resource, module, data, variable, and output blocks are processed; other
-// top-level block types pass through untouched. Pre-CST FormatAndCleanBlankLines
+// top-level block types pass through untouched. Pre-CST formatAndCleanBlankLines
 // wrapping is intentionally dropped — the CST mutation produces byte-exact
 // output for unmodified regions.
 func (r *AttributeGroupSpacingRule) Fix(ctx *sdk.Context, _ *hcl.File) (*sdk.FixResult, error) {

--- a/internal/engines/style/rules/ordering_test.go
+++ b/internal/engines/style/rules/ordering_test.go
@@ -1588,7 +1588,7 @@ resource "aws_instance" "second" {
 	t.Run("Fix is a no-op (no diff) when depends_on is already adjacent to lifecycle with a blank gap", func(t *testing.T) {
 		// Closes the Fix/Check semantic gap the reviewer flagged: previously Fix would
 		// run the splice on this layout (because attrEnd+1 != insertBefore), produce a
-		// visually-equivalent output, then FormatAndCleanBlankLines would collapse the
+		// visually-equivalent output, then formatAndCleanBlankLines would collapse the
 		// blank — so the first pass produced a non-trivial diff. The tightened no-op
 		// guard now correctly recognizes this as already-canonical.
 		content := `resource "aws_instance" "x" {
@@ -3306,7 +3306,7 @@ func TestIsDependsOnRelevantBlock(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.blockType, func(t *testing.T) {
-			result := IsDependsOnRelevantBlock(tt.blockType)
+			result := isDependsOnRelevantBlock(tt.blockType)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/internal/engines/style/rules/spacing.go
+++ b/internal/engines/style/rules/spacing.go
@@ -36,7 +36,7 @@ func (r *NoLeadingTrailingBlankLinesRule) Check(ctx *sdk.Context, file *hcl.File
 	if err != nil {
 		return nil, err
 	}
-	lines := SplitLines(content)
+	lines := splitLines(content)
 
 	// Check each block for leading/trailing blank lines
 	for _, block := range hclFile.Blocks {
@@ -64,7 +64,7 @@ func (r *NoLeadingTrailingBlankLinesRule) checkBlock(ctx *sdk.Context, block *hc
 			continue
 		}
 		line := lines[lineNum-1]
-		trimmed := TrimLeftWhitespace(line)
+		trimmed := trimLeftWhitespace(line)
 
 		if len(trimmed) == 0 {
 			findings = append(findings, sdk.Finding{
@@ -91,7 +91,7 @@ func (r *NoLeadingTrailingBlankLinesRule) checkBlock(ctx *sdk.Context, block *hc
 			continue
 		}
 		line := lines[lineNum-1]
-		trimmed := TrimLeftWhitespace(line)
+		trimmed := trimLeftWhitespace(line)
 
 		if len(trimmed) == 0 {
 			findings = append(findings, sdk.Finding{
@@ -127,7 +127,7 @@ func (r *NoLeadingTrailingBlankLinesRule) Fix(ctx *sdk.Context, _ *hcl.File) (*s
 	if err != nil {
 		return nil, err
 	}
-	return WholeFileEdit(content, FormatAndCleanBlankLines(content)), nil
+	return WholeFileEdit(content, formatAndCleanBlankLines(content)), nil
 }
 
 // BlankLineBetweenBlocksRule ensures blank lines between top-level blocks.
@@ -194,7 +194,7 @@ func (r *BlankLineBetweenBlocksRule) Check(ctx *sdk.Context, file *hcl.File) ([]
 	if err != nil {
 		return nil, err
 	}
-	lines := SplitLines(content)
+	lines := splitLines(content)
 
 	blocks := hclFile.Blocks
 	for i := 0; i < len(blocks)-1; i++ {
@@ -205,10 +205,10 @@ func (r *BlankLineBetweenBlocksRule) Check(ctx *sdk.Context, file *hcl.File) ([]
 		startLine := nextBlock.Range().Start.Line
 
 		// Count actual blank lines (excluding comments) between blocks
-		blankLines := CountBlankLinesBetween(lines, endLine, startLine)
+		blankLines := countBlankLinesBetween(lines, endLine, startLine)
 
 		// Check if there's a comment between blocks
-		hasComment := HasCommentBetween(lines, endLine, startLine)
+		hasComment := hasCommentBetween(lines, endLine, startLine)
 
 		// Adjust max allowed blank lines when there's a comment
 		effectiveMax := maxLines
@@ -252,7 +252,7 @@ func (r *BlankLineBetweenBlocksRule) fixContent(content []byte, filePath string)
 	}
 
 	// Get original lines
-	lines := SplitLines(content)
+	lines := splitLines(content)
 
 	// Build a map of line numbers that need adjustments
 	type lineAdjustment struct {
@@ -270,7 +270,7 @@ func (r *BlankLineBetweenBlocksRule) fixContent(content []byte, filePath string)
 		startLine := nextBlock.Range().Start.Line
 
 		// Count actual blank lines between blocks
-		blankLines := CountBlankLinesBetween(lines, endLine, startLine)
+		blankLines := countBlankLinesBetween(lines, endLine, startLine)
 
 		if blankLines < 1 {
 			adjustments = append(adjustments, lineAdjustment{
@@ -307,7 +307,7 @@ func (r *BlankLineBetweenBlocksRule) fixContent(content []byte, filePath string)
 					skipIdx := lineNum
 					for skipIdx < len(lines) {
 						nextLine := lines[skipIdx]
-						trimmed := TrimLeftWhitespace(nextLine)
+						trimmed := trimLeftWhitespace(nextLine)
 						if len(trimmed) > 0 {
 							break
 						}

--- a/internal/engines/style/style_test.go
+++ b/internal/engines/style/style_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclparse"
 	"github.com/santosr2/TerraTidy/internal/config"
-	"github.com/santosr2/TerraTidy/internal/engines/style/rules"
 	"github.com/santosr2/TerraTidy/pkg/sdk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -839,29 +838,6 @@ func TestEngine_MultipleFiles(t *testing.T) {
 
 	// Both files processed without error; findings may be empty for valid HCL
 	_ = findings
-}
-
-func TestIsDependsOnRelevantBlock(t *testing.T) {
-	tests := []struct {
-		blockType string
-		want      bool
-	}{
-		{"resource", true},
-		{"module", true},
-		{"data", true},
-		{"variable", false},
-		{"output", false},
-		{"terraform", false},
-		{"locals", false},
-		{"provider", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.blockType, func(t *testing.T) {
-			got := rules.IsDependsOnRelevantBlock(tt.blockType)
-			assert.Equal(t, tt.want, got)
-		})
-	}
 }
 
 func TestEngine_Name(t *testing.T) {


### PR DESCRIPTION
## What and why

Unexport the helper functions in `internal/engines/style/rules` (`SplitLines`, `ValidateNaming`, `NamingCase`, and friends) that were exported but only ever called within the package. They now use lowercase names to reflect their actual scope.

Also drops the redundant `TestIsDependsOnRelevantBlock` from `style_test.go`, since `ordering_test.go` already covers that behavior in-package.

**Why:** These helpers were never part of the package's intended API. Exporting them widened the surface area for no benefit and implied a contract that doesn't exist. Shrinking it keeps the package honest and easier to reason about.

## How to test

Behavior-preserving refactor (renames only, no logic changes). Verify with:

```bash
mise run check   # fmt, vet, lint, test
```

## Notes for reviewers

- No behavior change: this is purely a visibility/rename refactor plus one redundant test removal.
- `internal/` is private, so nothing outside the module depends on these symbols.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works <!-- N/A: refactor, existing tests updated to match renames -->
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test)
- [x] I have updated documentation as needed <!-- N/A: no user-facing or exported API changes -->
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
