### PR TITLE
docs: correct stale Alpine and Go version references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -365,7 +365,7 @@ Self-tested in `action-test.yml` on Ubuntu, macOS, Windows.
 
 ## Docker
 
-- **Base**: Alpine 3.23 (pinned digest)
+- **Base**: Alpine 3.24.1 (pinned digest)
 - **User**: Non-root `terratidy` user
 - **Health check**: `terratidy version`
 - **Registry**: `ghcr.io/santosr2/terratidy`

--- a/docs/site/docs/user-guide/commands.md
+++ b/docs/site/docs/user-guide/commands.md
@@ -795,6 +795,6 @@ terratidy version --format json-compact
 TerraTidy version 0.3.0
   Commit:      abc1234
   Build date:  2025-12-22
-  Go version:  go1.26.4
+  Go version:  go1.27.1
   Platform:    darwin/arm64
 ```


### PR DESCRIPTION
## What and why

Corrects two documented values that had drifted from what the project actually ships.

- `CLAUDE.md` described the container base as Alpine 3.23; the `Dockerfile` has been on `alpine:3.24.1` since the base bump.
- The sample `terratidy version` output in `commands.md` reported `go1.26.4`; it now names `go1.27.1`, the toolchain pinned in `.go-version`.

**Why:** both were stated as fact and neither was going to fix itself. `.bumpversion.toml` rewrites only the `TerraTidy version {version}` line in `commands.md`, so the Go version there was frozen at whatever it was when someone last typed it, and would have kept drifting one release further from reality each time.

## How to test

```bash
grep -m1 FROM Dockerfile                    # alpine:3.24.1@sha256:...
grep 'Base' CLAUDE.md                       # matches
cat .go-version                             # 1.27.1
grep 'Go version' docs/site/docs/user-guide/commands.md   # matches
```

`mkdocs build --strict` passes.

## Notes for reviewers

Docs only, no behaviour change.

Found while sweeping for references left stale by #294. The equivalent corrections to the local `.claude/` agent and rules files were made separately and are not in this diff, since `.gitignore` marks that directory as untracked AI assistant config.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works
- [x] All checks pass (`mise run check` runs fmt, vet, lint, and test)
- [x] I have updated documentation as needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018VdXA9BdofrGizPX3CAVVu
