### PR TITLE
vscode: override diff and serialize-javascript to clear CVEs

### DIFF
--- a/vscode/bun.lock
+++ b/vscode/bun.lock
@@ -21,12 +21,14 @@
     },
   },
   "overrides": {
+    "diff": "^8.0.3",
     "fast-uri": "^3.1.2",
     "form-data": "^4.0.6",
     "js-yaml": "^4.2.0",
     "linkify-it": "^5.0.1",
     "markdown-it": "^14.2.0",
     "qs": "^6.15.2",
+    "serialize-javascript": "^7.0.5",
     "tmp": "^0.2.6",
     "undici": "^7.28.0",
   },
@@ -339,7 +341,7 @@
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
-    "diff": ["diff@7.0.0", "", {}, "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw=="],
+    "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 
@@ -665,8 +667,6 @@
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
-    "randombytes": ["randombytes@2.1.0", "", { "dependencies": { "safe-buffer": "^5.1.0" } }, "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ=="],
-
     "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
     "rc-config-loader": ["rc-config-loader@4.1.4", "", { "dependencies": { "debug": "^4.4.3", "js-yaml": "^4.1.1", "json5": "^2.2.3", "require-from-string": "^2.0.2" } }, "sha512-3GiwEzklkbXTDp52UR5nT8iXgYAx1V9ZG/kDZT7p60u2GCv2XTwQq4NzinMoMpNtXhmt3WkhYXcj6HH8HdwCEQ=="],
@@ -701,7 +701,7 @@
 
     "semver": ["semver@7.8.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA=="],
 
-    "serialize-javascript": ["serialize-javascript@6.0.2", "", { "dependencies": { "randombytes": "^2.1.0" } }, "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g=="],
+    "serialize-javascript": ["serialize-javascript@7.0.7", "", {}, "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g=="],
 
     "setimmediate": ["setimmediate@1.0.5", "", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
 
@@ -920,8 +920,6 @@
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
-
-    "randombytes/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -155,12 +155,14 @@
 		"typescript": "^6.0.2"
 	},
 	"overrides": {
+		"diff": "^8.0.3",
 		"fast-uri": "^3.1.2",
 		"form-data": "^4.0.6",
 		"js-yaml": "^4.2.0",
 		"linkify-it": "^5.0.1",
 		"markdown-it": "^14.2.0",
 		"qs": "^6.15.2",
+		"serialize-javascript": "^7.0.5",
 		"tmp": "^0.2.6",
 		"undici": "^7.28.0"
 	}


### PR DESCRIPTION
## What and why

Adds two flat `overrides` entries in `vscode/package.json` to clear the remaining transitive-dependency CVEs flagged by osv-scanner against `vscode/bun.lock`:

- `diff ^8.0.3` (resolves `8.0.4`) — CVE-2026-24001 / GHSA-73rr-hh4g-fpgx
- `serialize-javascript ^7.0.5` (resolves `7.0.7`) — GHSA-5c6j-r48x-rmvq + CVE-2026-34043 / GHSA-qj8w-gfj5-8c6v

Both packages come in only via the `mocha` devDependency (dev/test-time), so they are not part of the shipped `.vsix` runtime bundle. `bun.lock` was regenerated with bun `1.2.x` to match CI's pinned version.

`diff` is capped at `^8.0.3` (landing on `8.0.4`) rather than the latest `9.0.0`: `mocha` still declares `diff ^7.0.0`, so a two-major jump would ride entirely on the override with no semver signal from mocha, and the whole chain is dev-only — there's no runtime upside to the added risk.

**Why:** These are open code-scanning alerts on the extension's lockfile. Clearing them keeps the security posture green without touching the shipped runtime.

Part of #229 (tracking issue for the full osv-scanner CVE walk). Continues the series after #231 (undici) and #232 (esbuild + 7 transitive overrides).

## How to test

```bash
cd vscode
mise x bun@1.2 -- bun install --frozen-lockfile   # clean, no drift
mise x bun@1.2 -- bun run compile                  # tsc OK
mise x bun@1.2 -- bun run lint                      # biome clean
mise x bun@1.2 -- bun run package                   # builds a working .vsix
```

CI (`vscode.yml`, Ubuntu + macOS) runs the full `bun run test` suite, which is authoritative for the mocha/VSCode integration tests.

After merge, confirm the osv-scanner open count for `vscode/bun.lock` drops by 3 (alerts for `diff` and `serialize-javascript`).

## Notes for reviewers

- **Surgical diff**: only the two override lines plus the two version bumps. The removal of the `randombytes` / `randombytes/safe-buffer` transitive entries is a legitimate downstream effect — `serialize-javascript@7.x` dropped its `randombytes` dependency.
- **Reserved packages untouched**: `brace-expansion@5.0.5` and `uuid@8.3.2` (their own open alerts) are handled separately and are not modified here. The prior undici/esbuild override set is also unchanged.
- **No user-facing change**: dev/test-only transitive bump; no LSP, config, CLI, or docs surface is affected.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works <!-- N/A: transitive dependency override, no test-observable behavior change -->
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test)
- [ ] I have updated documentation as needed <!-- N/A: no user-facing or documented behavior changed -->
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
