### PR TITLE
docs(plugins): link bash rule verification TODO to #228

### DIFF
--- a/internal/plugins/bash_loader.go
+++ b/internal/plugins/bash_loader.go
@@ -14,7 +14,7 @@ func (m *Manager) loadAndRegisterBashRule(path, name string, checksums map[strin
 	if m.verifyIntegrity && checksums != nil {
 		if err := m.verifyPluginChecksum(path, checksums); err != nil {
 			// In warn-only mode (first release), log warning but continue
-			// TODO: In future release, return error here to enforce verification
+			// TODO(#228): enforce verification once warn-only deprecation period closes
 			m.logger.Printf("[WARN] bash rule verification failed for %s: %v (loading anyway - warn-only mode)", filepath.Base(path), err)
 		}
 	}


### PR DESCRIPTION
## What and why

Reword the TODO on bash rule checksum verification to reference the tracking issue instead of a vague "future release" note. The warn-only path in `loadAndRegisterBashRule` still logs and continues; only the comment changed.

**Why:** A concrete issue pointer is greppable and survives across releases, unlike "in future release". Relates to #228.

## How to test

No behavior change. `mise run check` (fmt, vet, lint, test) passes.

## Notes for reviewers

Comment-only edit. No code paths, config, docs, or tests are affected. #228 stays open; it tracks flipping this warn-only mode into hard enforcement, which this PR does not do.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
