### PR TITLE
ci(release): use gh auth setup-git for changelog and tag pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,7 +177,7 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+          gh auth setup-git
           git add CHANGELOG.md
           git commit -m "docs: update changelog for ${TAG_NAME}"
           git push origin main
@@ -204,7 +204,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+          gh auth setup-git
 
           if [[ -n "$PRERELEASE" ]]; then
             echo "Pre-release detected: $PRERELEASE"


### PR DESCRIPTION
## What and why

Replace the token-in-URL git remote (`git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/...`) with `gh auth setup-git` in the two `release.yml` jobs that push over HTTPS: `update-changelog` (commits `CHANGELOG.md` to `main`) and `update-version-tags` (force-pushes the floating alias tags). Both jobs keep their step-level `env: GITHUB_TOKEN`; `gh auth setup-git` installs a credential helper that reads the token at push time instead of embedding it in the remote URL.

**Why:** Embedding the token in the remote URL writes it into `.git/config` and exposes it in process arguments and any `set -x` / debug output. Routing auth through `gh`'s credential helper keeps the token out of on-disk config and process listings — a net reduction in credential-leak surface with identical push behavior.

## How to test

Static checks pass now and are the authoritative gate for a workflow-only change:

- `actionlint .github/workflows/release.yml` — clean
- `zizmor .github/workflows/release.yml` — clean (0 findings)
- pre-commit `Lint GitHub Actions workflow files`, `zizmor`, and `yamllint` hooks — all pass on this commit

The credential path itself only executes when a real `v*` tag fires the workflow, so end-to-end verification is deferred to the next release (see below).

## Notes for reviewers

**This is not exercised until the next real release.** `release.yml` runs only on `v*` tag pushes, and the affected jobs can't be dry-run on a fork or branch (the workflow hardcodes the canonical repo/registry in several places, and cosign keyless OIDC embeds the repo identity). So this lands as reviewed-but-not-yet-deployed.

**Blast radius is contained.** The change touches only `update-changelog` and `update-version-tags`. The `goreleaser` job that builds and publishes the binaries, archives, checksums, SBOMs, GitHub Release, and Docker image reads `GITHUB_TOKEN` from env directly and is **untouched** — if the new auth ever failed, the release artifacts still ship; only the changelog commit and alias-tag pushes would fail, and both are re-runnable in isolation. Rollback is a one-line revert to the previous `git remote set-url` form.

**First-release watch-list** (for whoever runs the next release):

1. `update-changelog` → "Commit changelog" step pushes `CHANGELOG.md` to `main` with no `Authentication failed` / `could not read Username` / `403`. Confirm a fresh `docs: update changelog for <tag>` commit lands on `main`.
2. `update-version-tags` → "Update version alias tags" step force-pushes the floating alias tags (`v<major>`, `v<major>.<minor>`, or the `-<prerelease>` variants) without auth error, and the alias tags now point at the new release tag.
3. If a push fails, re-run only the failed job after fixing auth — do **not** re-run `goreleaser` (it would `--clean` re-publish).

**Out of scope (correctly unchanged):** `update-docker-tags` authenticates to ghcr.io via `crane auth login`, a different credential path for a different registry.

**Optional follow-up (not applied):** `gh auth setup-git --hostname github.com` pins the host explicitly rather than relying on the env-token → `github.com` auto-detection (gh ≥ 2.32.0). Irrelevant on GitHub-hosted runners; pure defense-in-depth if this ever ran on a pinned-older or self-hosted runner.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works <!-- N/A: workflow-only change, no unit-testable logic; validated via actionlint/zizmor and deferred live run -->
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test) <!-- relevant gates: actionlint, zizmor, yamllint; no Go/TS touched -->
- [x] I have updated documentation as needed <!-- none needed: no docs reference the old credential mechanism -->
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
