### PR TITLE
ci(release): re-release existing tags and bump goreleaser to v2.16.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,15 @@ on:
   push:
     tags:
       - 'v*'
+  # Re-release an existing tag from its own commit without moving the tag
+  # (e.g. after a transient CI failure). The tag is never re-pointed, so the
+  # Go module proxy / sum.golang.org entry for that version stays consistent.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to (re-)release from its own commit, e.g. v0.2.0'
+        required: true
+        type: string
 
 concurrency:
   group: release-${{ github.ref }}
@@ -27,6 +36,9 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          # On a tag push this is the tag; on manual dispatch it is the input tag.
+          # Either way GoReleaser builds from the tag's own commit, not from main.
+          ref: ${{ github.event.inputs.tag || github.ref }}
           persist-credentials: false
 
       - name: Set up Go
@@ -72,7 +84,9 @@ jobs:
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser
-          version: v2.15.0
+          # cosign v3.x (installed by cosign-installer) cannot verify goreleaser
+          # v2.15.0's sigstore bundle; v2.16.0's bundle verifies under cosign v3.
+          version: v2.16.0
           args: release --clean --release-notes RELEASE_NOTES.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -85,7 +99,7 @@ jobs:
           gh release upload "$TAG_NAME" dist/checksums.txt.bundle --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ github.ref_name }}
+          TAG_NAME: ${{ github.event.inputs.tag || github.ref_name }}
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
@@ -108,7 +122,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: 'ghcr.io/santosr2/terratidy:${{ github.ref_name }}'
+          image-ref: 'ghcr.io/santosr2/terratidy:${{ github.event.inputs.tag || github.ref_name }}'
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
@@ -152,7 +166,7 @@ jobs:
 
           echo "Parsed: tag=$TAG_NAME major=$MAJOR minor=$MINOR prerelease=$PRERELEASE"
         env:
-          TAG_NAME: ${{ github.ref_name }}
+          TAG_NAME: ${{ github.event.inputs.tag || github.ref_name }}
 
   update-changelog:
     needs: goreleaser
@@ -191,7 +205,7 @@ jobs:
           git push origin main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ github.ref_name }}
+          TAG_NAME: ${{ github.event.inputs.tag || github.ref_name }}
 
   update-version-tags:
     needs: [parse-version, goreleaser]
@@ -290,7 +304,7 @@ jobs:
           chmod +x /tmp/terratidy-release/terratidy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ github.ref_name }}
+          TAG_NAME: ${{ github.event.inputs.tag || github.ref_name }}
 
       - name: Verify version
         run: /tmp/terratidy-release/terratidy version
@@ -300,7 +314,7 @@ jobs:
 
   test-homebrew:
     needs: goreleaser
-    if: "!contains(github.ref, '-')"
+    if: ${{ !contains(github.event.inputs.tag || github.ref_name, '-') }}
     runs-on: macos-latest
     timeout-minutes: 15
     steps:
@@ -332,6 +346,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
           persist-credentials: false
 
       - name: Set up Bun
@@ -357,11 +372,11 @@ jobs:
       - name: Attach VSIX to GitHub release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: gh release upload "$TAG" vscode/terratidy.vsix --repo "$GITHUB_REPOSITORY" --clobber
 
       - name: Publish to VS Code Marketplace
-        if: "!contains(github.ref, '-')"
+        if: ${{ !contains(github.event.inputs.tag || github.ref_name, '-') }}
         working-directory: vscode
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}


### PR DESCRIPTION
## What and why

The `v0.2.0` release run failed at the **GoReleaser install** step — before any of our release logic ran, so nothing was published (no GitHub Release, Docker, Homebrew, or Marketplace). Two fixes:

1. **Bump goreleaser `v2.15.0` → `v2.16.0`.** `cosign-installer` now installs cosign **v3.0.6**, and cosign v3 cannot verify goreleaser v2.15.0's sigstore bundle (`invalid signature when validating ASN.1 encoded signature`). Confirmed locally that cosign v3.0.6 **`Verified OK`** against goreleaser v2.16.0's bundle, and that `goreleaser v2.16.0 release --snapshot` builds our config cleanly (binaries, archives, Homebrew formula; the `dockers`/`brews` deprecations are warnings, not errors, in `release`).

2. **Add a `workflow_dispatch` path to re-release an existing tag from its own commit, without moving the tag.** `v0.2.0` is already frozen in the Go module proxy / `sum.golang.org` (pinned to `3b68f9b`), so re-tagging it would permanently diverge the module checksum. Instead, dispatch checks out the tag's own commit and builds it with the fixed workflow. The release tag is resolved from `github.event.inputs.tag || github.ref[_name]` throughout, and the GoReleaser + `vscode-publish` checkouts build from the tag's commit rather than `main`.

**Why:** unblock the `v0.2.0` release without burning the version number or leaving a Go-module checksum landmine, and give the release pipeline a way to recover from transient install-time failures in future.

## How to test

- `actionlint` and `zizmor` pass on the changed workflow (pre-commit hooks green).
- Confirmed cosign v3.0.6 verifies goreleaser v2.16.0's checksums bundle (`Verified OK`).
- Confirmed `goreleaser v2.16.0 release --snapshot` succeeds against `.goreleaser.yml`.
- The normal tag-push path is unchanged: on `push`, `github.event.inputs.tag` is empty, so every resolution falls back to `github.ref`/`github.ref_name` exactly as before.

## Notes for reviewers

- After merge, the release is produced by dispatching this workflow against the existing tag: `gh workflow run release.yml -f tag=v0.2.0` (or the Actions UI). The tag stays at `3b68f9b`; the workflow runs from `main`'s fixed definition.
- Both manual approval gates (`goreleaser`, `vscode-publish`) still apply on dispatch.
- No `version.json` change is included (expected build-placeholder noise).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
