### PR TITLE
ci(release): fix downstream release jobs and stop alias-tag loop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,10 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      # Full X.Y.Z (and X.Y.Z-prerelease) tags only. The floating aliases v0 / v0.2
+      # pushed by update-version-tags have fewer than two dots, so they do NOT match
+      # here. Without this, every alias push would re-trigger Release and loop.
+      - 'v*.*.*'
   # Re-release an existing tag from its own commit without moving the tag
   # (e.g. after a transient CI failure). The tag is never re-pointed, so the
   # Go module proxy / sum.golang.org entry for that version stays consistent.
@@ -328,7 +331,13 @@ jobs:
 
       - name: Test Homebrew formula
         run: |
-          brew install --build-from-source Formula/terratidy.rb
+          # Modern Homebrew refuses `brew install <path/to/formula.rb>`; a formula
+          # must live in a tap. Stage the freshly generated formula in a throwaway
+          # local tap and build-install it from there.
+          TAP_DIR="$(brew --repository)/Library/Taps/terratidy/homebrew-localtest"
+          mkdir -p "$TAP_DIR/Formula"
+          cp Formula/terratidy.rb "$TAP_DIR/Formula/terratidy.rb"
+          brew install --build-from-source terratidy/localtest/terratidy
           terratidy version
 
   # Every tag attaches the .vsix to the GitHub release. Only stable tags publish to
@@ -347,7 +356,23 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
+          # Full history + tags so git-cliff can render the finalized changelog below.
+          fetch-depth: 0
           persist-credentials: false
+
+      # The tag's tree freezes CHANGELOG.md at its pre-release state: the finalized
+      # entry for this version is only git-cliff'd onto main *after* the tag is cut,
+      # so a tag checkout would bundle a stale changelog (e.g. topping out at an
+      # -alpha entry). Regenerate it here so the packaged .vsix embeds the real
+      # released section. vscode/CHANGELOG.md is a symlink to this root file, so vsce
+      # bundles whatever we write here.
+      - name: Finalize changelog for this tag
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0
+        with:
+          config: cliff.toml
+          args: --verbose
+        env:
+          OUTPUT: CHANGELOG.md
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### CI/CD
 
 - **release**: Re-release existing tags and bump goreleaser to v2.16.0 ([#250](https://github.com/santosr2/TerraTidy/pull/250)) by [@santosr2](https://github.com/santosr2)
+- **release**: Fix downstream release jobs and stop alias-tag loop ([bc3c760](https://github.com/santosr2/TerraTidy/commit/bc3c760064e09dd4b2adc5c62b388cd792e2a119)) by [@Rubens](https://github.com/Rubens)
+
+### Documentation
+
+- Update changelog for v0.2.0 ([ffe738c](https://github.com/santosr2/TerraTidy/commit/ffe738c57636dbf03d4ba8f3f915e368752e4e93)) by [@github-actions[bot]](https://github.com/github-actions[bot])
+
+### Other
+
+- Drop trailing blank line from CHANGELOG.md ([a32d5c2](https://github.com/santosr2/TerraTidy/commit/a32d5c270b3447d829c3c820efdf9eb5a7f926ab)) by [@Rubens](https://github.com/Rubens)
+
 ## [0.2.0] - 2026-07-22
 
 ### Added
@@ -249,6 +259,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **release**: Publish multi-arch amd64/arm64 docker images ([bc1606d](https://github.com/santosr2/TerraTidy/commit/bc1606d782ed1cdb7f6e0fd5c3773df62370f2a3)) by [@santosr2](https://github.com/santosr2)
 - **release**: Track discussion template version placeholder ([d918e91](https://github.com/santosr2/TerraTidy/commit/d918e91f0a381153382c4e64c4b162f83f0f9927)) by [@santosr2](https://github.com/santosr2)
 - **release**: Drop stale CHANGELOG.md from release archives ([4487b6c](https://github.com/santosr2/TerraTidy/commit/4487b6cd1fea500a317a63ab41cbb5a21d4e6856)) by [@santosr2](https://github.com/santosr2)
+
 ## [0.2.0-alpha.4] - 2026-04-04
 
 ### Added
@@ -346,6 +357,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Revert
 
 - Remove make_latest (GitHub limitation for prereleases) ([15c013c](https://github.com/santosr2/TerraTidy/commit/15c013c71269c3e074f83b14cfb80d0573a02a97)) by [@santosr2](https://github.com/santosr2)
+
 ## [0.2.0-alpha.3] - 2026-01-19
 
 ### Added
@@ -377,6 +389,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **cli**: Fix color flag and add changelog links ([b11560c](https://github.com/santosr2/TerraTidy/commit/b11560c1bab748e08cd634e98d31543257db4798)) by [@santosr2](https://github.com/santosr2)
 - **cli**: Apply global color flag to all commands ([3f50fbb](https://github.com/santosr2/TerraTidy/commit/3f50fbb473810f03efe5e35ba683f6fa31575b41)) by [@santosr2](https://github.com/santosr2)
 - **style**: Preserve inline comments when reordering HCL attributes ([#2](https://github.com/santosr2/TerraTidy/pull/2)) by [@santosr2](https://github.com/santosr2)
+
 ## [0.2.0-alpha.2] - 2026-01-12
 
 ### Added
@@ -411,6 +424,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add bump-my-version to mise and update bumpversion config ([12e9a9f](https://github.com/santosr2/TerraTidy/commit/12e9a9fed782753fd610d1f4d8efb891ad221493)) by [@santosr2](https://github.com/santosr2)
 - Bump version to 0.2.0-alpha.2 ([a4b88fc](https://github.com/santosr2/TerraTidy/commit/a4b88fcc90c9d3565f8c399a58d40bc98d705316)) by [@santosr2](https://github.com/santosr2)
+
 ## [0.2.0-alpha] - 2026-01-08
 
 ### Added
@@ -445,6 +459,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 
 - Update gitignore and mise configuration ([3d4cabc](https://github.com/santosr2/TerraTidy/commit/3d4cabc453cfb8fce22237da700c21d42bb2c923)) by [@santosr2](https://github.com/santosr2)
+
 ## [0.1.0] - 2025-12-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -497,4 +497,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.2.0-alpha.3]: https://github.com/santosr2/TerraTidy/compare/v0.2.0-alpha.2...v0.2.0-alpha.3
 [0.2.0-alpha.2]: https://github.com/santosr2/TerraTidy/compare/v0.2.0-alpha...v0.2.0-alpha.2
 [0.2.0-alpha]: https://github.com/santosr2/TerraTidy/compare/v0.1.0...v0.2.0-alpha
-

--- a/cliff.toml
+++ b/cliff.toml
@@ -10,7 +10,6 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
 """
 # template for the changelog body
 # Uses PR number if available (from commit.remote.pr_number), otherwise falls back to commit SHA
@@ -43,12 +42,17 @@ footer = """
     {% else -%}
         [Unreleased]: https://github.com/santosr2/TerraTidy/compare/{{ release.previous.version }}...HEAD
     {% endif -%}
-{% endfor %}
+{% endfor -%}
 """
 # remove the leading and trailing s]
 trim = true
 # postprocessors
-postprocessors = []
+postprocessors = [
+  # git-cliff joins release bodies with a single newline, gluing "## [x]" onto the
+  # previous section's last line. Postprocessors run per release body, so anchor to
+  # the body start (^) to prepend a blank line before every version header.
+  { pattern = '^## \[', replace = "\n## [" },
+]
 
 [git]
 # parse the commits based on https://www.conventionalcommits.org


### PR DESCRIPTION
## What and why

Fixes three downstream jobs in the Release workflow that failed (or were latent bugs) during the v0.2.0 release, and closes a re-trigger loop introduced by the version alias tags.

- **`test-homebrew`** — replaced `brew install --build-from-source Formula/terratidy.rb` with staging the generated formula into a throwaway local tap and installing from there. Modern Homebrew rejects installing a formula from a bare file path ("formulae must be in a tap"), which failed the job in the v0.2.0 run.
- **Trigger** — narrowed `on: push: tags` from `v*` to `v*.*.*` so the floating `v0` / `v0.2` alias tags (fewer than two dots) no longer match. Pushing those aliases previously re-triggered Release, which would re-push the aliases again — an infinite loop. Two such stray runs were already observed and cancelled.
- **`vscode-publish`** — regenerate `CHANGELOG.md` with git-cliff at the tag (added `fetch-depth: 0`) before packaging. The tag's tree freezes the changelog at its pre-release state because the finalized entry is only committed to `main` after the tag is cut, so the packaged `.vsix` was embedding a stale (`-alpha`) changelog.

**Why:** the v0.2.0 run surfaced these; without them the next release repeats the same failures and ships a `.vsix` with the wrong changelog.

## How to test

- `actionlint .github/workflows/release.yml` and `zizmor .github/workflows/release.yml` both pass clean.
- Trigger pattern: `v0` / `v0.2` no longer match `v*.*.*`, while `v0.2.0` and `v0.2.0-alpha.5` still do.
- The homebrew and vscode-publish steps exercise on the next tagged release.

## Notes for reviewers

This is the ready subset of the release-pipeline fixes. One more job, `update-version-tags`, still needs a workflow-scoped credential (its `GITHUB_TOKEN` cannot push the workflow-file-bearing alias-tag refs) plus an annotated-tag peel fix; that lands in a follow-up once the PAT-vs-App choice is made.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works — N/A (CI workflow change; validated with actionlint + zizmor)
- [x] All checks pass — actionlint + zizmor clean; Go suite unaffected
- [x] I have updated documentation as needed — no doc changes required
- [x] My commits follow Conventional Commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
