### PR TITLE
fix(changelog): repair release notes, contributors, and the generated changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,6 +227,13 @@ jobs:
         env:
           OUTPUT: CHANGELOG.md
 
+      # git-cliff ends its output with a blank line. This job commits CHANGELOG.md
+      # without running pre-commit, so that extra newline lands on main and then fails
+      # the end-of-file-fixer hook on every subsequent PR until some unrelated commit
+      # silently repairs it. Collapse trailing newlines to exactly one at the source.
+      - name: Normalize trailing newline
+        run: perl -0pi -e 's/\n+\z/\n/' CHANGELOG.md
+
       - name: Commit changelog
         run: |
           if git diff --quiet CHANGELOG.md; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,12 +87,18 @@ jobs:
         with:
           syft-version: v1.42.3
 
+      # --strip all, not just the header: the footer emits Keep a Changelog link
+      # reference definitions, which exist so the many version headings in
+      # CHANGELOG.md resolve to their compare views. A single release's notes carry
+      # exactly one, and the page already ends with a Full Changelog link, so keeping
+      # it would only turn the "## [x.y.z]" heading into a stray link. The two
+      # CHANGELOG.md invocations below keep the footer, where it belongs.
       - name: Generate release notes
         uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0
         id: git-cliff
         with:
           config: cliff.toml
-          args: --latest --strip header
+          args: --latest --strip all
         env:
           OUTPUT: RELEASE_NOTES.md
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -551,4 +551,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.2.0-alpha.3]: https://github.com/santosr2/TerraTidy/compare/v0.2.0-alpha.2...v0.2.0-alpha.3
 [0.2.0-alpha.2]: https://github.com/santosr2/TerraTidy/compare/v0.2.0-alpha...v0.2.0-alpha.2
 [0.2.0-alpha]: https://github.com/santosr2/TerraTidy/compare/v0.1.0...v0.2.0-alpha
-

--- a/cliff.toml
+++ b/cliff.toml
@@ -30,9 +30,20 @@ body = """
             {% elif commit.author.name %} by [@{{ commit.author.name }}](https://github.com/{{ commit.author.name }}){% endif %}\
     {% endfor %}
 {% endfor %}
+{% if github.contributors | filter(attribute="is_first_time", value=true) | length != 0 %}
+    ### New Contributors
+    {% for contributor in github.contributors | filter(attribute="is_first_time", value=true) %}
+        - @{{ contributor.username }} made their first contribution\
+            {% if contributor.pr_number %} in [#{{ contributor.pr_number }}](https://github.com/santosr2/TerraTidy/pull/{{ contributor.pr_number }}){% endif %}\
+    {% endfor %}
+{% endif %}
 """
 # template for the changelog footer
+# A blank line separates the link-reference definitions from the last list item.
+# Without it markdown treats them as lazy continuation of that item and renders
+# them as literal text instead of consuming them as link definitions.
 footer = """
+
 {% for release in releases -%}
     {% if release.version -%}
         {% if release.previous.version -%}

--- a/cliff.toml
+++ b/cliff.toml
@@ -31,6 +31,8 @@ body = """
     {% endfor %}
 {% endfor %}
 {% if github.contributors | filter(attribute="is_first_time", value=true) | length != 0 %}
+    ---
+
     ### New Contributors
     {% for contributor in github.contributors | filter(attribute="is_first_time", value=true) %}
         - @{{ contributor.username }} made their first contribution\


### PR DESCRIPTION
## What and why

Four changelog defects surfaced by the v0.3.0 release. All were pre-existing; the release only made them visible.

**1. No New Contributors section.** The `body` template credits contributors inline per commit but never emitted a first-time contributor block, so the first outside contribution to this repo was not called out anywhere. No release has ever had this section: v0.1.0, all four alphas, and v0.2.0 all score zero. GoReleaser supplies custom notes from git-cliff, which suppresses GitHub's native auto-generated notes, and that is the feature that normally produces "New Contributors". It now renders behind a thematic break, so it reads as a trailer rather than as one more commit group alongside `### Fixed`.

**2. Link reference definitions glued to the last list item.** The `footer` emits Keep a Changelog link definitions with no blank line before them:

```
- Refresh bun.lock to pull patched transitive deps (#283) ...
[0.3.0]: https://github.com/santosr2/TerraTidy/compare/v0.2.0...v0.3.0
```

A link reference definition cannot interrupt a paragraph, so markdown treats it as lazy continuation of that item and renders it verbatim. This is the shared footer, so the stray line also lands in `CHANGELOG.md` and in `vscode/CHANGELOG.md`, a symlink to the root file bundled into the `.vsix` — the Marketplace listing shows it too. It only looked VS Code specific because `### VS Code Extension` happened to be the last section.

**3. Release notes carried link definitions at all.** Those definitions exist so the many version headings in `CHANGELOG.md` resolve to their compare views. A single release's notes carry exactly one, and the release page already ends with a Full Changelog link. Fixing defect 2 in isolation made that lone definition *valid*, which turned the `## [0.3.0] - date` heading into a link — something no previous release rendered. Earlier releases were plain text only by accident: v0.1.0, v0.2.0-alpha, v0.2.0-alpha.2 and v0.2.0 emitted no definition at all, while v0.2.0-alpha.3 and v0.2.0-alpha.4 emitted a malformed one that leaked as literal text. `--strip all` on the release-notes invocation restores plain-text headings and drops the stray line. The two `CHANGELOG.md` invocations keep the footer, where the definitions belong.

**4. The generated changelog breaks `end-of-file-fixer`.** git-cliff ends its output with a blank line, and `update-changelog` commits `CHANGELOG.md` without running pre-commit. Since `pre-commit/action` runs `--all-files`, that extra newline fails the hook on every subsequent PR. It has been cycling since v0.2.0:

| Commit | Source | Ending |
|---|---|---|
| `ffe738c` | CI, v0.2.0 release | `\n\n` broken |
| `6b23df7` | human commit, ran pre-commit | `\n` silently repaired |
| `efcba7d` | CI, v0.3.0 release | `\n\n` broken again |

PR #284 passed only because it landed inside the repaired window. The job now collapses trailing newlines at the source, and the file on main is fixed via the hook itself rather than by hand, since it is generated.

## How to test

The release workflow does not pass a `GITHUB_TOKEN` to git-cliff, so both paths were checked:

```bash
GITHUB_TOKEN=$(gh auth token) git-cliff --config cliff.toml --latest --strip all -o /tmp/with-token.md
env -u GITHUB_TOKEN -u GH_TOKEN     git-cliff --config cliff.toml --latest --strip all -o /tmp/no-token.md
```

Both exit 0 and render identically:

```
## [0.3.0] - 2026-08-31        <- plain text, as in v0.2.0

...

---

### New Contributors

- @Marukome0743 made their first contribution in #280
```

The blank lines around the rule are load-bearing: `---` directly under the preceding list item would parse as a setext heading rather than a thematic break.

Full changelog render (`git-cliff --config cliff.toml`) was checked for the version-heading boundary and the link-definition block, and `pre-commit run --all-files` passes.

## Notes for reviewers

`github.contributors` resolves unauthenticated against the public API, so this does not depend on adding a token to the workflow. If the repo went private or hit the 60/hr unauthenticated limit, the section would render empty rather than fail the build.

The section is computed per release, so the next `CHANGELOG.md` regeneration adds four historical New Contributors entries, not just v0.3.0's. One of them (`@goreleaserbot`) has no associated PR and renders as a bare "made their first contribution", which the `pr_number` guard handles. `CHANGELOG.md` content is otherwise left to regenerate on the next release rather than hand-synced here.

The published v0.3.0 release notes were regenerated in place with these templates, so the release already reads correctly without waiting for this to merge.

Unrelated but found while investigating, and worth its own issue: Trivy reports as failing under Security → Code scanning. `trivy-scan` lives only in `release.yml`, which runs on tags, so its analyses upload under `refs/tags/*`. Its single `refs/heads/main` analysis dates from v0.2.0 and exists only because that release was dispatched from `main` — the mislabeling #280 corrected. With the ref now correct, the default branch has no current Trivy analysis. Scanning the image on main pushes (`container-test.yml` already builds it) would restore coverage.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works <!-- changelog templates and CI wiring; verified by rendering, tokened and tokenless, plus a full pre-commit run -->
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
