### PR TITLE
ci(docs): rebuild the site when the root changelog changes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,15 +1,23 @@
 name: Documentation
 
+# docs/site/docs/changelog.md is a symlink to the root CHANGELOG.md. Its own blob is
+# just the constant link target, so regenerating the changelog changes no path under
+# docs/site/** and would never rebuild the site. The root file has to be listed too.
 on:
   push:
     branches: [main]
     paths:
       - "docs/site/**"
+      - "CHANGELOG.md"
       - ".github/workflows/docs.yml"
   pull_request:
     branches: [main]
     paths:
       - "docs/site/**"
+      - "CHANGELOG.md"
+  # The release changelog commit is pushed with GITHUB_TOKEN, which by design cannot
+  # trigger a push run. That job dispatches this workflow explicitly instead.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -46,7 +54,9 @@ jobs:
           path: docs/site/site
 
   deploy:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Deploy on push and on manual/dispatched runs, never from a pull request, and
+    # only ever from main so a dispatch on a branch cannot publish that branch.
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,6 +211,8 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write
+      # Dispatching the docs workflow after the changelog lands.
+      actions: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -247,6 +249,12 @@ jobs:
           git add CHANGELOG.md
           git commit -m "docs: update changelog for ${TAG_NAME}"
           git push origin main
+
+          # The docs site renders CHANGELOG.md through a symlink, but this push is
+          # authenticated with GITHUB_TOKEN and so raises no push event. Dispatch the
+          # docs workflow directly, or the published changelog stays a release behind.
+          # workflow_dispatch is one of the two events GITHUB_TOKEN may still trigger.
+          gh workflow run docs.yml --ref main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ github.ref_name }}


### PR DESCRIPTION
## What and why

Make the documentation site rebuild when the root `CHANGELOG.md` changes. Two compounding bugs kept the published changelog stale.

**Why:** The live site tops out at `[0.2.0] - 2026-07-22` while the repo is on `[0.3.0] - 2026-08-31`. It is also missing the release-notes repair from #285.

The first bug is the path filter. `docs/site/docs/changelog.md` is a symlink to the root `CHANGELOG.md`, and MkDocs resolves it correctly at build time, so the wiring looks fine. But a symlink's git blob is just its constant target path (`../../../CHANGELOG.md`), which never changes. Regenerating the changelog therefore touches no path under `docs/site/**`, `docs.yml` never fires, and the site only refreshed by accident whenever an unrelated commit happened to touch `docs/site/`. That is exactly what happened last: the most recent deploy came from the v0.3.0 release-prep commit, and the two commits that actually updated the changelog afterwards changed zero files under `docs/site/`.

Adding `CHANGELOG.md` to the filter is necessary but not sufficient. The `update-changelog` job in `release.yml` pushes its commit with `GITHUB_TOKEN`, and GitHub deliberately suppresses workflow runs triggered by that token, so the release-time changelog commit would still never rebuild the site. `workflow_dispatch` is one of only two events `GITHUB_TOKEN` may still trigger, so that job now dispatches the docs workflow explicitly. No PAT required.

## How to test

Merging this PR is itself the test. The commit touches `.github/workflows/docs.yml`, which is in the push path filter, so it self-triggers a build and deploy. After the run completes, https://santosr2.github.io/TerraTidy/changelog/ should show a `0.3.0` section instead of topping out at `0.2.0`.

Locally:

```bash
# The symlink resolves and the built page carries the current release
mise run docs:build
grep -o 'id=030-2026-08-31' docs/site/site/changelog/index.html

# Workflow linting
pre-commit run actionlint --files .github/workflows/docs.yml .github/workflows/release.yml
pre-commit run zizmor --files .github/workflows/docs.yml .github/workflows/release.yml
```

The release-time dispatch path can only be exercised by an actual tag push, so it is verified by inspection here.

## Notes for reviewers

The deploy gate widened, and it is worth a look. It moved from `github.event_name == 'push' && github.ref == 'refs/heads/main'` to `github.event_name != 'pull_request' && github.ref == 'refs/heads/main'`, because a `workflow_dispatch` run would otherwise build without deploying. The practical effect is that anyone who can dispatch the workflow can now trigger a Pages deploy. That was already true of anyone who could push to main, and the `refs/heads/main` condition still blocks publishing an arbitrary branch, so I read this as no meaningful change in exposure. Happy to tighten it if you disagree.

`update-changelog` gains `actions: write`, which `gh workflow run` requires.

Unrelated and untouched: `vscode/CHANGELOG.md` and `vscode/LICENSE` are also symlinks, and `vscode.yml` has the same path-filter blind spot. It is harmless there. That workflow is CI-only, and the marketplace publish job in `release.yml` already regenerates the changelog at package time precisely because a tag's tree freezes it at the pre-release state. Confirmed: `git show v0.3.0:CHANGELOG.md` tops out at `[0.2.0]`.

No tests accompany this change; it is a CI trigger fix with no unit-testable surface. `mise run check` was not run in full since no Go code changed, but the complete pre-commit suite passes, including `actionlint`, `zizmor`, and `yamllint`.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works (n/a: CI trigger change, verified by build and workflow linters)
- [x] All checks pass (full pre-commit suite; `mise run check` n/a, no Go changes)
- [x] I have updated documentation as needed (n/a: no user-facing docs change; this restores publishing of existing docs)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
