### PR TITLE
vscode: override undici to ^7.28.0 to clear transitive CVEs

### DIFF
--- a/vscode/bun.lock
+++ b/vscode/bun.lock
@@ -20,6 +20,9 @@
       },
     },
   },
+  "overrides": {
+    "undici": "^7.28.0",
+  },
   "packages": {
     "@azu/format-text": ["@azu/format-text@1.0.2", "", {}, "sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg=="],
 
@@ -781,7 +784,7 @@
 
     "underscore": ["underscore@1.13.8", "", {}, "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ=="],
 
-    "undici": ["undici@7.24.7", "", {}, "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ=="],
+    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -153,5 +153,8 @@
 		"esbuild": "^0.28.0",
 		"mocha": "^11.7.5",
 		"typescript": "^6.0.2"
+	},
+	"overrides": {
+		"undici": "^7.28.0"
 	}
 }


### PR DESCRIPTION
## What and why

Add an `overrides` block to `vscode/package.json` pinning `undici` to `^7.28.0`.

`undici@7.24.7` is a frozen transitive dependency of `cheerio` (pulled in through the `@vscode/vsce` packaging tool). Neither `bun update @vscode/vsce` nor `bun update undici` moves it in isolation, so an explicit override is the only way to lift it.

**Why:** Clears the transitive CVEs flagged by osv-scanner (alerts #86–#92). This is a build-time-only dependency used for packaging the extension; the shipped runtime bundle inlines only `vscode-languageclient`, so runtime exposure is nil.

Refs #229.

## How to test

```bash
cd vscode
bun install          # lockfile resolves undici to ^7.28.0
bun run compile      # extension still builds
bun run package      # @vscode/vsce still packages the .vsix
```

Re-run osv-scanner (or the security workflow) and confirm alerts #86–#92 no longer appear.

## Notes for reviewers

- Only `vscode/package.json` and `vscode/bun.lock` change; no source or runtime behavior is affected.
- The override is scoped to the VS Code extension workspace and does not touch the Go module or any runtime dependency.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
