### PR TITLE
ci(container): scan the image on main, not only on release tags

### DIFF
--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -218,6 +218,47 @@ jobs:
             exit 1
           fi
 
+  # The release workflow also scans the image, but it runs on tags, so its results
+  # upload under refs/tags/* where the default-branch Security view never shows them.
+  # Scanning here puts Trivy on refs/heads/main alongside the other scanners and
+  # refreshes it per push, so a CVE published between releases surfaces immediately.
+  #
+  # Findings do not fail the build, matching the release workflow: most come from the
+  # Alpine base layer and are not actionable in the moment. The SARIF upload is the
+  # signal.
+  trivy-scan:
+    name: Container Vulnerability Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [build-test]
+    permissions:
+      security-events: write
+
+    steps:
+      - name: Download Docker image artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: docker-image
+
+      - name: Load Docker image
+        run: |
+          gunzip -c image.tar.gz | docker load
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ env.IMAGE_NAME }}:latest
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy scan results
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'
+          category: container-test-trivy
+
   non-root-test:
     name: Container Non-Root
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What and why

Adds a Trivy image scan to `container-test.yml` so container vulnerabilities land on the default branch.

**Why:** `trivy-scan` exists only in `release.yml`, which runs on tags. Its SARIF therefore uploads under `refs/tags/*`, while the Security tab's Code scanning view defaults to the default branch. The v0.3.0 scan ran fine and filed **22 findings** under `refs/tags/v0.3.0` that nothing surfaces:

| Severity | Count |
|---|---|
| critical | 1 |
| high | 2 |
| medium | 6 |
| low | 12 |
| none | 1 |

Trivy's only `refs/heads/main` analysis is dated `2026-07-22` and exists purely because the v0.2.0 release was dispatched from a branch — the mislabeling #280 corrected. Now that the ref is right, the default branch has no current container scan, which is why Trivy reads as failing under Security → Code scanning.

It is the sole outlier. Latest analysis per tool on `refs/heads/main` before this change:

| Tool | Latest on main |
|---|---|
| osv-scanner | 2026-09-01 |
| Scorecard | 2026-09-01 |
| zizmor | 2026-09-01 |
| TerraTidy self-scan | 2026-08-31 |
| **Trivy** | **2026-07-22** |

The others run from `security.yml`, `scorecard.yml`, and `action-test.yml` on main pushes and PRs, so they stay current. Scanning in `container-test.yml` puts Trivy alongside them and refreshes per push, so a CVE published between releases surfaces immediately rather than waiting for the next tag.

## How to test

`container-test.yml` triggers on `Dockerfile`, `**/*.go`, `go.mod`, `go.sum`, and its own path, so this PR's own CI exercises the new job. After merge, confirm the analysis lands on the default branch:

```bash
gh api "repos/santosr2/TerraTidy/code-scanning/analyses?tool_name=Trivy&ref=refs/heads/main" \
  -q '.[] | "\(.created_at) results=\(.results_count) cat=\(.category)"'
```

The newest entry should carry `category=container-test-trivy` and today's date.

## Notes for reviewers

The job reuses the existing `build-test` artifact rather than rebuilding, matching how `run-test`, `check-test`, `healthcheck-test`, and `non-root-test` all consume the image.

Action pins and structure follow the existing house pattern: same `trivy-action` and `upload-sarif` SHAs already used in `release.yml`, job-level `security-events: write`, explicit `category`, and `if: always()` on the upload as in `security.yml`. `severity: 'CRITICAL,HIGH'` mirrors `release.yml` so the two scans stay comparable.

**Findings deliberately do not fail the build**, matching `release.yml`. Most originate in the Alpine base layer and are not actionable at commit time — the two HIGH entries today are an OpenSSL QUIC DoS resolved by bumping the pinned base digest. Turning this into a gate is a reasonable follow-up but would red the pipeline immediately on findings outside our control.

Worth knowing about the one CRITICAL, `CVE-2026-56854`: it is not exploitable in this binary. Trivy matches at module granularity — the binary's build info records `golang.org/x/crypto v0.53.0`, so the CVE maps to it, but that vulnerability is in the `ssh` package and the only package linked from that module is `pbkdf2`:

```
golang.org/x/crypto/pbkdf2       <- linked
golang.org/x/crypto/ssh          <- NOT linked
```

That is precisely why `govulncheck` passes in `security.yml`: it performs reachability analysis, while Trivy flags on version presence. Bumping the indirect `x/crypto` would still clear the noise.

Once this is on main and has populated a current analysis, the stale `refs/heads/main` analysis from July (id `1509632197`, 1 result, `deletable=true`) can be deleted. Doing it in that order matters — deleting first would leave the container showing nothing at all, which reads as "clean" rather than "unmonitored".

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works <!-- CI workflow change; exercised by this PR's own container-test run -->
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
